### PR TITLE
Remove IP filtering code because it is not working on the docker.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1170,17 +1170,6 @@
         "vary": "~1.1.2"
       }
     },
-    "express-ipfilter": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/express-ipfilter/-/express-ipfilter-1.1.2.tgz",
-      "integrity": "sha512-dm1G3sVxlSbcOWSxfUTCo20ySyNQXJ4hJD5fuQJFoZlhkQvpbuDGBlh8AbFm1GwX85EWvfyhekOkvcydaXkBkg==",
-      "requires": {
-        "ip": "~1.1.0",
-        "lodash": "^4.17.11",
-        "proxy-addr": "^2.0.4",
-        "range_check": "^1.2.0"
-      }
-    },
     "ext": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
@@ -1581,16 +1570,6 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
-    },
-    "ip": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
-    },
-    "ip6": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/ip6/-/ip6-0.0.4.tgz",
-      "integrity": "sha1-RMWp23njnUBSAbTXjROzhw5I2zE="
     },
     "ipaddr.js": {
       "version": "1.9.1",
@@ -2954,22 +2933,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
-    },
-    "range_check": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/range_check/-/range_check-1.4.0.tgz",
-      "integrity": "sha1-zYfHrGLEC6nfabhwPGBPYMN0hjU=",
-      "requires": {
-        "ip6": "0.0.4",
-        "ipaddr.js": "1.2"
-      },
-      "dependencies": {
-        "ipaddr.js": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.2.0.tgz",
-          "integrity": "sha1-irpJyRknmVhb3WQ+DMtQ6K53e6Q="
-        }
-      }
     },
     "raw-body": {
       "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "cors": "^2.8.5",
     "crc": "^3.8.0",
     "express": "^4.17.1",
-    "express-ipfilter": "^1.1.2",
     "extend": "^3.0.2",
     "js-yaml": "^3.14.0",
     "json-schema-to-typescript": "^9.1.1",

--- a/src/Stoa.ts
+++ b/src/Stoa.ts
@@ -12,7 +12,6 @@ import { WebService } from './modules/service/WebService';
 import bodyParser from 'body-parser';
 import cors from 'cors';
 import express from 'express';
-import { IpFilter, IpList } from 'express-ipfilter';
 import { UInt64 } from 'spu-integer-math';
 import { URL } from 'url';
 
@@ -41,18 +40,13 @@ class Stoa extends WebService
     private _max_count_on_recovery: number = 64;
 
     /**
-     * List that allows access only to those IPs
-     */
-    private readonly white_ip_list: IpList;
-
-    /**
      * Constructor
      * @param database_filename sqlite3 database file name
      * @param agora_endpoint The network endpoint to connect to Agora
      * @param port The network port of Stoa
      * @param address The network address of Stoa
      */
-    constructor (database_filename: string, agora_endpoint: URL, port: number | string, address?: string, white_ip_list?: Array<string>)
+    constructor (database_filename: string, agora_endpoint: URL, port: number | string, address?: string)
     {
         super(port, address);
 
@@ -75,12 +69,6 @@ class Stoa extends WebService
         {
             return this.task();
         }, 10);
-
-        // List that allows access only to those IPs
-        if (white_ip_list !== undefined)
-            this.white_ip_list = white_ip_list;
-        else
-            this.white_ip_list = ['::ffff:127.0.0.1'];
 
         this.prepareMiddleware();
         this.prepareRoutes();
@@ -108,12 +96,10 @@ class Stoa extends WebService
         this.app.get("/validator/:address", this.getValidator.bind(this));
 
         // POST /block_externalized
-        this.app.post("/block_externalized",
-            IpFilter(this.white_ip_list, { mode: 'allow', log: false }), this.putBlock.bind(this));
+        this.app.post("/block_externalized", this.putBlock.bind(this));
 
         // POST /preimage_received
-        this.app.post("/preimage_received",
-            IpFilter(this.white_ip_list, { mode: 'allow', log: false }), this.putPreImage.bind(this));
+        this.app.post("/preimage_received", this.putPreImage.bind(this));
     }
 
     /**

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,7 +19,6 @@ logger.info(`The file name of sqlite3 database: ${config.database.filename}`);
 const stoa: Stoa = new Stoa(config.database.filename,
     config.server.agora_endpoint,
     config.server.port,
-    config.server.address,
-    config.server.white_ip_list,
+    config.server.address
     );
 stoa.start();

--- a/src/modules/common/Config.ts
+++ b/src/modules/common/Config.ts
@@ -153,25 +153,18 @@ export class ServerConfig implements IServerConfig
     public agora_endpoint: URL;
 
     /**
-     * The white IP list for IP-filtering
-     */
-    public white_ip_list: Array<string>;
-
-    /**
      * Constructor
      * @param address The address to which we bind
      * @param port The port on which we bind
      * @param agora_endpoint The endpoint of Agora
-     * @param white_ip_list The white IP list for IP-filtering
      */
-    constructor (address?: string, port?: number, agora_endpoint?: string, white_ip_list?: Array<string>)
+    constructor (address?: string, port?: number, agora_endpoint?: string)
     {
         let conf = extend(true, {}, ServerConfig.defaultValue());
-        extend(true, conf, {address: address, port: port, agora_endpoint: agora_endpoint, white_ip_list: white_ip_list});
+        extend(true, conf, {address: address, port: port, agora_endpoint: agora_endpoint});
         this.address = conf.address;
         this.port = conf.port;
         this.agora_endpoint = conf.agora_endpoint;
-        this.white_ip_list = conf.white_ip_list;
     }
 
     /**
@@ -186,7 +179,6 @@ export class ServerConfig implements IServerConfig
         this.port = conf.port;
         this.agora_endpoint = conf.agora_endpoint;
         this.agora_endpoint = conf.agora_endpoint;
-        this.white_ip_list = conf.white_ip_list;
     }
 
     /**
@@ -197,8 +189,7 @@ export class ServerConfig implements IServerConfig
         return {
             address: "",
             port: 3836,
-            agora_endpoint: new URL("http://127.0.0.1:2826"),
-            white_ip_list: ["::ffff:127.0.0.1", "::ffff:172.17.0.0/16"]
+            agora_endpoint: new URL("http://127.0.0.1:2826")
         }
     }
 }
@@ -317,11 +308,6 @@ export interface IServerConfig
      * The endpoint of Agora
      */
     agora_endpoint: URL;
-
-    /**
-     * The white IP list for IP-filtering
-     */
-    white_ip_list: Array<string>;
 }
 
 /**

--- a/tests/Config.test.ts
+++ b/tests/Config.test.ts
@@ -25,9 +25,6 @@ describe('Test of Config', () => {
                 "   address: 127.0.0.1",
                 "   port:    3838",
                 "   agora_endpoint: http://127.0.0.1:2826",
-                "   white_ip_list:",
-                "       - ::ffff:127.0.0.1",
-                "       - ::ffff:172.17.0.0/16",
                 "database:",
                 "   filename: database",
                 "logging:",
@@ -39,7 +36,6 @@ describe('Test of Config', () => {
         assert.strictEqual(config.server.address, "127.0.0.1");
         assert.strictEqual(config.server.port.toString(), "3838");
         assert.strictEqual(config.server.agora_endpoint.toString(), "http://127.0.0.1:2826");
-        assert.deepStrictEqual(config.server.white_ip_list, ['::ffff:127.0.0.1', '::ffff:172.17.0.0/16']);
 
         assert.strictEqual(config.database.filename, path.resolve(appRootPath.toString(), "database"));
 
@@ -53,7 +49,6 @@ describe('Test of Config', () => {
         assert.strictEqual(config.server.address, "");
         assert.strictEqual(config.server.port.toString(), "3836");
         assert.strictEqual(config.server.agora_endpoint.toString(), "http://127.0.0.1:2826");
-        assert.deepStrictEqual(config.server.white_ip_list, ['::ffff:127.0.0.1', '::ffff:172.17.0.0/16']);
 
         assert.strictEqual(config.database.filename, path.resolve(appRootPath.toString(), "stoa/data/database"));
 

--- a/tests/config.example.yaml
+++ b/tests/config.example.yaml
@@ -11,11 +11,6 @@ server:
   # Endpoint of Agora
   agora_endpoint: http://127.0.0.1:2826
 
-  # White IP list for IP-filtering ('\block_externalized', '\preimage_received')
-  white_ip_list:
-    - ::ffff:127.0.0.1
-    - ::ffff:172.17.0.0/16
-
 ################################################################################
 ##                               Database options                             ##
 ################################################################################


### PR DESCRIPTION
I tested it on the docker environment, but I remove it because IP filtering is not easy to apply to various environments.

Fixes #120 