### PR TITLE
Create a Docker image to bundle both stoa and a full node

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+# From Agora Runner
+FROM bpfk/agora:latest
+RUN apk add --no-cache curl git python3 py-pip alpine-sdk \
+    bash autoconf libtool automake nodejs npm supervisor
+ADD . /stoa/
+WORKDIR /stoa/
+RUN npm ci
+EXPOSE 3836
+# Use the supervisord to run agora and stoa multiprocessor.
+ENTRYPOINT [ "supervisord", "-c", "/stoa/config/service_script.conf" ]

--- a/README.md
+++ b/README.md
@@ -4,6 +4,20 @@ API server for Agora
 # Build instructions
 Install any version of Node.js >= 12.18.0
 
+# Docker usage
+
+The easiest way to get stoa is to run `docker pull bpfk/stoa`.
+The `Dockerfile` lives at the root of this repository,
+
+For a test run,
+This requires the Agora config.yaml file in advance.
+try:
+```console
+docker run -p 127.0.0.1:3836:3836/tcp -v $(pwd)/config.yaml:/stoa/config.yaml -e "CONFIG=/stoa/config.yaml" bpfk/stoa
+```
+This will start a stoa & full node agora with the example config/agora_config file,
+and make the port locally accessible (See http://127.0.0.1:3836/).
+
 ## Building on Ubuntu
 ```sh
 $ sudo apt-get install nodejs

--- a/config/service_script.conf
+++ b/config/service_script.conf
@@ -1,0 +1,21 @@
+[supervisord]  ## This is the main process for the Supervisor
+nodaemon=true  ## This setting is to specify that we are not running in daemon mode
+
+## agora_service
+[program:agora_service]
+command=agora -c %(ENV_CONFIG)s
+autorestart=true
+stderr_logfile=/dev/stdout
+stderr_logfile_maxbytes=0
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+
+## stoa_service
+[program:stoa_service]
+command=npm start
+autostart=true
+autorestart=true
+stderr_logfile =/dev/stdout
+stderr_logfile_maxbytes=0
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0


### PR DESCRIPTION
Dockerfile can produce `Stoa` dockerImage, which is based on `agora` dockerImage.
Used `supervisord` to multiProcessing run the Stoa service and `agora Fullnode`


Relates to #28 