### PR TITLE
Apply DB transactions to the Block storage processing

### DIFF
--- a/src/modules/storage/LedgerStorage.ts
+++ b/src/modules/storage/LedgerStorage.ts
@@ -153,12 +153,15 @@ export class LedgerStorage extends Storages
                 {
                     let block: Block = new Block();
                     block.parseJSON(data);
+                    await this.begin();
                     await saveBlock(this, block);
                     await this.putTransactions(block);
                     await this.putEnrollments(block);
+                    await this.commit();
                 }
                 catch (error)
                 {
+                    await this.rollback();
                     reject(error);
                     return;
                 }

--- a/src/modules/storage/Storages.ts
+++ b/src/modules/storage/Storages.ts
@@ -62,4 +62,62 @@ export class Storages
     {
         this.db.close();
     }
+
+    /**
+     * SQLite transaction statement
+     * To start a transaction explicitly,
+     * Open a transaction by issuing the begin function
+     * the transaction is open until it is explicitly
+     * committed or rolled back.
+     */
+    protected begin (): Promise<void>
+    {
+        return new Promise<void>((resolve, reject) =>
+        {
+            this.db.run('BEGIN', (err: Error | null) =>
+            {
+                if (err == null)
+                    resolve();
+                else
+                    reject(err);
+            });
+        });
+    }
+    
+    /**
+     * SQLite transaction statement
+     * Commit the changes to the database by using this.
+     */
+    protected commit (): Promise<void>
+    {
+        return new Promise<void>((resolve, reject) =>
+        {
+            this.db.run('COMMIT', (err: Error | null) =>
+            {
+                if (err == null)
+                    resolve();
+                else
+                    reject(err);
+            });
+        });
+    }
+
+    /**
+     * SQLite transaction statement
+     * If it do not want to save the changes,
+     * it can roll back using this.
+     */
+    protected rollback (): Promise<void>
+    {
+        return new Promise<void>((resolve, reject) =>
+        {
+            this.db.run('ROLLBACK', (err: Error | null) =>
+            {
+                if (err == null)
+                    resolve();
+                else
+                    reject(err);
+            });
+        });
+    }
 }


### PR DESCRIPTION
If an error occurs while storing blocks and transactions or enrollments, that do not match the ledger actual data may exist.
For example, if only block data exists.
In this case, rollback must be done and must be `rollback` in the tables.

Related #51 