### PR TITLE
Only create information table if it does not already exist

### DIFF
--- a/src/modules/storage/LedgerStorage.ts
+++ b/src/modules/storage/LedgerStorage.ts
@@ -107,7 +107,7 @@ export class LedgerStorage extends Storages
             PRIMARY KEY(enrolled_at,utxo_key)
         );
 
-        CREATE TABLE information
+        CREATE TABLE IF NOT EXISTS information
         (
             key     TEXT NOT NULL,
             value   TEXT,


### PR DESCRIPTION
If information table is already existing then the stoa app reports error on startup.