### PR TITLE
Add /preimage_received endPoint and update preimage

### DIFF
--- a/src/Stoa.ts
+++ b/src/Stoa.ts
@@ -52,16 +52,42 @@ class Stoa {
             this.ledger_storage.getValidatorsAPI(height, null,
                 (rows: any[]) =>
                 {
-                    let out_put:Array<ValidatorData> = new Array<ValidatorData>();
                     if (rows.length)
                     {
                         let out_put:Array<ValidatorData> = new Array<ValidatorData>();
 
                         for (const row of rows)
                         {
-                            let preimage: IPreimage = {distance: row.distance,
-                                hash: (row.distance == 0 ? row.random_seed : '')} as IPreimage;
-                            var validator: ValidatorData =
+                            let preimage_hash: string = row.preimage_hash;
+                            let preimage_distance: number = row.preimage_distance;
+                            let target_height: number = row.height;
+                            let result_preimage_hash = new Hash();
+                            let start_index: number = row.enrolled_at + 1;
+
+                            // Hashing preImage
+                            if ((target_height >= start_index) &&
+                                (start_index + row.preimage_distance) >= target_height)
+                            {
+                                result_preimage_hash.fromHexString(preimage_hash);
+                                for (let i = 0; i < start_index + row.preimage_distance - target_height; i++)
+                                {
+                                    result_preimage_hash.hash(result_preimage_hash.buffer.slice());
+                                    preimage_distance--;
+                                }
+                            }
+                            else
+                            {
+                                preimage_distance = NaN;
+                                result_preimage_hash.fromHexString(Hash.NULL);
+                            }
+
+                            let preimage: IPreimage =
+                                {
+                                    distance: preimage_distance,
+                                    hash: result_preimage_hash.toHexString()
+                                } as IPreimage;
+
+                            let validator: ValidatorData =
                                 new ValidatorData(row.address, row.enrolled_at, row.stake, preimage);
                             out_put.push(validator);
                         }
@@ -109,8 +135,35 @@ class Stoa {
 
                         for (const row of rows)
                         {
-                            let preimage: IPreimage = {distance: row.distance,
-                                hash: (row.distance == 0 ? row.random_seed : '')} as IPreimage;
+                            let preimage_hash: string = row.preimage_hash;
+                            let preimage_distance: number = row.preimage_distance;
+                            let target_height: number = row.height;
+                            let result_preimage_hash = new Hash();
+                            let start_index: number = row.enrolled_at + 1;
+
+                            // Hashing preImage
+                            if ((target_height >= start_index) &&
+                                (start_index + row.preimage_distance) >= target_height)
+                            {
+                                result_preimage_hash.fromHexString(preimage_hash);
+                                for (let i = 0; i < start_index + row.preimage_distance - target_height; i++)
+                                {
+                                    result_preimage_hash.hash(result_preimage_hash.buffer.slice());
+                                    preimage_distance--;
+                                }
+                            }
+                            else
+                            {
+                                preimage_distance = NaN;
+                                result_preimage_hash.fromHexString(Hash.NULL);
+                            }
+
+                            let preimage: IPreimage =
+                                {
+                                    distance: preimage_distance,
+                                    hash: result_preimage_hash.toHexString()
+                                } as IPreimage;
+
                             let validator: ValidatorData =
                                 new ValidatorData(row.address, row.enrolled_at, row.stake, preimage);
                             out_put.push(validator);

--- a/src/modules/common/Hash.ts
+++ b/src/modules/common/Hash.ts
@@ -30,6 +30,12 @@ export class Hash
      */
     public buffer: Buffer;
 
+    public static NULL: string =
+        "0x0000000000000000000000000000000000000" +
+        "000000000000000000000000000000000000000" +
+        "000000000000000000000000000000000000000" +
+        "0000000000000";
+
     /**
      * Constructor
      * @param hex Hex string of hash

--- a/src/modules/data/PreImageInfo.ts
+++ b/src/modules/data/PreImageInfo.ts
@@ -1,0 +1,39 @@
+/*******************************************************************************
+
+    The class that defines and parses the preImageInfo.
+
+    Copyright:
+        Copyright (c) 2020 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+import { Validator, IPreImageInfo } from './validator'
+
+/**
+ * The class that defines and parses the preImageInfo.
+ * Convert JSON object to TypeScript's instance.
+ * An exception occurs if the required property is not present.
+ */
+export class PreImageInfo
+{
+    enroll_key: string = "";
+    hash: string = "";
+    distance: number = 0;
+
+    /**
+     * This parses JSON.
+     * @param json The object of the JSON
+     */
+    public parseJSON (json: any)
+    {
+        Validator.isValidOtherwiseThrow<IPreImageInfo>('PreImageInfo', json);
+
+        this.enroll_key = json.enroll_key;
+        this.hash = json.hash;
+        this.distance = json.distance;
+    }
+}

--- a/src/modules/data/index.ts
+++ b/src/modules/data/index.ts
@@ -19,6 +19,7 @@ import { Transaction } from './Transaction';
 import { BlockHeader } from './BlockHeader';
 import { Block } from './Block';
 import { Height } from './Height';
+import { PreImageInfo } from './PreImageInfo';
 
 export
 {
@@ -30,4 +31,5 @@ export
     BlockHeader,
     Block,
     Height,
+    PreImageInfo
 }

--- a/src/modules/data/schemas/PreImageInfo.json
+++ b/src/modules/data/schemas/PreImageInfo.json
@@ -1,0 +1,17 @@
+{
+  "title": "IPreImageInfo",
+  "type": "object",
+  "properties": {
+    "enroll_key": {
+      "type": "string"
+    },
+    "hash": {
+      "type": "string"
+    },
+    "distance": {
+      "type": "integer"
+    }
+  },
+  "additionalProperties": false,
+  "required": ["enroll_key", "hash", "distance"]
+}

--- a/src/modules/data/validator/index.ts
+++ b/src/modules/data/validator/index.ts
@@ -20,6 +20,7 @@ export { IHeight } from '../types/Height';
 export { ITransaction } from '../types/Transaction';
 export { ITxInputs } from '../types/TxInputs';
 export { ITxOutputs } from '../types/TxOutputs';
+export { IPreImageInfo } from '../types/PreImageInfo';
 
 const ajv = new Ajv();
 

--- a/tests/SampleData.test.ts
+++ b/tests/SampleData.test.ts
@@ -287,3 +287,10 @@ export const sample_data =
             ]
         }
     ];
+
+export const sample_preImageInfo =
+    {
+        "enroll_key": "0x210b66053c73e7bd7b27673706f0272617d09b8cda76605e91ab66ad1cc3bfc1f3f5fede91fd74bb2d2073de587c6ee495cfb0d981f03a83651b48ce0e576a1a",
+        "hash": "0x4869b90d82af612dac15b6f152700b2e0f0b4a198fa09d83853d4ac3be4032b051c48806692b37776534f2ae7b404c9221ae1c9616fe50e3585d63e607d0afc6",
+        "distance": 6
+    };

--- a/tests/SampleData.test.ts
+++ b/tests/SampleData.test.ts
@@ -294,3 +294,10 @@ export const sample_preImageInfo =
         "hash": "0x4869b90d82af612dac15b6f152700b2e0f0b4a198fa09d83853d4ac3be4032b051c48806692b37776534f2ae7b404c9221ae1c9616fe50e3585d63e607d0afc6",
         "distance": 6
     };
+
+export const sample_reEnroll_preImageInfo =
+    {
+        "enroll_key": "0x210b66053c73e7bd7b27673706f0272617d09b8cda76605e91ab66ad1cc3bfc1f3f5fede91fd74bb2d2073de587c6ee495cfb0d981f03a83651b48ce0e576a1a",
+        "hash": "0x25677ee5a05590d68276d1967cbe37e3cf3e731502afd043fafc82b0181cd120cef6272e5aea2dafaca0236a4ce7c1edd4fe21ae770930a8e206bd7080066a4c",
+        "distance": 6
+    };

--- a/tests/Stoa.test.ts
+++ b/tests/Stoa.test.ts
@@ -17,7 +17,7 @@ import express from "express";
 import axios from "axios";
 import * as http from "http";
 import URI from "urijs";
-import {sample_data} from "./SampleData.test";
+import {sample_data, sample_preImageInfo} from "./SampleData.test";
 
 /**
  * This is an API server for testing and inherited from Stoa.
@@ -125,5 +125,22 @@ describe ('Test of Stoa API Server', () =>
                 assert.ok(!error, error);
             })
             .finally(doneIt);
+    });
+
+    it ('Test of the path /preimage_received', async () =>
+    {
+        let uri = URI(host)
+            .port(port)
+            .directory("preimage_received");
+
+        await client.post (uri.toString(), {pre_image: sample_preImageInfo})
+        .then((response) =>
+        {
+            assert.strictEqual(response.status, 200);
+        })
+        .catch((error) =>
+        {
+            assert.fail(error);
+        });
     });
 });

--- a/tests/Stoa.test.ts
+++ b/tests/Stoa.test.ts
@@ -17,7 +17,12 @@ import express from "express";
 import axios from "axios";
 import * as http from "http";
 import URI from "urijs";
-import {sample_data, sample_preImageInfo} from "./SampleData.test";
+import {sample_data,
+        sample_preImageInfo,
+        sample_reEnroll_preImageInfo
+       } from "./SampleData.test";
+import { Hash } from '../src/modules/common/Hash';
+import { Block, Enrollment, Height } from '../src/modules/data';
 
 /**
  * This is an API server for testing and inherited from Stoa.
@@ -51,10 +56,11 @@ describe ('Test of Stoa API Server', () =>
     let host: string = 'http://localhost';
     let port: string = '3837';
     let client = axios.create();
+    let stoa: TestStoa;
 
     before ('Start Stoa API Server', (doneIt: () => void) =>
     {
-        new TestStoa(":memory:", port, doneIt);
+        stoa = new TestStoa(":memory:", port, doneIt);
     });
 
     after ('Stop Stoa API Server', (doneIt: () => void) =>
@@ -95,7 +101,7 @@ describe ('Test of Stoa API Server', () =>
                 assert.strictEqual(response.data.length, 3);
                 assert.strictEqual(response.data[0].address,
                     "GA3DMXTREDC4AIUTHRFIXCKWKF7BDIXRWM2KLV74OPK2OKDM2VJ235GN");
-                assert.strictEqual(response.data[0].preimage.distance, 10);
+                assert.strictEqual(response.data[0].preimage.distance, null);
             })
             .catch((error) =>
             {
@@ -118,7 +124,7 @@ describe ('Test of Stoa API Server', () =>
                 assert.strictEqual(response.data.length, 1);
                 assert.strictEqual(response.data[0].address,
                     "GBJABNUCDJCIL5YJQMB5OZ7VCFPKYLMTUXM2ZKQJACT7PXL7EVOMEKNZ");
-                assert.strictEqual(response.data[0].preimage.distance, 10);
+                assert.strictEqual(response.data[0].preimage.distance, null);
             })
             .catch((error) =>
             {
@@ -127,20 +133,131 @@ describe ('Test of Stoa API Server', () =>
             .finally(doneIt);
     });
 
-    it ('Test of the path /preimage_received', async () =>
+    it ('Tests that sending a pre-image with get /validator and /validators', async () =>
     {
         let uri = URI(host)
             .port(port)
             .directory("preimage_received");
+        let response = await client.post (uri.toString(), {pre_image: sample_preImageInfo});
+        assert.strictEqual(response.status, 200);
 
-        await client.post (uri.toString(), {pre_image: sample_preImageInfo})
-        .then((response) =>
-        {
-            assert.strictEqual(response.status, 200);
-        })
-        .catch((error) =>
-        {
-            assert.fail(error);
-        });
+        let uri2 = URI(host)
+            .port(port)
+            .directory("validator")
+            .filename("GA3DMXTREDC4AIUTHRFIXCKWKF7BDIXRWM2KLV74OPK2OKDM2VJ235GN")
+            .setSearch("height", "7");
+
+        response = await client.get (uri2.toString());
+        assert.strictEqual(response.data.length, 1);
+        assert.strictEqual(response.data[0].preimage.distance, 6);
+        assert.strictEqual(response.data[0].preimage.hash,
+            "0x4869b90d82af612dac15b6f152700b2e0f0b4a198fa09d83853d4ac3be4032b051c48806692b37776534f2ae7b404c9221ae1c9616fe50e3585d63e607d0afc6");
+
+        let uri3 = URI(host)
+            .port(port)
+            .directory("validator")
+            .filename("GA3DMXTREDC4AIUTHRFIXCKWKF7BDIXRWM2KLV74OPK2OKDM2VJ235GN")
+            .setSearch("height", "1");
+        response = await client.get (uri3.toString());
+        assert.strictEqual(response.data.length, 1);
+        assert.strictEqual(response.data[0].preimage.distance, 0);
+        assert.strictEqual(response.data[0].preimage.hash,
+            "0xba665738077b352ed93c2d30882bd0505cf1147ed7610fd43d8bfe72cb29eee3b9b95a81bb3550c23dfa811bde4a7290d1dba85097b064de3557878fe62fd6ab");
+
+        let uri4 = URI(host)
+            .port(port)
+            .directory("validator")
+            .filename("GA3DMXTREDC4AIUTHRFIXCKWKF7BDIXRWM2KLV74OPK2OKDM2VJ235GN")
+            .setSearch("height", "8");
+        response = await client.get (uri4.toString());
+        assert.strictEqual(response.data.length, 1);
+        assert.strictEqual(response.data[0].preimage.distance, null);
+        assert.strictEqual(response.data[0].preimage.hash, Hash.NULL);
+
+        let uri5 = URI(host)
+            .port(port)
+            .directory("validators");
+        response = await client.get (uri5.toString());
+        assert.strictEqual(response.data.length, 3);
+        assert.strictEqual(response.data[0].preimage.distance, 0);
+        assert.strictEqual(response.data[0].preimage.hash,
+            "0xba665738077b352ed93c2d30882bd0505cf1147ed7610fd43d8bfe72cb29eee3b9b95a81bb3550c23dfa811bde4a7290d1dba85097b064de3557878fe62fd6ab");
+
+        let block = new Block();
+        let height = new Height();
+        let enrollment = new Enrollment();
+        height.value = 1008;
+        block.header.height = height;
+
+        // re-enrollment
+        enrollment.cycle_length = 1008;
+        enrollment.utxo_key =
+            "0x210b66053c73e7bd7b27673706f0272617d09b8cda76605e91ab66ad1cc3bfc1f3f5fede91fd74bb2d2073de587c6ee495cfb0d981f03a83651b48ce0e576a1a";
+        enrollment.enroll_sig =
+            "0x0c48e78972e1b138a37e37ae27a01d5ebdea193088ddef2d9883446efe63086925e8803400d7b93d22b1eef5c475098ce08a5b47e8125cf6b04274cc4db34bfd";
+        enrollment.random_seed =
+            "0xe0c04a5bd47ffc5b065b7d397e251016310c43dc77220bf803b73f1183da00b0e67602b1f95cb18a0059aa1cdf2f9adafe979998364b38cd5c15d92b9b8fd815";
+        block.header.enrollments.push(enrollment);
+
+        // put the re-enrollment
+        await stoa.ledger_storage.putEnrollments(block);
+
+        let uri6 = URI(host)
+        .port(port)
+        .directory("validators")
+        .setSearch("height", "1008");
+
+        response = await client.get (uri6.toString());
+        assert.strictEqual(response.data.length, 3);
+
+        assert.strictEqual(response.data[0].stake, enrollment.utxo_key);
+        assert.strictEqual(response.data[0].enrolled_at, 0);
+
+        let uri7 = URI(host)
+        .port(port)
+        .directory("validators")
+        .setSearch("height", "1009");
+
+        response = await client.get (uri7.toString());
+        assert.strictEqual(response.data.length, 1);
+
+        assert.strictEqual(response.data[0].stake, enrollment.utxo_key);
+        assert.strictEqual(response.data[0].enrolled_at, 1008);
+
+        let uri8 = URI(host)
+        .port(port)
+        .directory("validators")
+        .setSearch("height", "2016");
+
+        response = await client.get (uri8.toString());
+        assert.strictEqual(response.data.length, 1);
+
+        assert.strictEqual(response.data[0].stake, enrollment.utxo_key);
+        assert.strictEqual(response.data[0].enrolled_at, 1008);
+
+        let uri9 = URI(host)
+        .port(port)
+        .directory("validators")
+        .setSearch("height", "2017");
+
+        response = await client.get (uri9.toString());
+        assert.strictEqual(response.data.length, 0);
+
+        // push the re-enroll's preImage
+        let uri10 = URI(host)
+        .port(port)
+        .directory("preimage_received");
+        response = await client.post (uri10.toString(), {pre_image: sample_reEnroll_preImageInfo});
+        assert.strictEqual(response.status, 200);
+
+        let uri11 = URI(host)
+        .port(port)
+        .directory("validators")
+        .setSearch("height", "1015");
+
+        response = await client.get (uri11.toString());
+        assert.strictEqual(response.data.length, 1);
+        assert.strictEqual(response.data[0].preimage.distance, 6);
+        assert.strictEqual(response.data[0].preimage.hash, sample_reEnroll_preImageInfo.hash);
     });
 });

--- a/tests/Storage.test.ts
+++ b/tests/Storage.test.ts
@@ -198,7 +198,7 @@ function runValidatorsAPITest (ledger_storage: LedgerStorage, onDone: () => void
         {
             assert.strictEqual(rows[0].address, address);
             assert.strictEqual(rows[0].enrolled_at, 0);
-            assert.strictEqual(rows[0].distance, 1);
+            assert.strictEqual(rows[0].distance, undefined);
 
             ledger_storage.getValidatorsAPI(1, address,
                 (rows: any[]) =>
@@ -212,7 +212,7 @@ function runValidatorsAPITest (ledger_storage: LedgerStorage, onDone: () => void
                         (rows: any[]) =>
                         {
                             assert.strictEqual(rows.length, 3);
-                            assert.strictEqual(rows[0].distance, 1);
+                            assert.strictEqual(rows[0].distance, undefined);
                             onDone();
                         },
                         (err3: Error) =>
@@ -379,7 +379,7 @@ function updatePreImageTest (allDoneIt: () => void)
                             ledger_storage.getValidators(height,
                                 (rows: any[]) =>
                                 {
-                                    assert.strictEqual(rows[0].preimage_distance, 6);
+                                    assert.strictEqual(rows[0].preimage_distance, sample_preImageInfo.distance);
                                     assert.strictEqual(rows[0].preimage_hash, sample_preImageInfo.hash);
                                 },
                                 (err1: Error) =>
@@ -419,7 +419,7 @@ function updatePreImageTest (allDoneIt: () => void)
                         });
                     });
 
-                    it ('Preimage distance Greater Than ValidatorCycle Test', (doneIt: () => void) =>
+                    it ('Fail tests that sending a pre-image with a distance of 1008 works', (doneIt: () => void) =>
                     {
                         // Distance test out of cycle_length range Test
                         sample_preImageInfo.distance = 1008;


### PR DESCRIPTION
Receive the preimageInfo and store the preimage information in the validators table.
This saves only new preimage information and the distance must be greater than the previously saved one.
And the distance cannot be greater than the cycle of the enrollment.
The preimage information is provided in /getvalidator /getvalidators .
Returns the preimage of the enrolled Enrollment by the Height value.
At this point, the preimage can be found by hashing the preimage to the distance.
The Validators table has the last released preimage.
And it's each stored on a continuous Enrollment cycle.

Related to #52 

