### PR TITLE
Implement the function that provides the height of the block to be added next

### DIFF
--- a/docs/Database_Schema.md
+++ b/docs/Database_Schema.md
@@ -171,3 +171,29 @@ CREATE TABLE "validators" (
     PRIMARY KEY("enrolled_at","utxo_key")
 )
 ```
+
+----
+
+## 6. Table **information**
+
+It can store information that is required for operation.
+The following data is recorded when the most recently recorded block height is 100.
+
+{"key": "height", "value": "100"}
+
+### _Schema_
+
+| Column            | Data Type | PK | Not NULL | Default  |Description|
+|:----------------- |:--------- |:--:|:--------:| -------- | --------- |
+|  key              | TEXT      | Y  | Y        |          | The key   |
+|  value            | TEXT      |    | Y        |          | The value |
+
+### _Create Script_
+
+```sql
+CREATE TABLE informations (
+    key         TEXT NOT NULL,
+    value       TEXT,
+    PRIMARY KEY(key)
+)
+```


### PR DESCRIPTION
Stoa records data pushed from the Agora node in the database.
This is necessary to ensure that a block with a block height of 5 is correct before it is recorded.
If the block height is recorded up to 3 and just when the block height of 5 was pushed in,
This allows Stoa to detect that the expected 4 and 5 are different.

Related at #45 