### PR TITLE
Use statusMessage in error response

### DIFF
--- a/src/Stoa.ts
+++ b/src/Stoa.ts
@@ -125,7 +125,8 @@ class Stoa extends WebService
         if ((req.query.height !== undefined) &&
             !Utils.isPositiveInteger(req.query.height.toString()))
         {
-            res.status(400).send("The Height value is not valid.");
+            res.status(400).send({
+                statusMessage: `Invalid value for parameter 'height': ${req.query.height.toString()}`});
             return;
         }
 
@@ -209,7 +210,8 @@ class Stoa extends WebService
         if ((req.query.height !== undefined) &&
             !Utils.isPositiveInteger(req.query.height.toString()))
         {
-            res.status(400).send("The Height value is not valid.");
+            res.status(400).send({
+                statusMessage: `Invalid value for parameter 'height': ${req.query.height.toString()}`});
             return;
         }
 
@@ -295,7 +297,7 @@ class Stoa extends WebService
         let body = JSON.parse(text);
         if (body.block === undefined)
         {
-            res.status(400).send("Missing 'block' object in body");
+            res.status(400).send({ statusMessage: "Missing 'block' object in body"});
             return;
         }
 
@@ -321,7 +323,7 @@ class Stoa extends WebService
         let body = JSON.parse(req.body.toString());
         if (body.pre_image === undefined)
         {
-            res.status(400).send("Missing 'preImage' object in body");
+            res.status(400).send({ statusMessage: "Missing 'preImage' object in body"});
             return;
         }
 


### PR DESCRIPTION
See Vibe.d issue 2491 ()

Tested live. Before:
```
Nov 03 09:49:04 eu-002 docker[12976]: 2020-11-03 09:49:04,970 Error [agora.node.FullNode] - Error sending preImage (enroll_key: 0xb20da9cfbda971f3f573f55eabcd677feaf12f7948e8994a97cdf9e570799b71631e87bb9ebce0d6a402275adfb6e365fdb72139c18559a10df0e5fe4bae08eb) to http://stoa:2828/preimage_received :std.json.JSONException@submodules/vibe.d/data/vibe/data/json.d(1344): (0): Error: Expected valid JSON token, got 'Missing 'pre'.
```

After:
```
Nov 03 09:49:34 eu-002 docker[12976]: 2020-11-03 09:49:34,972 Error [agora.node.FullNode] - Error sending preImage (enroll_key: 0xb20da9cfbda971f3f573f55eabcd677feaf12f7948e8994a97cdf9e570799b71631e87bb9ebce0d6a402275adfb6e365fdb72139c18559a10df0e5fe4bae08eb) to http://stoa:2828/preimage_received :vibe.web.common.RestException@submodules/vibe.d/web/vibe/web/rest.d(1896): Missing 'preImage' object in body
```