### PR TITLE
Update Dockerfile to allow bind mounting the working directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,11 @@
 FROM alpine:3.12
 RUN apk add --no-cache curl git python3 py-pip alpine-sdk \
     bash autoconf libtool automake nodejs npm
-ADD . /stoa/
-WORKDIR /stoa/
-RUN npm ci
-EXPOSE 3836
+
+WORKDIR /stoa/wd/
+
+ADD . /stoa/bin/
+RUN npm ci --prefix /stoa/bin/
+
 # Starts a node process, which compiles TS and watches `src` for changes
-ENTRYPOINT [ "npm", "start" ]
+ENTRYPOINT /stoa/bin/docker/entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ For a test run,
 This requires the Agora config.yaml file in advance.
 try:
 ```console
-docker run -p 127.0.0.1:3836:3836/tcp -v $(pwd)/config.yaml:/stoa/config.yaml -e "CONFIG=/stoa/config.yaml" bpfk/stoa
+docker run -p 127.0.0.1:3836:3836/tcp -v $(pwd)/config.yaml:/stoa/wd/config.yaml bpfk/stoa -- -c /stoa/wd/config.yaml
 ```
 This will start a stoa & full node agora with the example config/agora_config file,
 and make the port locally accessible (See http://127.0.0.1:3836/).

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec npm start --prefix /stoa/bin/ -- $@


### PR DESCRIPTION
Bind mounting the working directory is necessary to keep the database around
when the production node runs under docker.
To do this, we use `--prefix` to tell `npm` where to find the app,
and we add a shell script as entrypoint to allow providing arguments.
Finally, using `exec` ensures signal propagation.

The EXPOSE statement was also removed as it can be configured from
the config file, hence needs to be provided by the user explicitly.