### PR TITLE
Change all paths from app-root to working directory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -294,11 +294,6 @@
         "picomatch": "^2.0.4"
       }
     },
-    "app-root-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-3.0.0.tgz",
-      "integrity": "sha512-qMcx+Gy2UZynHjOHOIXPNvpf+9cjvk3cWrBBK7zg4gH9+clobJRb9NGzcT7mQTcV/6Gm/1WelUtqxVXnNlrwcw=="
-    },
     "aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "@types/sodium-native": "^2.3.5",
     "@types/sqlite3": "^3.1.6",
     "ajv": "^6.12.3",
-    "app-root-path": "^3.0.0",
     "argparse": "^2.0.1",
     "assert": "^2.0.0",
     "axios": "^0.19.2",

--- a/src/modules/common/Config.ts
+++ b/src/modules/common/Config.ts
@@ -11,7 +11,8 @@
 
 *******************************************************************************/
 
-import appRootPath from 'app-root-path';
+import { Utils } from '../utils/Utils';
+
 import {ArgumentParser} from 'argparse';
 import extend from 'extend';
 import fs from "fs";
@@ -62,7 +63,7 @@ export class Config implements IConfig
      */
     public readFromFile (config_file: string)
     {
-        let config_content = fs.readFileSync(path.resolve(appRootPath.toString(), config_file), 'utf8');
+        let config_content = fs.readFileSync(path.resolve(Utils.getInitCWD(), config_file), 'utf8');
         this.readFromString(config_content);
     }
 
@@ -97,7 +98,7 @@ export class Config implements IConfig
                 this.server.address = this.args.address;
 
             if ((this.args.database !== undefined) && (this.args.database !== ""))
-                this.database.filename = path.resolve(appRootPath.toString(), this.args.database);
+                this.database.filename = path.resolve(Utils.getInitCWD(), this.args.database);
         }
     }
 
@@ -212,7 +213,7 @@ export class DatabaseConfig implements IDatabaseConfig
     {
         let conf = extend(true, {}, DatabaseConfig.defaultValue());
         extend(true, conf, {filename: filename});
-        this.filename = path.resolve(appRootPath.toString(), conf.filename);
+        this.filename = path.resolve(Utils.getInitCWD(), conf.filename);
     }
 
     /**
@@ -223,7 +224,7 @@ export class DatabaseConfig implements IDatabaseConfig
     {
         let conf = extend(true, {}, DatabaseConfig.defaultValue());
         extend(true, conf, config);
-        this.filename = path.resolve(appRootPath.toString(), conf.filename);
+        this.filename = path.resolve(Utils.getInitCWD(), conf.filename);
     }
 
     /**
@@ -232,7 +233,7 @@ export class DatabaseConfig implements IDatabaseConfig
     public static defaultValue (): IDatabaseConfig
     {
         return {
-            filename: path.resolve(appRootPath.toString(), "stoa/data/Stoa.db")
+            filename: path.resolve(Utils.getInitCWD(), "stoa/data/Stoa.db")
         }
     }
 }
@@ -261,7 +262,7 @@ export class LoggingConfig implements ILoggingConfig
     {
         let conf = extend(true, {}, LoggingConfig.defaultValue());
         extend(true, conf, {folder: folder, level: level});
-        this.folder = path.resolve(appRootPath.toString(), conf.folder);
+        this.folder = path.resolve(Utils.getInitCWD(), conf.folder);
         this.level = conf.level;
     }
 
@@ -273,7 +274,7 @@ export class LoggingConfig implements ILoggingConfig
     {
         let conf = extend(true, {}, LoggingConfig.defaultValue());
         extend(true, conf, config);
-        this.folder = path.resolve(appRootPath.toString(), conf.folder);
+        this.folder = path.resolve(Utils.getInitCWD(), conf.folder);
         this.level = conf.level;
     }
 
@@ -283,7 +284,7 @@ export class LoggingConfig implements ILoggingConfig
     public static defaultValue (): ILoggingConfig
     {
         return {
-            folder: path.resolve(appRootPath.toString(), "stoa/logs/"),
+            folder: path.resolve(Utils.getInitCWD(), "stoa/logs/"),
             level: "info"
         }
     }

--- a/src/modules/common/Logger.ts
+++ b/src/modules/common/Logger.ts
@@ -14,7 +14,8 @@
 
 *******************************************************************************/
 
-import appRoot from 'app-root-path';
+import { Utils } from '../utils/Utils';
+
 import path from 'path';
 import winston from 'winston';
 
@@ -26,7 +27,7 @@ const logFormat = printf(({ level, message, label, timestamp }) => {
 
 export class Logger
 {
-    public static folder: string = path.resolve(appRoot.toString(), 'stoa/logs/');
+    public static folder: string = path.resolve(Utils.getInitCWD(), 'stoa/logs/');
 
     public static setFolder(folder: string)
     {

--- a/src/modules/utils/Utils.ts
+++ b/src/modules/utils/Utils.ts
@@ -114,14 +114,13 @@ export class Utils
 
     /**
      *  Gets the path to where the execution command was entered for this process.
-     *  If this value is not set, returns the root path of the app.
+     * This value must be set, otherwise the application will terminate.
      */
     public static getInitCWD (): string
     {
-        //  A type of process.env.INIT_CWD is string | undefined.
-        //  In order to use this, it is always necessary to make sure
-        //  that it is `undefined`.
-        //  `string` can be return only when it is not `undefined`.
+        //  The type of `process.env.INIT_CWD` is `string | undefined`.
+        //  In order to simply return `string`, it is necessary to make sure
+        //  that it is not `undefined` first.
         if (process.env.INIT_CWD === undefined)
             assert.fail("INIT_CWD is not defined.");
         else

--- a/src/modules/utils/Utils.ts
+++ b/src/modules/utils/Utils.ts
@@ -11,6 +11,7 @@
 
 *******************************************************************************/
 
+import * as assert from 'assert';
 import { UInt64 } from 'spu-integer-math';
 
 export class Utils
@@ -109,5 +110,21 @@ export class Utils
         }
 
         return res;
+    }
+
+    /**
+     *  Gets the path to where the execution command was entered for this process.
+     *  If this value is not set, returns the root path of the app.
+     */
+    public static getInitCWD (): string
+    {
+        //  A type of process.env.INIT_CWD is string | undefined.
+        //  In order to use this, it is always necessary to make sure
+        //  that it is `undefined`.
+        //  `string` can be return only when it is not `undefined`.
+        if (process.env.INIT_CWD === undefined)
+            assert.fail("INIT_CWD is not defined.");
+        else
+            return process.env.INIT_CWD;
     }
 }

--- a/tests/Config.test.ts
+++ b/tests/Config.test.ts
@@ -12,8 +12,8 @@
  *******************************************************************************/
 
 import { Config } from '../src/modules/common/Config';
+import { Utils } from '../src/modules/utils/Utils';
 
-import appRootPath from 'app-root-path';
 import * as assert from 'assert';
 import path from "path";
 
@@ -37,7 +37,7 @@ describe('Test of Config', () => {
         assert.strictEqual(config.server.port.toString(), "3838");
         assert.strictEqual(config.server.agora_endpoint.toString(), "http://127.0.0.1:2826");
 
-        assert.strictEqual(config.database.filename, path.resolve(appRootPath.toString(), "database"));
+        assert.strictEqual(config.database.filename, path.resolve(Utils.getInitCWD(), "database"));
 
         assert.strictEqual(config.logging.folder, "/stoa/logs");
         assert.strictEqual(config.logging.level, "debug");
@@ -45,14 +45,14 @@ describe('Test of Config', () => {
 
     it ('Test parsing the settings of a file', () => {
         let config: Config = new Config(null);
-        config.readFromFile(path.resolve(appRootPath.toString(), "tests/config.example.yaml"));
+        config.readFromFile(path.resolve(Utils.getInitCWD(), "tests/config.example.yaml"));
         assert.strictEqual(config.server.address, "");
         assert.strictEqual(config.server.port.toString(), "3836");
         assert.strictEqual(config.server.agora_endpoint.toString(), "http://127.0.0.1:2826");
 
-        assert.strictEqual(config.database.filename, path.resolve(appRootPath.toString(), "stoa/data/database"));
+        assert.strictEqual(config.database.filename, path.resolve(Utils.getInitCWD(), "stoa/data/database"));
 
-        assert.strictEqual(config.logging.folder, path.resolve(appRootPath.toString(), "stoa/logs/"));
+        assert.strictEqual(config.logging.folder, path.resolve(Utils.getInitCWD(), "stoa/logs/"));
         assert.strictEqual(config.logging.level, "info");
     });
 
@@ -64,10 +64,10 @@ describe('Test of Config', () => {
             database: "argument-db"
         };
         let config: Config = new Config(argument);
-        config.readFromFile(path.resolve(appRootPath.toString(), "tests/config.example.yaml"));
+        config.readFromFile(path.resolve(Utils.getInitCWD(), "tests/config.example.yaml"));
         assert.strictEqual(config.server.address, "127.0.0.1");
         assert.strictEqual(config.server.port.toString(), "5000");
         assert.strictEqual(config.server.agora_endpoint.toString(), "http://127.0.0.1:4000/");
-        assert.strictEqual(config.database.filename, path.resolve(appRootPath.toString(), "argument-db"));
+        assert.strictEqual(config.database.filename, path.resolve(Utils.getInitCWD(), "argument-db"));
     });
 });


### PR DESCRIPTION
I use `process.env.INIT_CWD`, If this value is undefined, use the root path of the app.

Relates to #121 