### PR TITLE
Change the parameter of `LedgerStorage.putBlocks` to an instance of the `Block`

### DIFF
--- a/src/Stoa.ts
+++ b/src/Stoa.ts
@@ -3,7 +3,7 @@ import { cors_options } from './cors';
 import { Endian } from './modules/utils/buffer';
 import { LedgerStorage } from './modules/storage/LedgerStorage';
 import { logger } from './modules/common/Logger';
-import { Height, PreImageInfo, Hash, hash } from './modules/data';
+import {Height, PreImageInfo, Hash, hash, Block } from './modules/data';
 import { Utils } from './modules/utils/Utils';
 import { ValidatorData, IPreimage } from './modules/data/ValidatorData';
 import { WebService } from './modules/service/WebService';
@@ -383,7 +383,7 @@ class Stoa extends WebService
                             let element_height = Stoa.getBlockHeight(elem);
                             if (UInt64.compare(element_height.value, expected_height.value) == 0)
                             {
-                                await this.ledger_storage.putBlocks(elem);
+                                await this.ledger_storage.putBlocks(Block.fromJSON(elem));
                                 expected_height.value = UInt64.add(expected_height.value, 1);
                                 logger.info(`Recovered a block with block height of ${element_height.toString()}`);
                             }
@@ -398,7 +398,7 @@ class Stoa extends WebService
                     // Save a block just received
                     if (UInt64.compare(height.value, expected_height.value) <= 0)
                     {
-                        await this.ledger_storage.putBlocks(block);
+                        await this.ledger_storage.putBlocks(Block.fromJSON(block));
                         logger.info(`Saved a block with block height of ${height.toString()}`);
                         resolve(true);
                     }
@@ -450,7 +450,7 @@ class Stoa extends WebService
                     {
                         // The normal case
                         // Save a block just received
-                        await this.ledger_storage.putBlocks(block);
+                        await this.ledger_storage.putBlocks(Block.fromJSON(block));
                         logger.info(`Saved a block with block height of ${height.toString()}`);
                     }
                     else if (UInt64.compare(height.value, expected_height.value) > 0)

--- a/src/modules/data/Block.ts
+++ b/src/modules/data/Block.ts
@@ -81,4 +81,14 @@ export class Block
 
         return this;
     }
+
+    /**
+     * This create new instance of Block and parses JSON.
+     * @param json - The JSON data
+     * @returns The new instance of Block
+     */
+    public static fromJSON (json: any): Block
+    {
+        return (new Block()).parseJSON(json)
+    }
 }

--- a/src/modules/storage/LedgerStorage.ts
+++ b/src/modules/storage/LedgerStorage.ts
@@ -139,12 +139,12 @@ export class LedgerStorage extends Storages
 
     /**
      * Puts a block to database
-     * @param data a block data
+     * @param block a block data
      * @returns Returns the Promise. If it is finished successfully the `.then`
      * of the returned Promise is called and if an error occurs the `.catch`
      * is called with an error.
      */
-    public putBlocks (data: any): Promise<void>
+    public putBlocks (block: Block): Promise<void>
     {
         function saveBlock (storage: LedgerStorage, block: Block): Promise<void>
         {
@@ -183,8 +183,6 @@ export class LedgerStorage extends Storages
             (async () => {
                 try
                 {
-                    let block: Block = new Block();
-                    block.parseJSON(data);
                     await this.begin();
                     await saveBlock(this, block);
                     await this.putTransactions(block);


### PR DESCRIPTION
The method LedgerStorage.putBlocks has one parameter. This has data from the block.
Previously this was the JSON Object. I changed this to an instance of Block.
In order to deliver the correct type and create a more stable Stoa, I revised it like this.