### PR TITLE
Change the host and port of Agora to the endpoint

### DIFF
--- a/src/Stoa.ts
+++ b/src/Stoa.ts
@@ -13,6 +13,7 @@ import cors from 'cors';
 import express from 'express';
 import { IpFilter, IpList } from 'express-ipfilter';
 import { UInt64 } from 'spu-integer-math';
+import { URL } from 'url';
 
 class Stoa {
     public stoa: express.Application;
@@ -20,14 +21,9 @@ class Stoa {
     public ledger_storage: LedgerStorage;
 
     /**
-     * The network host to connect to Agora
+     * The network endpoint to connect to Agora
      */
-    private readonly agora_host: string;
-
-    /**
-     * The network port to connect to Agora
-     */
-    private readonly agora_port: string;
+    private readonly agora_endpoint: URL;
 
     /**
      * The temporary storage of the data received from Agora
@@ -47,13 +43,11 @@ class Stoa {
     /**
      * Constructor
      * @param database_filename sqlite3 database file name
-     * @param agora_host The network host to connect to Agora
-     * @param agora_port The network port to connect to Agora
+     * @param agora_endpoint The network endpoint to connect to Agora
      */
-    constructor (database_filename: string, agora_host: string, agora_port: string)
+    constructor (database_filename: string, agora_endpoint: URL)
     {
-        this.agora_host = agora_host;
-        this.agora_port = agora_port;
+        this.agora_endpoint = agora_endpoint;
 
         this.pool = [];
 
@@ -346,7 +340,7 @@ class Stoa {
 
                     if (max_blocks > 0)
                     {
-                        let agora_client = new AgoraClient(this.agora_host, this.agora_port);
+                        let agora_client = new AgoraClient(this.agora_endpoint);
                         let blocks = await agora_client.requestBlocks(expected_height, max_blocks);
 
                         // Save previous block

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,11 +18,11 @@ const address: string = args.address || "0.0.0.0";
 const port: number = Number(args.port || "3836");
 const agora_address: URL = new URL(args.agora || "http://127.0.0.1:2826");
 const database_filename: string = args.database || "database";
-logger.info(`Using Agora located at: ${agora_address.hostname}: ${agora_address.port}`);
+logger.info(`Using Agora located at: ${agora_address}`);
 logger.info(`The address to which we bind to Stoa: ${address}`);
 logger.info(`The port to which we bind to Stoa: ${port}`);
 logger.info(`The file name of sqlite3 database: ${database_filename}`);
-const stoa: express.Application = new Stoa(database_filename, agora_address.hostname, agora_address.port).stoa;
+const stoa: express.Application = new Stoa(database_filename, agora_address).stoa;
 
 stoa.listen(port, address, () => logger.info(`Listening to requests on: ${address}:${port}`))
 .on('error', err => logger.error(err));

--- a/src/modules/agora/AgoraClient.ts
+++ b/src/modules/agora/AgoraClient.ts
@@ -15,6 +15,7 @@ import { Height } from '../data/';
 
 import axios, { AxiosInstance, AxiosResponse, AxiosError } from 'axios';
 import URI from 'urijs';
+import { URL } from 'url';
 
 /**
  * The class that recovers data
@@ -22,14 +23,9 @@ import URI from 'urijs';
 export class AgoraClient
 {
     /**
-     * The network address to connect to Agora
+     * The network endpoint to connect to Agora
      */
-    private host: string;
-
-    /**
-     * The network port to connect to Agora
-     */
-    private port: string;
+    private endpoint: URL;
 
     /**
      * The instance of the axios
@@ -38,13 +34,11 @@ export class AgoraClient
 
     /**
      * Constructor
-     * @param host - The network address to connect to Agora
-     * @param port - The network port to connect to Agora
+     * @param endpoint - The network endpoint to connect to Agora
      */
-    constructor (host: string, port: string)
+    constructor (endpoint: URL)
     {
-        this.host = host;
-        this.port = port;
+        this.endpoint = endpoint;
         this.client = axios.create();
         this.client.defaults.timeout = 10000;
     }
@@ -58,8 +52,7 @@ export class AgoraClient
     {
         return new Promise<Array<any>>((resolve, reject) =>
         {
-            let uri = URI(this.host)
-                .port(this.port)
+            let uri = URI(this.endpoint)
                 .directory("blocks_from")
                 .addSearch("block_height", block_height.toString())
                 .addSearch("max_blocks", max_blocks);

--- a/tests/Recovery.test.ts
+++ b/tests/Recovery.test.ts
@@ -24,6 +24,7 @@ import express from 'express';
 import * as http from 'http';
 import { UInt64 } from 'spu-integer-math';
 import URI from 'urijs';
+import { URL } from 'url';
 
 /**
  * This is an Agora node for testing.
@@ -109,9 +110,9 @@ class TestStoa extends Stoa
 {
     public server: http.Server;
 
-    constructor (file_name: string, agora_address: string, agora_port: string, port: string, done: () => void)
+    constructor (file_name: string, agora_endpoint: URL, port: string, done: () => void)
     {
-        super(file_name, agora_address, agora_port);
+        super(file_name, agora_endpoint);
 
         // Shut down
         this.stoa.get("/stop", (req: express.Request, res: express.Response) =>
@@ -164,7 +165,7 @@ class TestStoa extends Stoa
 
 describe ('Test of Recovery', () =>
 {
-    let agora_host: string = 'http://localhost';
+    let agora_endpoint: URL = new URL('http://localhost:2820');
     let agora_port: string = '2820';
     let agora_node: TestAgora;
 
@@ -178,7 +179,7 @@ describe ('Test of Recovery', () =>
     {
         agora_node = new TestAgora(agora_port, () =>
         {
-            stoa_server = new TestStoa(":memory:", agora_host, agora_port, stoa_port, () =>
+            stoa_server = new TestStoa(":memory:", agora_endpoint, stoa_port, () =>
             {
                 doneIt();
             });
@@ -198,7 +199,7 @@ describe ('Test of Recovery', () =>
 
     it ('Test a function requestBlocks', async () =>
     {
-        let agora_client = new AgoraClient(agora_host, agora_port);
+        let agora_client = new AgoraClient(agora_endpoint);
 
         await assert.doesNotReject(async () =>
         {
@@ -226,7 +227,7 @@ describe ('Test of Recovery', () =>
 
     it ('Test a function requestBlocks using async, await', (doneIt: () => void) =>
     {
-        let agora_client = new AgoraClient(agora_host, agora_port);
+        let agora_client = new AgoraClient(agora_endpoint);
 
         assert.doesNotThrow(async () =>
         {

--- a/tests/Stoa.test.ts
+++ b/tests/Stoa.test.ts
@@ -26,6 +26,7 @@ import express from 'express';
 import * as http from 'http';
 import { UInt64 } from 'spu-integer-math';
 import URI from 'urijs';
+import { URL } from 'url';
 
 /**
  * This is an API server for testing and inherited from Stoa.
@@ -35,9 +36,9 @@ class TestStoa extends Stoa
 {
     public server: http.Server;
 
-    constructor (file_name: string, agora_address: string, agora_port: string, port: string, done: () => void)
+    constructor (file_name: string, agora_endpoint: URL, port: string, done: () => void)
     {
-        super(file_name, agora_address, agora_port);
+        super(file_name, agora_endpoint);
 
         // Shut down
         this.stoa.get("/stop", (req: express.Request, res: express.Response) =>
@@ -69,7 +70,7 @@ describe ('Test of Stoa API Server', () =>
 
     before ('Start Stoa API Server', (doneIt: () => void) =>
     {
-        stoa_server = new TestStoa(":memory:", "127.0.0.1", "2826", port, doneIt);
+        stoa_server = new TestStoa(":memory:", new URL("http://127.0.0.1:2826"), port, doneIt);
     });
 
     after ('Stop Stoa API Server', (doneIt: () => void) =>


### PR DESCRIPTION
Agora's information is entered via the command line parameter in the endpoint rather than the hostname and port (ex http://127.0.0.1:2826).

Inside the store, it was used separately from the hostname and port.
Therefore, it will not function normally when the protocol is changed.

I changed this so that Agora's endpoint was used as they were inside Stoa. Thus, it may be possible to apply the protocol that may change in the future.