### PR TITLE
Replace all usages of UInt64 with BigInt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2835,11 +2835,6 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
-    "spu-integer-math": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/spu-integer-math/-/spu-integer-math-0.0.3.tgz",
-      "integrity": "sha512-4GRbZFcCIl8QIYIAvBgrQHhWm6wlJIOfayZoSs4ON63pfuDKSGjtCl9w72lJ4yqMF8seXAjFW2RPryPHTufAFA=="
-    },
     "sqlite3": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-5.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "smart-buffer": "^4.1.0",
     "sodium-native": "^3.2.0",
     "source-map-support": "^0.5.19",
-    "spu-integer-math": "0.0.3",
     "sqlite3": "^5.0.0",
     "urijs": "^1.19.2",
     "winston": "^3.3.3"

--- a/src/Stoa.ts
+++ b/src/Stoa.ts
@@ -181,7 +181,7 @@ class Stoa extends WebService
                                               preimage);
                         out_put.push(validator);
                     }
-                    res.status(200).send(Utils.toJson(out_put));
+                    res.status(200).send(JSON.stringify(out_put));
                 }
                 else
                 {
@@ -267,7 +267,7 @@ class Stoa extends WebService
                                               preimage);
                         out_put.push(validator);
                     }
-                    res.status(200).send(Utils.toJson(out_put));
+                    res.status(200).send(JSON.stringify(out_put));
                 }
                 else
                 {

--- a/src/modules/data/Height.ts
+++ b/src/modules/data/Height.ts
@@ -14,7 +14,6 @@
 import { Utils } from '../utils/Utils';
 
 import { SmartBuffer } from 'smart-buffer';
-import { UInt64 } from 'spu-integer-math';
 
 /**
  * The class that defines the Height.
@@ -24,18 +23,15 @@ export class Height
     /**
      * the block height
      */
-    public value: UInt64;
+    public value: bigint;
 
     /**
      * Construct
      * @param value - The block height
      */
-    constructor (value: bigint | string | UInt64)
+    constructor (value: bigint | string)
     {
-        if (value instanceof UInt64)
-            this.value = new UInt64(value);
-        else
-            this.value = UInt64.fromString(value.toString());
+        this.value = BigInt(value);
     }
 
     /**
@@ -44,8 +40,9 @@ export class Height
      */
     public computeHash (buffer: SmartBuffer)
     {
-        buffer.writeInt32LE(this.value.lo);
-        buffer.writeInt32LE(this.value.hi);
+        let buf = Buffer.allocUnsafe(8);
+        buf.writeBigUInt64LE(this.value);
+        buffer.writeBuffer(buf);
     }
 
     /**
@@ -54,7 +51,7 @@ export class Height
      */
     public fromString (value: string)
     {
-        this.value = UInt64.fromString(value);
+        this.value = BigInt(value);
     }
 
     /**
@@ -62,7 +59,7 @@ export class Height
      */
     public toString ()
     {
-        return Utils.UInt64ToString(this.value);
+        return this.value.toString();
     }
 
     /**

--- a/src/modules/data/TxOutputs.ts
+++ b/src/modules/data/TxOutputs.ts
@@ -16,7 +16,6 @@ import { Utils } from '../utils/Utils';
 import { Validator, ITxOutputs } from './validator';
 
 import { SmartBuffer } from 'smart-buffer';
-import { UInt64 } from 'spu-integer-math';
 
 /**
  * The class that defines the transaction's outputs of a block.
@@ -28,7 +27,7 @@ export class TxOutputs
     /**
      * The monetary value of this output, in 1/10^7
      */
-    public value: UInt64;
+    public value: bigint;
 
     /**
      * The public key that can spend this output
@@ -40,12 +39,12 @@ export class TxOutputs
      * @param value - The monetary value
      * @param address - The public key
      */
-    constructor (value?: UInt64, address?: PublicKey)
+    constructor (value?: bigint, address?: PublicKey)
     {
         if (value !== undefined)
-            this.value = new UInt64(value);
+            this.value = value;
         else
-            this.value = new UInt64(0);
+            this.value = 0n;
 
         if (address !== undefined)
             this.address = address;
@@ -63,7 +62,7 @@ export class TxOutputs
         Validator.isValidOtherwiseThrow<ITxOutputs>('TxOutputs', json);
 
         if (Utils.isPositiveInteger(json.value))
-            this.value = UInt64.fromString(json.value);
+            this.value = BigInt(json.value);
         else
             throw new Error ("Amount is not a positive number.");
 
@@ -78,8 +77,9 @@ export class TxOutputs
      */
     public computeHash (buffer: SmartBuffer)
     {
-        buffer.writeInt32LE(this.value.lo);
-        buffer.writeInt32LE(this.value.hi);
+        const buf = Buffer.allocUnsafe(8);
+        buf.writeBigUInt64LE(this.value);
+        buffer.writeBuffer(buf);
         this.address.computeHash(buffer);
     }
 }

--- a/src/modules/storage/LedgerStorage.ts
+++ b/src/modules/storage/LedgerStorage.ts
@@ -495,7 +495,7 @@ export class LedgerStorage extends Storages
                         hash.toBinary(Endian.Little),
                         utxo_key.toBinary(Endian.Little),
                         output.address.toString(),
-                        Utils.UInt64ToString(output.value)
+                        output.value.toString(),
                     ]
                 )
                     .then(() =>

--- a/src/modules/utils/Utils.ts
+++ b/src/modules/utils/Utils.ts
@@ -12,7 +12,6 @@
 *******************************************************************************/
 
 import * as assert from 'assert';
-import { UInt64 } from 'spu-integer-math';
 
 export class Utils
 {
@@ -44,32 +43,6 @@ export class Utils
     }
 
     /**
-     * Converts the UInt64 to the string
-     * @param value The number of UInt64
-     * @param radix An integer in the range 2 through 36 specifying
-     * the base to use for representing numeric values.
-     */
-    public static UInt64ToString(value: UInt64, radix?: number): string
-    {
-        const BIT32 = 4294967296;
-
-        let high = value.hi;
-        let low = value.lo;
-        let str = "";
-
-        radix = radix || 10;
-        while (true)
-        {
-            let mod = (high % radix) * BIT32 + low;
-            high = Math.floor(high / radix);
-            low = Math.floor(mod / radix);
-            str = (mod % radix).toString(radix) + str;
-            if (!high && !low) break;
-        }
-        return str;
-    }
-
-    /**
      * It is a function that outputs an object with BigInt as JSON.
      * @param data - Object to be converted to a JSON string
      * @returns - If the data type is UInt64 then it converts
@@ -86,11 +59,6 @@ export class Utils
         // it converts it into a string and adds '#uint64' after that.
         const json = JSON.stringify(data, (_, value) =>
         {
-            if (value instanceof UInt64)
-            {
-                uint64_to_string++;
-                return `${Utils.UInt64ToString(value)}#uint64`;
-            }
             return value;
         });
 

--- a/src/modules/utils/Utils.ts
+++ b/src/modules/utils/Utils.ts
@@ -43,44 +43,6 @@ export class Utils
     }
 
     /**
-     * It is a function that outputs an object with BigInt as JSON.
-     * @param data - Object to be converted to a JSON string
-     * @returns - If the data type is UInt64 then it converts
-     * it to a string and returns a JSON string with " removed.
-     */
-    public static toJson(data: object): string
-    {
-        if (data === undefined)
-            return "";
-
-        let uint64_to_string = 0;
-
-        // If the data type is UInt64,
-        // it converts it into a string and adds '#uint64' after that.
-        const json = JSON.stringify(data, (_, value) =>
-        {
-            return value;
-        });
-
-
-        let remove_quotation = 0;
-
-        // Remove " and #uint64 from the pattern "NUBER#uint64" in JSON.
-        const res = json.replace(/"(-?\d+)#uint64"/g, (_, value) =>
-        {
-            remove_quotation++;
-            return value;
-        });
-
-        if (remove_quotation > uint64_to_string)
-        {
-            throw new Error(`UInt64 serialization pattern conflict with a string value.`);
-        }
-
-        return res;
-    }
-
-    /**
      *  Gets the path to where the execution command was entered for this process.
      * This value must be set, otherwise the application will terminate.
      */

--- a/tests/Recovery.test.ts
+++ b/tests/Recovery.test.ts
@@ -22,7 +22,6 @@ import { Utils } from '../src/modules/utils/Utils';
 import * as assert from 'assert';
 import axios from 'axios';
 import express from 'express';
-import { UInt64 } from 'spu-integer-math';
 import URI from 'urijs';
 import { URL } from 'url';
 
@@ -118,14 +117,14 @@ describe ('Test of Recovery', () =>
                 {
                     // The number of blocks is three.
                     assert.strictEqual(response.length, 3);
-                    let expected_height = UInt64.fromNumber(1);
+                    let expected_height : Height = new Height(1n);
                     for (let elem of response)
                     {
                         let block = new Block();
                         block.parseJSON(elem);
                         // Make sure that the received block height is equal to the expected value.
-                        assert.ok(UInt64.compare(block.header.height.value, expected_height) == 0);
-                        expected_height = UInt64.add(expected_height, 1);
+                        assert.deepEqual(block.header.height, expected_height);
+                        expected_height.value += 1n;
                     }
                 })
                 .catch((error) =>
@@ -145,14 +144,14 @@ describe ('Test of Recovery', () =>
             // The number of blocks is two.
             // Because the total number is 10. The last block height is 9.
             assert.strictEqual(response.length, 2);
-            let expected_height = UInt64.fromNumber(8);
+            let expected_height : Height = new Height(8n);
             for (let elem of response)
             {
                 let block = new Block();
                 block.parseJSON(elem);
                 // Make sure that the received block height is equal to the expected value.
-                assert.ok(UInt64.compare(block.header.height.value, expected_height) == 0);
-                expected_height = UInt64.add(expected_height, 1);
+                assert.deepEqual(block.header.height, expected_height);
+                expected_height.value += 1n;
             }
             doneIt();
         });


### PR DESCRIPTION
We can greatly simplify the code by using the builtin Javascript type (at the expense of dropping compatibility with older Node.js versions).