### PR TITLE
Make 'WebService.start' Promise asynchronous

### DIFF
--- a/src/Stoa.ts
+++ b/src/Stoa.ts
@@ -85,10 +85,8 @@ class Stoa extends WebService
 
     /**
      * Setup and start the server
-     *
-     * @param callback An optional callback to register as listener
      */
-    public start (callback?: Function)
+    public async start (): Promise<void>
     {
         // Prepare middleware
 
@@ -106,7 +104,7 @@ class Stoa extends WebService
         this.app.post("/preimage_received", this.putPreImage.bind(this));
 
         // Start the server
-        super.start(callback);
+        return super.start();
     }
 
     /**

--- a/src/main.ts
+++ b/src/main.ts
@@ -34,4 +34,20 @@ const stoa: Stoa = new Stoa(config.database.filename,
     config.server.port,
     config.server.address
     );
-stoa.start();
+
+stoa.start().then(() => {
+    logger.info(`Listening to requests on: ${config.server.address}:${config.server.port}`);
+}).catch((error) => {
+    // handle specific listen errors with friendly messages
+    switch (error.code) {
+        case 'EACCES':
+            logger.error(`${config.server.port} requires elevated privileges`);
+            break;
+        case 'EADDRINUSE':
+            logger.error(`Port ${config.server.port} is already in use`);
+            break;
+        default:
+            logger.error(`An error occured while starting the server: ${error.stack}`);
+    }
+    process.exit(1);
+});

--- a/src/modules/service/WebService.ts
+++ b/src/modules/service/WebService.ts
@@ -58,40 +58,20 @@ export class WebService
     }
 
     /**
-     * Start web server
-     *
-     * @param callback An optional callback to register as listener
+     * Asynchronously start the web server
      */
-    public start (callback?: Function)
+    public async start (): Promise<void>
     {
         this.app.set('port', this.port);
 
-        // Create HTTP server.
-        this.server = http.createServer(this.app);
-
-        this.server.on('error', (error: any) =>
-        {
-            // handle specific listen errors with friendly messages
-            switch (error.code) {
-                case 'EACCES':
-                    logger.error(`${this.port} requires elevated privileges`);
-                    process.exit(1);
-                    break;
-                case 'EADDRINUSE':
-                    logger.error(`${this.port} is already in use`);
-                    process.exit(1);
-                    break;
-                default:
-                    logger.error(error);
-            }
-        });
-
         // Listen on provided this.port on this.address.
-        this.server.listen(this.port, this.address, () =>
-        {
-            logger.info(`Listening to requests on: ${this.address}:${this.port}`);
-            if (callback !== undefined)
-                callback();
+        return new Promise<void>((resolve, reject) => {
+            // Create HTTP server.
+            this.server = http.createServer(this.app);
+            this.server.on('error', reject);
+            this.server.listen(this.port, this.address, () => {
+                resolve();
+            });
         });
     }
 }

--- a/tests/Recovery.test.ts
+++ b/tests/Recovery.test.ts
@@ -174,10 +174,10 @@ describe ('Test of Recovery', () =>
         agora_node.stop(doneIt);
     });
 
-    beforeEach ('Start TestStoa', (doneIt: () => void) =>
+    beforeEach ('Start TestStoa', () =>
     {
         stoa_server = new TestStoa(":memory:", agora_endpoint, stoa_port);
-        stoa_server.start(doneIt);
+        return stoa_server.start();
     });
 
     afterEach ('Stop TestStoa', (doneIt: () => void) =>

--- a/tests/Stoa.test.ts
+++ b/tests/Stoa.test.ts
@@ -48,10 +48,10 @@ describe ('Test of Stoa API Server', () =>
     let stoa_server : TestStoa;
     let client = axios.create();
 
-    before ('Start Stoa API Server', (doneIt: () => void) =>
+    before ('Start Stoa API Server', () =>
     {
         stoa_server = new TestStoa(":memory:", new URL("http://127.0.0.1:2826"), port);
-        stoa_server.start(doneIt);
+        return stoa_server.start();
     });
 
     after ('Stop Stoa API Server', (doneIt: () => void) =>


### PR DESCRIPTION
This allows us to integrate it better with Mocha and to delay
the error messages to the main in dev / prod,
and to let Mocha handle it (without exiting the process) in tests.