### PR TITLE
Separate listening, middleware, and routers of web service into methods

### DIFF
--- a/src/Stoa.ts
+++ b/src/Stoa.ts
@@ -98,15 +98,32 @@ class Stoa extends WebService
 
     private prepareRoutes ()
     {
-        /**
-         * Called when a request is received through the `/validators` handler
-         *
-         * Returns a set of Validators based on the block height if there is a height.
-         * If height was not provided the latest validator set is returned.
-         */
-        this.app.get("/validators",
-            (req: express.Request, res: express.Response, next: express.NextFunction) =>
-        {
+        // GET /validators
+        this.app.get("/validators", this.getValidators.bind(this));
+
+        // GET /validator/:address
+        this.app.get("/validator/:address", this.getValidator.bind(this));
+
+        // POST /block_externalized
+        this.app.post("/block_externalized",
+            IpFilter(this.white_ip_list, { mode: 'allow', log: false }), this.putBlock.bind(this));
+
+        // POST /preimage_received
+        this.app.post("/preimage_received",
+            IpFilter(this.white_ip_list, { mode: 'allow', log: false }), this.putPreImage.bind(this));
+    }
+
+    /**
+     * GET /validators
+     *
+     * Called when a request is received through the `/validators` handler
+     *
+     * Returns a set of Validators based on the block height if there is a height.
+     * If height was not provided the latest validator set is returned.
+     */
+    private getValidators (req: express.Request, res: express.Response)
+    {
+        // TODO: No indentation was made to reduce change. Fix this next time.
             if  (
                     (req.query.height !== undefined) &&
                     !Utils.isPositiveInteger(req.query.height.toString())
@@ -179,18 +196,20 @@ class Stoa extends WebService
                     res.status(500).send("Failed to data lookup");
                 }
             );
-        });
+    }
 
-        /**
-         * Called when a request is received through the `/validators/:address` handler
-         *
-         * Returns a set of Validators based on the block height if there is a height.
-         * If height was not provided the latest validator set is returned.
-         * If an address was provided, return the validator data of the address if it exists.
-         */
-        this.app.get("/validator/:address",
-            (req: express.Request, res: express.Response, next: express.NextFunction) =>
-        {
+    /**
+     * GET /validator/:address
+     *
+     * Called when a request is received through the `/validators/:address` handler
+     *
+     * Returns a set of Validators based on the block height if there is a height.
+     * If height was not provided the latest validator set is returned.
+     * If an address was provided, return the validator data of the address if it exists.
+     */
+    private getValidator (req: express.Request, res: express.Response)
+    {
+        // TODO: No indentation was made to reduce change. Fix this next time.
             if  (
                 (req.query.height !== undefined) &&
                 !Utils.isPositiveInteger(req.query.height.toString())
@@ -265,17 +284,18 @@ class Stoa extends WebService
                     res.status(500).send("Failed to data lookup");
                 }
             );
-        });
+    }
 
-        /**
-         * When a request is received through the `/push` handler
-         * The block data received is stored in the pool
-         * and immediately sends a response to Agora
-         */
-        this.app.post("/block_externalized",
-            IpFilter(this.white_ip_list, { mode: 'allow', log: false }),
-            (req: express.Request, res: express.Response, next: express.NextFunction) => {
-
+    /**
+     * POST /block_externalized
+     *
+     * When a request is received through the `/push` handler
+     * The block data received is stored in the pool
+     * and immediately sends a response to Agora
+     */
+    private putBlock (req: express.Request, res: express.Response)
+    {
+        // TODO: No indentation was made to reduce change. Fix this next time.
             // Change the number to a string to preserve the precision of UInt64
             let text = req.body.toString().replace(/([\[:])?(\d+)([,\}\]])/g, "$1\"$2\"$3");
             let body = JSON.parse(text);
@@ -292,16 +312,17 @@ class Stoa extends WebService
             this.pool.push({type: "block", data: body.block});
 
             res.status(200).send();
-        });
+    }
 
-        /**
-         * When a request is received through the `/preimage_received` handler
-         * JSON preImage data is parsed and stored on each storage.
-         */
-        this.app.post("/preimage_received",
-            IpFilter(this.white_ip_list, { mode: 'allow', log: false }),
-            (req: express.Request, res: express.Response, next: express.NextFunction) => {
-
+    /**
+     * POST /preimage_received
+     *
+     * When a request is received through the `/preimage_received` handler
+     * JSON preImage data is parsed and stored on each storage.
+     */
+    private putPreImage (req: express.Request, res: express.Response)
+    {
+        // TODO: No indentation was made to reduce change. Fix this next time.
             let body = JSON.parse(req.body.toString());
             if (body.pre_image === undefined)
             {
@@ -316,7 +337,6 @@ class Stoa extends WebService
             this.pool.push({type: "pre_image", data: body.pre_image});
 
             res.status(200).send();
-        });
     }
 
     /**

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,6 @@ import { logger } from './modules/common/Logger';
 import Stoa from './Stoa';
 
 import { ArgumentParser } from "argparse";
-import express from 'express';
 import { URL } from 'url';
 
 // Parse the arguments
@@ -22,7 +21,6 @@ logger.info(`Using Agora located at: ${agora_address}`);
 logger.info(`The address to which we bind to Stoa: ${address}`);
 logger.info(`The port to which we bind to Stoa: ${port}`);
 logger.info(`The file name of sqlite3 database: ${database_filename}`);
-const stoa: express.Application = new Stoa(database_filename, agora_address).stoa;
 
-stoa.listen(port, address, () => logger.info(`Listening to requests on: ${address}:${port}`))
-.on('error', err => logger.error(err));
+const stoa: Stoa = new Stoa("database", agora_address, port, address);
+stoa.start();

--- a/src/modules/service/WebService.ts
+++ b/src/modules/service/WebService.ts
@@ -1,0 +1,100 @@
+/*******************************************************************************
+
+    The superclass for web service
+
+    Copyright:
+        Copyright (c) 2020 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+import express from 'express';
+import http  from 'http' ;
+import { logger } from '../common/Logger';
+
+export class WebService
+{
+    /**
+     * The bind address
+     */
+    private readonly address: string;
+
+    /**
+     * The bind port
+     */
+    private readonly port: number;
+
+    /**
+     * The application of express module
+     */
+    protected app: express.Application;
+
+    /**
+     * The Http server
+     */
+    protected server: http.Server | null = null;
+
+    /**
+     * Constructor
+     * @param port The bind port
+     * @param address The bind address
+     */
+    constructor (port: number | string, address?: string)
+    {
+        if (typeof port == "string")
+            this.port = parseInt(port, 10);
+        else
+            this.port = port;
+
+        if (address !== undefined)
+            this.address = address;
+        else
+            this.address = "";
+
+        this.app = express();
+    }
+
+    /**
+     * Start web server
+     * @param callback
+     */
+    public start (callback?: Function)
+    {
+        this.app.set('port', this.port);
+
+        // Create HTTP server.
+        this.server = http.createServer(this.app);
+
+        this.server.on('error', (error: any) =>
+        {
+            // handle specific listen errors with friendly messages
+            switch (error.code) {
+                case 'EACCES':
+                    logger.error(`${this.port} requires elevated privileges`);
+                    process.exit(1);
+                    break;
+                case 'EADDRINUSE':
+                    logger.error(`${this.port} is already in use`);
+                    process.exit(1);
+                    break;
+                default:
+                    logger.error(error);
+            }
+        });
+
+        this.server.on('listening', () =>
+        {
+            logger.info(`Listening to requests on: ${this.address}:${this.port}`);
+        });
+
+        // Listen on provided this.port on this.address.
+        this.server.listen(this.port, this.address, () =>
+        {
+            if (callback !== undefined)
+                callback();
+        });
+    }
+}

--- a/tests/Recovery.test.ts
+++ b/tests/Recovery.test.ts
@@ -112,14 +112,6 @@ class TestStoa extends Stoa
     {
         super(file_name, agora_endpoint, port);
 
-        // Shut down
-        this.app.get("/stop", (req: express.Request, res: express.Response) =>
-        {
-            res.send("The test server is stopped.");
-            if (this.server != null)
-                this.server.close();
-        });
-
         this.app.get("/block",
             async (req: express.Request, res: express.Response) =>
             {

--- a/tests/Recovery.test.ts
+++ b/tests/Recovery.test.ts
@@ -163,24 +163,26 @@ describe ('Test of Recovery', () =>
 
     let client = axios.create();
 
-    beforeEach ('Start TestAgora', (doneIt: () => void) =>
+    // Changed test agora to run only once.
+    before ('Start TestAgora', (doneIt: () => void) =>
     {
-        agora_node = new TestAgora(agora_port, () =>
-        {
-            stoa_server = new TestStoa(":memory:", agora_endpoint, stoa_port);
-            stoa_server.start(doneIt);
-        });
+        agora_node = new TestAgora(agora_port, doneIt);
     });
 
-    afterEach ('Stop TestAgora', (doneIt: () => void) =>
+    after ('Stop TestAgora', (doneIt: () => void) =>
     {
-        stoa_server.stop(() =>
-        {
-            agora_node.stop(() =>
-            {
-                doneIt();
-            });
-        });
+        agora_node.stop(doneIt);
+    });
+
+    beforeEach ('Start TestStoa', (doneIt: () => void) =>
+    {
+        stoa_server = new TestStoa(":memory:", agora_endpoint, stoa_port);
+        stoa_server.start(doneIt);
+    });
+
+    afterEach ('Stop TestStoa', (doneIt: () => void) =>
+    {
+        stoa_server.stop(doneIt);
     });
 
     it ('Test a function requestBlocks', async () =>

--- a/tests/Stoa.test.ts
+++ b/tests/Stoa.test.ts
@@ -22,8 +22,6 @@ import { TaskManager } from '../src/modules/task/TaskManager';
 
 import * as assert from 'assert';
 import axios from 'axios';
-import express from 'express';
-import * as http from 'http';
 import { UInt64 } from 'spu-integer-math';
 import URI from 'urijs';
 import { URL } from 'url';
@@ -34,19 +32,6 @@ import { URL } from 'url';
  */
 class TestStoa extends Stoa
 {
-    constructor (file_name: string, agora_endpoint: URL, port: string)
-    {
-        super(file_name, agora_endpoint, port);
-
-        // Shut down
-        this.app.get("/stop", (req: express.Request, res: express.Response) =>
-        {
-            res.send("The test server is stopped.");
-            if (this.server != null)
-                this.server.close();
-        });
-    }
-
     public stop (callback?: (err?: Error) => void)
     {
         this.task_manager.terminate();


### PR DESCRIPTION
The class has binding ports and addresses.
I gathered the callbacks and exceptions of listening to one place.
I separated the middleware setting.
I changed the routers of the web service from the callback function to the method. This will make scalability easy.