### PR TITLE
Remove custom 'reverse' function

### DIFF
--- a/src/modules/data/Hash.ts
+++ b/src/modules/data/Hash.ts
@@ -11,7 +11,7 @@
 
 *******************************************************************************/
 
-import { readFromString, writeToString, Endian, reverse } from '../utils/buffer';
+import { readFromString, writeToString, Endian } from '../utils/buffer';
 
 import * as assert from 'assert';
 import { SmartBuffer } from 'smart-buffer';
@@ -94,10 +94,9 @@ export class Hash
         if (endian === undefined)
             endian = Endian.Big;
 
+        bin.copy(this.data);
         if (endian === Endian.Little)
-            reverse(bin, this.data);
-        else
-            bin.copy(this.data);
+            this.data.reverse();
 
         return this;
     }
@@ -113,7 +112,7 @@ export class Hash
             endian = Endian.Big;
 
         if (endian === Endian.Little)
-            return reverse(this.data);
+            return Buffer.from(this.data).reverse();
         else
             return this.data;
     }

--- a/src/modules/data/Signature.ts
+++ b/src/modules/data/Signature.ts
@@ -11,7 +11,7 @@
 
 *******************************************************************************/
 
-import { readFromString, writeToString, Endian, reverse } from '../utils/buffer';
+import { readFromString, writeToString, Endian } from '../utils/buffer';
 
 import * as assert from 'assert';
 
@@ -83,10 +83,9 @@ export class Signature
         if (endian === undefined)
             endian = Endian.Big;
 
+        bin.copy(this.data);
         if (endian === Endian.Little)
-            reverse(bin, this.data);
-        else
-            bin.copy(this.data);
+            this.data.reverse();
 
         return this;
     }
@@ -102,7 +101,7 @@ export class Signature
             endian = Endian.Big;
 
         if (endian === Endian.Little)
-            return reverse(this.data);
+            return Buffer.from(this.data).reverse();
         else
             return this.data;
     }

--- a/src/modules/utils/buffer.ts
+++ b/src/modules/utils/buffer.ts
@@ -76,27 +76,3 @@ export function writeToString (source: Buffer, endian?: Endian): string
     else
         return '0x' + source.toString("hex");
 }
-
-/**
- * Reverse the Buffer
- * @param source The source buffer
- * @param target The target buffer
- */
-export function reverse (source: Buffer, target?: Buffer): Buffer
-{
-    if (target == undefined)
-        target = Buffer.alloc(source.length);
-    else
-        assert.strictEqual(source.length, target.length);
-
-    let start = 0;
-    let end = source.length - 1;
-    while (start < end)
-    {
-        target[start] = source[end];
-        target[end] = source[start];
-        start++;
-        end--;
-    }
-    return target;
-}


### PR DESCRIPTION
Since we're already working with Node.js' Buffer class,
which is itself a subclass of Javascript's UInt8Array,
we can just use the in-place reverse that comes as
part of the superclass prototype.