### PR TITLE
Dockerfile: Depends on Node 14.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # From Agora Runner
-FROM alpine:3.12
-RUN apk add --no-cache curl git python3 py-pip alpine-sdk \
-    bash autoconf libtool automake nodejs npm
+FROM node:14-alpine3.12
+RUN apk add --no-cache git py-pip alpine-sdk \
+    bash autoconf libtool automake
 
 WORKDIR /stoa/wd/
 


### PR DESCRIPTION
Use the proper node image, as the default Alpine one has Node 12.x.

The current image in the docker repository is broken because of this.