### PR TITLE
Apply IP Filtering with whitelist

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1146,6 +1146,17 @@
         "vary": "~1.1.2"
       }
     },
+    "express-ipfilter": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/express-ipfilter/-/express-ipfilter-1.1.2.tgz",
+      "integrity": "sha512-dm1G3sVxlSbcOWSxfUTCo20ySyNQXJ4hJD5fuQJFoZlhkQvpbuDGBlh8AbFm1GwX85EWvfyhekOkvcydaXkBkg==",
+      "requires": {
+        "ip": "~1.1.0",
+        "lodash": "^4.17.11",
+        "proxy-addr": "^2.0.4",
+        "range_check": "^1.2.0"
+      }
+    },
     "ext": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
@@ -1541,6 +1552,16 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+    },
+    "ip": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
+    },
+    "ip6": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/ip6/-/ip6-0.0.4.tgz",
+      "integrity": "sha1-RMWp23njnUBSAbTXjROzhw5I2zE="
     },
     "ipaddr.js": {
       "version": "1.9.1",
@@ -2870,6 +2891,22 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
+    },
+    "range_check": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/range_check/-/range_check-1.4.0.tgz",
+      "integrity": "sha1-zYfHrGLEC6nfabhwPGBPYMN0hjU=",
+      "requires": {
+        "ip6": "0.0.4",
+        "ipaddr.js": "1.2"
+      },
+      "dependencies": {
+        "ipaddr.js": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.2.0.tgz",
+          "integrity": "sha1-irpJyRknmVhb3WQ+DMtQ6K53e6Q="
+        }
+      }
     },
     "raw-body": {
       "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "cors": "^2.8.5",
     "crc": "^3.8.0",
     "express": "^4.17.1",
+    "express-ipfilter": "^1.1.2",
     "json-schema-to-typescript": "^9.1.1",
     "sodium-native": "^3.2.0",
     "source-map-support": "^0.5.19",

--- a/src/Stoa.ts
+++ b/src/Stoa.ts
@@ -1,6 +1,7 @@
 import express from "express";
 import bodyParser from "body-parser";
 import cors from "cors";
+import { IpFilter, IpList } from "express-ipfilter";
 import { LedgerStorage } from "./modules/storage/LedgerStorage";
 import { ValidatorData, IPreimage, IValidator } from "./modules/data/ValidatorData";
 import { PreImageInfo, Hash, hash } from "./modules/data";
@@ -71,6 +72,9 @@ class Stoa {
         {
             return this.task();
         }, 10);
+
+        // List that allows access only to those IPs
+        const white_ip_list: IpList = ['::ffff:127.0.0.1'];
 
         /**
          * Called when a request is received through the `/validators` handler
@@ -228,6 +232,7 @@ class Stoa {
          * and immediately sends a response to Agora
          */
         this.stoa.post("/block_externalized",
+            IpFilter(white_ip_list, { mode: 'allow', log: false }),
             (req: express.Request, res: express.Response, next: express.NextFunction) => {
 
             if (req.body.block === undefined)
@@ -250,6 +255,7 @@ class Stoa {
          * JSON preImage data is parsed and stored on each storage.
          */
         this.stoa.post("/preimage_received",
+            IpFilter(white_ip_list, { mode: 'allow', log: false }),
             (req: express.Request, res: express.Response, next: express.NextFunction) => {
 
             if (req.body.pre_image === undefined)


### PR DESCRIPTION
IP filtering applied to /block_externalized and /preimage_received.
This is applied to receive from a trusted node.
Also, trusted nodes are based on the local network.

https://github.com/bpfkorea/stoa/issues/85
The whitelist will be included because there are issues related to setting up the environment.

Related to #76  