### PR TITLE
Log errors to the console in test mode

### DIFF
--- a/src/modules/common/Logger.ts
+++ b/src/modules/common/Logger.ts
@@ -87,7 +87,8 @@ export class Logger
         switch (process.env.NODE_ENV) {
             case "test":
                 return winston.createLogger({
-                    silent: true,
+                    level: "error",
+                    transports: [ Logger.defaultConsoleTransport() ],
                 });
             case "development":
                 return winston.createLogger({


### PR DESCRIPTION
This allows the user to have an idea of what's going on when a test fails.