### PR TITLE
JSON type block data is also acceptable and change API path for test

### DIFF
--- a/src/Stoa.ts
+++ b/src/Stoa.ts
@@ -127,7 +127,7 @@ class Stoa {
          * When a request is received through the `/push` handler
          * JSON block data is parsed and stored on each storage.
          */
-        this.stoa.post("/push",
+        this.stoa.post("/block_externalized",
             (req: express.Request, res: express.Response, next: express.NextFunction) => {
 
             let block: any;
@@ -138,7 +138,10 @@ class Stoa {
             }
 
             try {
-                block = JSON.parse(req.body.block);
+                if (typeof req.body.block === "string")
+                    block = JSON.parse(req.body.block);
+                else
+                    block = req.body.block;
             } catch(e) {
                 res.status(400).send("Not a valid JSON format");
                 return;

--- a/tests/Stoa.test.ts
+++ b/tests/Stoa.test.ts
@@ -67,17 +67,17 @@ describe ('Test of Stoa API Server', () =>
             .finally(doneIt);
     });
 
-    it ('Test of the path /push', (doneIt: () => void) =>
+    it ('Test of the path /block_externalized', (doneIt: () => void) =>
     {
         let uri = URI(host)
             .port(port)
-            .directory("push");
+            .directory("block_externalized");
 
         let url = uri.toString();
         assert.doesNotThrow(async () =>
         {
-            await client.post(url, {block: JSON.stringify(sample_data[0])});
-            await client.post(url, {block: JSON.stringify(sample_data[1])});
+            await client.post(url, {block: sample_data[0]});
+            await client.post(url, {block: sample_data[1]});
             doneIt();
         });
     });


### PR DESCRIPTION
Correction according to the RestInterfaceClient in vibe.d.

Related to issue #39