### PR TITLE
Fix the logic of the previous PR and return the correct preimage output

### DIFF
--- a/src/Stoa.ts
+++ b/src/Stoa.ts
@@ -56,7 +56,8 @@ class Stoa {
 
                     for (const row of rows)
                     {
-                        let preimage: IPreimage = {distance: row.distance, hash: '0'} as IPreimage;
+                        let preimage: IPreimage = {distance: row.distance,
+                            hash: (row.distance == 0 ? row.random_seed : '')} as IPreimage;
                         var validator: ValidatorData =
                             new ValidatorData(row.address, row.enrolled_at, row.stake, preimage);
                         out_put.push(validator);
@@ -98,12 +99,19 @@ class Stoa {
                     return;
                 }
 
-                if (rows.length == 1)
+                if (rows.length)
                 {
-                    let preimage: IPreimage = {distance: rows[0].distance, hash: '0'} as IPreimage;
-                    let validator: ValidatorData | null =
-                        new ValidatorData(rows[0].address, rows[0].enrolled_at, rows[0].stake, preimage);
-                    res.status(200).send(JSON.stringify(validator));
+                    let out_put:Array<ValidatorData> = new Array<ValidatorData>();
+
+                    for (const row of rows)
+                    {
+                        let preimage: IPreimage = {distance: row.distance,
+                            hash: (row.distance == 0 ? row.random_seed : '')} as IPreimage;
+                        var validator: ValidatorData =
+                            new ValidatorData(row.address, row.enrolled_at, row.stake, preimage);
+                        out_put.push(validator);
+                    }
+                    res.status(200).send(JSON.stringify(out_put));
                 }
                 else
                 {

--- a/src/modules/storage/LedgerStorage.ts
+++ b/src/modules/storage/LedgerStorage.ts
@@ -714,7 +714,7 @@ export class LedgerStorage extends Storages
         `SELECT tx_outputs.address,
                 enrollments.block_height as enrolled_at,
                 enrollments.utxo_key as stake,
-                (` + cur_height + ` - (enrollments.block_height + 1)) as distance,
+                (` + cur_height + ` - enrollments.block_height) as distance,
                 enrollments.random_seed,
                 (SELECT MAX(height) as height FROM blocks) as height,
                 ((SELECT MAX(height) as height FROM blocks) - (enrollments.block_height + 1)) as test
@@ -727,6 +727,8 @@ export class LedgerStorage extends Storages
 
         if (address != null)
             sql += ` AND tx_outputs.address = '` + address + `'`;
+
+        sql += ` ORDER BY enrollments.block_height ASC, enrollments.utxo_key ASC;`;
 
         this.db.all(sql, [], (err: Error | null, rows: any[]) =>
         {

--- a/tests/Storage.test.ts
+++ b/tests/Storage.test.ts
@@ -466,7 +466,7 @@ function runValidatorsAPITest (ledger_storage: LedgerStorage, callback: () => vo
       assert.ok(!err1, err1?.message);
       assert.equal(rows[0].address, address);
       assert.equal(rows[0].enrolled_at, 0);
-      assert.equal(rows[0].distance, 0);
+      assert.equal(rows[0].distance, 1);
 
       var res1 = ledger_storage.getValidatorsAPI(1, address, (err2: Error | null, rows: any[]) =>
       {
@@ -480,7 +480,7 @@ function runValidatorsAPITest (ledger_storage: LedgerStorage, callback: () => vo
           {
               assert.ok(!err3, err3?.message);
               assert.equal(rows.length, 3);
-              assert.equal(rows[0].distance, 0);
+              assert.equal(rows[0].distance, 1);
               callback();
           });
       });


### PR DESCRIPTION
One validator can enrollment using multiples UTXOs.
These results can be multiple enrolments in one address.
It can set sorting rules, sort them, and output them as a list.
It also outputs the correct distance.

Fix https://github.com/bpfkorea/stoa/pull/32