### PR TITLE
Implement the ability to receive the information needed to execute through the arguments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,12 @@
       "resolved": "https://registry.npmjs.org/@types/app-root-path/-/app-root-path-1.2.4.tgz",
       "integrity": "sha1-p4twMoKzKsVN52j1US7MNWmRncc="
     },
+    "@types/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-C4jqpdasIkxgjHEfAtQEx59/rprJxP4R2GgPW6xdKeOSmEPf3jvQB706R7hebZAimKWPMU88l9MchWxtAcgT3g==",
+      "dev": true
+    },
     "@types/body-parser": {
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.0.tgz",
@@ -293,12 +299,9 @@
       "dev": true
     },
     "argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "requires": {
-        "sprintf-js": "~1.0.2"
-      }
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "array-filter": {
       "version": "1.0.0",
@@ -1779,6 +1782,16 @@
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        }
       }
     },
     "json-buffer": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@types/sqlite3": "^3.1.6",
     "ajv": "^6.12.3",
     "app-root-path": "^3.0.0",
+    "argparse": "^2.0.1",
     "assert": "^2.0.0",
     "axios": "^0.19.2",
     "body-parser": "^1.19.0",
@@ -47,6 +48,7 @@
     "winston": "^3.3.3"
   },
   "devDependencies": {
+    "@types/argparse": "^2.0.1",
     "@types/chai": "^4.2.12",
     "@types/crc": "^3.4.0",
     "@types/express": "^4.17.7",

--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
   "scripts": {
     "json2ts": "./node_modules/.bin/json2ts -i src/modules/data/schemas/ -o src/modules/data/types/",
     "_test": "mocha -r ts-node/register tests/**/*.test.ts",
-    "_start": "nodemon --watch src --delay 1 --exec 'ts-node' src/main.ts",
     "test": "NODE_ENV=test npm-run-all --serial json2ts _test",
     "debug": "NODE_ENV=development npm-run-all --serial json2ts _test",
-    "start": "NODE_ENV=production npm-run-all --serial json2ts _start",
+    "prestart": "npm run json2ts",
+    "start": "NODE_ENV=production nodemon -w src -d 1 -x ts-node src/main.ts",
     "tsc": "tsc"
   },
   "repository": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,13 +2,27 @@ import 'source-map-support/register';
 import { logger } from './modules/common/Logger';
 import Stoa from './Stoa';
 
+import { ArgumentParser } from "argparse";
 import express from 'express';
 import { URL } from 'url';
 
-const port: number = Number(process.env.PORT) || 3836;
-const agora_address: URL = new URL(process.env.AGORA_ENDPOINT || "http://127.0.0.1:2826");
-// TODO: Replace hardcoded "127.0.0.1" with  agora_address.hostname (#106)
-const stoa: express.Application = new Stoa("database", "127.0.0.1", agora_address.port).stoa;
+// Parse the arguments
+const parser = new ArgumentParser();
+parser.add_argument('-a', '--agora', { help: "The endpoint of Agora" });
+parser.add_argument('--address', { help: "The address to which we bind to Stoa" });
+parser.add_argument('-p', '--port', { help: "The port on which we bind to Stoa" });
+parser.add_argument('-d', '--database', { help: "The file name of sqlite3 database" });
+let args = parser.parse_args();
 
-stoa.listen(port, () => logger.info(`Stoa API server listening at ${port}`))
+const address: string = args.address || "0.0.0.0";
+const port: number = Number(args.port || "3836");
+const agora_address: URL = new URL(args.agora || "http://127.0.0.1:2826");
+const database_filename: string = args.database || "database";
+logger.info(`Using Agora located at: ${agora_address.hostname}: ${agora_address.port}`);
+logger.info(`The address to which we bind to Stoa: ${address}`);
+logger.info(`The port to which we bind to Stoa: ${port}`);
+logger.info(`The file name of sqlite3 database: ${database_filename}`);
+const stoa: express.Application = new Stoa(database_filename, agora_address.hostname, agora_address.port).stoa;
+
+stoa.listen(port, address, () => logger.info(`Listening to requests on: ${address}:${port}`))
 .on('error', err => logger.error(err));


### PR DESCRIPTION
We had previously tried to solve the problem using environmental variables.
I realized after several attempts that this was impossible.
I couldn't set the environment variable with 'npm start'.

Instead, I solved the problem in the following ways.

I implemented the ability to receive the information needed to execute through the arguments

Used as below.
npm start -- --agora=http://127.0.0.1:4826/  

Used in the docker as follows
docker run -d -p 3836:3836 -i -t stoa -- --agora=http://127.0.0.1:4826/

Additional arguments
'-a', '--agora' - The endpoint of Agora
'-p', '--port' - The network port of Stoa
'-d', '--database’ - The file name of sqlite3 database

Relates to #106 