### PR TITLE
Improve json parsing of PreImageInfo

### DIFF
--- a/src/Stoa.ts
+++ b/src/Stoa.ts
@@ -177,7 +177,7 @@ class Stoa extends WebService
 
                         let validator: ValidatorData =
                             new ValidatorData(row.address, new Height(BigInt(row.enrolled_at)),
-                                              Hash.createFromBinary(row.stake, Endian.Little).toString(),
+                                              new Hash(row.stake, Endian.Little).toString(),
                                               preimage);
                         out_put.push(validator);
                     }
@@ -263,7 +263,7 @@ class Stoa extends WebService
 
                         let validator: ValidatorData =
                             new ValidatorData(row.address, new Height(BigInt(row.enrolled_at)),
-                                              Hash.createFromBinary(row.stake, Endian.Little).toString(),
+                                              new Hash(row.stake, Endian.Little).toString(),
                                               preimage);
                         out_put.push(validator);
                     }

--- a/src/Stoa.ts
+++ b/src/Stoa.ts
@@ -474,11 +474,9 @@ class Stoa extends WebService
             }
             else if (stored_data.type === "pre_image")
             {
-                let pre_image: PreImageInfo = new PreImageInfo();
-
                 try
                 {
-                    pre_image.parseJSON(stored_data.data);
+                    let pre_image = PreImageInfo.reviver("", stored_data.data);
 
                     await this.ledger_storage.updatePreImage(pre_image);
                     logger.info(`Saved a pre-image enroll_key : ${pre_image.enroll_key.toString().substr(0, 18)}, ` +

--- a/src/modules/data/Hash.ts
+++ b/src/modules/data/Hash.ts
@@ -117,17 +117,6 @@ export class Hash
     }
 
     /**
-     * Creates from Buffer
-     * @param bin The binary data of the hash
-     * @param endian The byte order
-     * @returns The instance of Hash
-     */
-    public static createFromBinary (bin: Buffer, endian?: Endian): Hash
-    {
-        return new Hash(bin, endian);
-    }
-
-    /**
      * Collects data to create a hash.
      * @param buffer - The buffer where collected data is stored
      */

--- a/src/modules/data/PreImageInfo.ts
+++ b/src/modules/data/PreImageInfo.ts
@@ -44,18 +44,23 @@ export class PreImageInfo
     }
 
     /**
-     * This parses JSON.
-     * @param json The object of the JSON
-     * @returns The instance of PreImageInfo
+     * The reviver parameter to give to `JSON.parse`
+     *
+     * This function allows to perform any necessary conversion,
+     * as well as validation of the final object.
+     *
+     * @param key   Name of the field being parsed
+     * @param value The value associated with `key`
+     * @returns A new instance of `PreImageInfo` if `key == ""`, `value` otherwise.
      */
-    public parseJSON (json: any): PreImageInfo
+    public static reviver (key: string, value: any): any
     {
-        Validator.isValidOtherwiseThrow<IPreImageInfo>('PreImageInfo', json);
+        if (key !== "")
+            return value;
 
-        this.enroll_key.fromString(json.enroll_key);
-        this.hash.fromString(json.hash);
-        this.distance = Number(json.distance);
+        Validator.isValidOtherwiseThrow<IPreImageInfo>('PreImageInfo', value);
 
-        return this;
+        return new PreImageInfo(
+            new Hash(value.enroll_key), new Hash(value.hash), Number(value.distance));
     }
 }

--- a/src/modules/data/PreImageInfo.ts
+++ b/src/modules/data/PreImageInfo.ts
@@ -21,26 +21,33 @@ import { Validator, IPreImageInfo } from './validator'
  */
 export class PreImageInfo
 {
+    /**
+     * UTXO used to enroll
+     */
     public enroll_key: Hash;
+
+    /**
+     * Value of the pre-image
+     */
     public hash: Hash;
-    public distance: number = 0;
 
-    constructor (enroll_key?: Hash, hash?: Hash, distance?: number)
+    /**
+     * Distance from the enrollment, 0 based
+     */
+    public distance: number;
+
+    /**
+     * Construct a new instance of this object
+     *
+     * @param enroll_key The UTXO used to enroll
+     * @param hash       The value of the pre-image
+     * @param distance   The distance from the Enrollment
+     */
+    constructor (enroll_key: Hash, hash: Hash, distance: number)
     {
-        if (enroll_key !== undefined)
-            this.enroll_key = enroll_key;
-        else
-            this.enroll_key = new Hash();
-
-        if (hash !== undefined)
-            this.hash = hash;
-        else
-            this.hash = new Hash();
-
-        if (distance !== undefined)
-            this.distance = distance;
-        else
-            this.distance = 0;
+        this.enroll_key = enroll_key;
+        this.hash = hash;
+        this.distance = distance;
     }
 
     /**

--- a/src/modules/data/Signature.ts
+++ b/src/modules/data/Signature.ts
@@ -104,15 +104,4 @@ export class Signature
         else
             return this.data;
     }
-
-    /**
-     * Creates from Buffer
-     * @param bin The binary data of the signature
-     * @param endian The byte order
-     * @returns The instance of Signature
-     */
-    public static createFromBinary (bin: Buffer, endian?: Endian): Signature
-    {
-        return new Signature(bin, endian);
-    }
 }

--- a/tests/Storage.test.ts
+++ b/tests/Storage.test.ts
@@ -58,7 +58,7 @@ describe ('Test ledger storage and inquiry function.', () =>
                 {
                     assert.strictEqual(rows.length, 1);
                     assert.strictEqual(rows[0].height, height_value);
-                    assert.strictEqual(Hash.createFromBinary(rows[0].merkle_root, Endian.Little).toString(),
+                    assert.strictEqual(new Hash(rows[0].merkle_root, Endian.Little).toString(),
                         '0x9c4a20550ac796274f64e93872466ebb551ba2cd3f2f051533d07a478d2402b' +
                         '59e5b0f0a2a14e818b88007ec61d4a82dc9128851f43799d6c1dc0609fca1537d');
                 })
@@ -71,7 +71,7 @@ describe ('Test ledger storage and inquiry function.', () =>
             .then((rows3: any[]) =>
             {
                 assert.strictEqual(rows3.length, 4);
-                assert.strictEqual(Hash.createFromBinary(rows3[0].tx_hash, Endian.Little).toString(),
+                assert.strictEqual(new Hash(rows3[0].tx_hash, Endian.Little).toString(),
                     '0x3a245017fee266f2aeacaa0ca11171b5825d34814bf1e33fae76cca50751e5c' +
                     'fb010896f009971a8748a1d3720e33404f5a999ae224b54f5d5c1ffa345c046f7');
 
@@ -79,7 +79,7 @@ describe ('Test ledger storage and inquiry function.', () =>
                     .then((rows4: any[]) =>
                     {
                         assert.strictEqual(rows4.length, 1);
-                        assert.strictEqual(Hash.createFromBinary(rows4[0].previous, Endian.Little).toString(),
+                        assert.strictEqual(new Hash(rows4[0].previous, Endian.Little).toString(),
                             '0x5d7f6a7a30f7ff591c8649f61eb8a35d034824ed5cd252c2c6f10cdbd223671' +
                             '3dc369ef2a44b62ba113814a9d819a276ff61582874c9aee9c98efa2aa1f10d73');
 
@@ -87,10 +87,10 @@ describe ('Test ledger storage and inquiry function.', () =>
                             .then((rows5: any[]) =>
                             {
                                 assert.strictEqual(rows5.length, 8);
-                                assert.strictEqual(Hash.createFromBinary(rows5[0].utxo_key, Endian.Little).toString(),
+                                assert.strictEqual(new Hash(rows5[0].utxo_key, Endian.Little).toString(),
                                     '0xef81352c7436a19d376acf1eb8f832a28c6229885aaa4e3bd8c11d5d072e160' +
                                     '798a4ff3a7565b66ca2d0ff755f8cc0f1f97e049ca23b615c85f77fb97d7919b4');
-                                assert.strictEqual(Hash.createFromBinary(rows5[0].tx_hash, Endian.Little).toString(),
+                                assert.strictEqual(new Hash(rows5[0].tx_hash, Endian.Little).toString(),
                                     '0x5d7f6a7a30f7ff591c8649f61eb8a35d034824ed5cd252c2c6f10cdbd223671' +
                                     '3dc369ef2a44b62ba113814a9d819a276ff61582874c9aee9c98efa2aa1f10d73');
                                 assert.strictEqual(rows5[0].address, 'GCOQEOHAUFYUAC6G22FJ3GZRNLGVCCLESEJ2AXBIJ5BJNUVTAERPLRIJ');
@@ -125,7 +125,7 @@ describe ('Test ledger storage and inquiry function.', () =>
             {
                 assert.strictEqual(rows.length, 3);
                 assert.strictEqual(rows[0].block_height, height_value);
-                assert.strictEqual(Hash.createFromBinary(rows[0].utxo_key, Endian.Little).toString(),
+                assert.strictEqual(new Hash(rows[0].utxo_key, Endian.Little).toString(),
                     '0x210b66053c73e7bd7b27673706f0272617d09b8cda76605e91ab66ad1cc3b' +
                     'fc1f3f5fede91fd74bb2d2073de587c6ee495cfb0d981f03a83651b48ce0e576a1a');
 
@@ -134,7 +134,7 @@ describe ('Test ledger storage and inquiry function.', () =>
                     {
                         assert.strictEqual(rows.length, 3);
                         assert.strictEqual(rows[0].enrolled_at, height_value);
-                        assert.strictEqual(Hash.createFromBinary(rows[0].utxo_key, Endian.Little).toString(),
+                        assert.strictEqual(new Hash(rows[0].utxo_key, Endian.Little).toString(),
                             '0x210b66053c73e7bd7b27673706f0272617d09b8cda76605e91ab66ad1cc3b' +
                             'fc1f3f5fede91fd74bb2d2073de587c6ee495cfb0d981f03a83651b48ce0e576a1a');
                         assert.strictEqual(rows[0].address,
@@ -169,7 +169,7 @@ describe ('Test ledger storage and inquiry function.', () =>
                     {
                         assert.strictEqual(rows.length, 1);
                         assert.strictEqual(rows[0].address, address);
-                        assert.strictEqual(Hash.createFromBinary(rows[0].stake, Endian.Little).toString(),
+                        assert.strictEqual(new Hash(rows[0].stake, Endian.Little).toString(),
                             '0x210b66053c73e7bd7b27673706f0272617d09b8cda76605e91ab66ad1cc3bfc1f3f' +
                             '5fede91fd74bb2d2073de587c6ee495cfb0d981f03a83651b48ce0e576a1a');
 
@@ -288,7 +288,7 @@ describe ('Test for storing block data in the database', () =>
             // Check that the `prev_block` of block1 is the same as the hash value of the database.
             const block1 = Block.fromJSON(sample_data1);
 
-            assert.deepStrictEqual(block1.header.prev_block, Hash.createFromBinary(rows[0].hash, Endian.Little));
+            assert.deepStrictEqual(block1.header.prev_block, new Hash(rows[0].hash, Endian.Little));
         }
     });
 });
@@ -332,7 +332,7 @@ describe ('Tests that sending a pre-image', () =>
                     .then((rows: any[]) =>
                     {
                         assert.strictEqual(rows[0].preimage_distance, sample_preImageInfo.distance);
-                        assert.strictEqual(Hash.createFromBinary(rows[0].preimage_hash, Endian.Little).toString(), sample_preImageInfo.hash);
+                        assert.strictEqual(new Hash(rows[0].preimage_hash, Endian.Little).toString(), sample_preImageInfo.hash);
                         doneIt();
                     })
                     .catch((err) =>
@@ -360,7 +360,7 @@ describe ('Tests that sending a pre-image', () =>
                     .then((rows: any[]) =>
                     {
                         assert.strictEqual(rows[0].preimage_distance, 6);
-                        assert.strictEqual(Hash.createFromBinary(rows[0].preimage_hash, Endian.Little).toString(), sample_preImageInfo.hash);
+                        assert.strictEqual(new Hash(rows[0].preimage_hash, Endian.Little).toString(), sample_preImageInfo.hash);
                         doneIt();
                     })
                     .catch((err) =>
@@ -389,7 +389,7 @@ describe ('Tests that sending a pre-image', () =>
                     .then((rows: any[]) =>
                     {
                         assert.strictEqual(rows[0].preimage_distance, 6);
-                        assert.strictEqual(Hash.createFromBinary(rows[0].preimage_hash, Endian.Little).toString(), sample_preImageInfo.hash);
+                        assert.strictEqual(new Hash(rows[0].preimage_hash, Endian.Little).toString(), sample_preImageInfo.hash);
                         doneIt();
                     })
                     .catch((err) =>

--- a/tests/Storage.test.ts
+++ b/tests/Storage.test.ts
@@ -323,8 +323,7 @@ describe ('Tests that sending a pre-image', () =>
 
     it ('Tests that sending a pre-image with a distance of 6 works', (doneIt: () => void) =>
     {
-        let pre_image: PreImageInfo = new PreImageInfo();
-        pre_image.parseJSON(sample_preImageInfo);
+        let pre_image: PreImageInfo = PreImageInfo.reviver("", sample_preImageInfo);
         ledger_storage.updatePreImage(pre_image)
             .then(() =>
             {
@@ -351,8 +350,7 @@ describe ('Tests that sending a pre-image', () =>
     it ('Fail tests that sending a pre-image with a distance of 5 works', (doneIt: () => void) =>
     {
         sample_preImageInfo.distance = 5;
-        let pre_image: PreImageInfo = new PreImageInfo();
-        pre_image.parseJSON(sample_preImageInfo);
+        let pre_image: PreImageInfo = PreImageInfo.reviver("", sample_preImageInfo);
         ledger_storage.updatePreImage(pre_image)
             .then(() =>
             {
@@ -380,8 +378,7 @@ describe ('Tests that sending a pre-image', () =>
     {
         // Distance test out of cycle_length range Test
         sample_preImageInfo.distance = 1008;
-        let pre_image: PreImageInfo = new PreImageInfo();
-        pre_image.parseJSON(sample_preImageInfo);
+        let pre_image: PreImageInfo = PreImageInfo.reviver("", sample_preImageInfo);
         ledger_storage.updatePreImage(pre_image)
             .then(() =>
             {


### PR DESCRIPTION
Currently, we allocate a dummy object and parse into it. The right way to do it in JS is through the `reviver` parameter to `JSON.parse`. Since the data in the test-suite is not actually a JSON string but actually an untyped object, the first step is to call reviver manually, and later on, once we switch to string, we can use `JSON.parse`.