### PR TITLE
Add .dockerignore for removing logs, docs, database, ...

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+# Part of the source tree, but not needed to build Stoa
+.git/
+.github/
+docs/
+logs/
+
+# Dependency build files, It is installed when creating a docker image.
+node_modules/
+
+# Database file
+database
+
+# Visual Studio Code
+.vscode/
+
+# WebStorm
+.idea/


### PR DESCRIPTION
I added the list below to ignore folders and files that are not needed to create a docker image.
node_modules
docs
logs
database
.vscode
.github
.idea