### PR TITLE
Add an error handler in `putBlocks`.

### DIFF
--- a/src/modules/storage/LedgerStorage.ts
+++ b/src/modules/storage/LedgerStorage.ts
@@ -150,6 +150,11 @@ export class LedgerStorage extends Storages
                 block.header.enrollments.length
             ], (err: Error | null) =>
         {
+            if (err != null)
+            {
+                onError(err);
+                return;
+            }
             this.putTransactionsUseStatement(block,
             () =>
             {


### PR DESCRIPTION
When an error occurred, an error callback had to be executed, but it was not called.