### PR TITLE
Use the received data without replacing it

### DIFF
--- a/src/Stoa.ts
+++ b/src/Stoa.ts
@@ -86,8 +86,9 @@ class Stoa extends WebService
         // Prepare middleware
 
         // parse application/x-www-form-urlencoded
-        this.app.use(bodyParser.urlencoded({extended: false}));
-        this.app.use(bodyParser.raw({type: "*/*"}));
+        this.app.use(bodyParser.urlencoded({ extended: false }))
+        // parse application/json
+        this.app.use(bodyParser.json())
         this.app.use(cors(cors_options));
         // enable pre-flight
         this.app.options('*', cors(cors_options));
@@ -292,22 +293,19 @@ class Stoa extends WebService
      */
     private putBlock (req: express.Request, res: express.Response)
     {
-        // Change the number to a string to preserve the precision of UInt64
-        let text = req.body.toString().replace(/([\[:])?(\d+)([,\}\]])/g, "$1\"$2\"$3");
-        let body = JSON.parse(text);
-        if (body.block === undefined)
+        if (req.body.block === undefined)
         {
             res.status(400).send({ statusMessage: "Missing 'block' object in body"});
             return;
         }
 
-        logger.http(`POST /blocks_externalized block=${body.block.toString()}`);
+        logger.http(`POST /blocks_externalized block=${req.body.block.toString()}`);
 
         // To do
         // For a more stable operating environment,
         // it would be necessary to consider organizing the pool
         // using the database instead of the array.
-        this.pending = this.pending.then(() => { return this.task({type: "block", data: body.block}); });
+        this.pending = this.pending.then(() => { return this.task({type: "block", data: req.body.block}); });
 
         res.status(200).send();
     }
@@ -320,20 +318,19 @@ class Stoa extends WebService
      */
     private putPreImage (req: express.Request, res: express.Response)
     {
-        let body = JSON.parse(req.body.toString());
-        if (body.preimage === undefined)
+        if (req.body.preimage === undefined)
         {
             res.status(400).send({ statusMessage: "Missing 'preimage' object in body"});
             return;
         }
 
-        logger.http(`POST /preimage_received preimage=${body.preimage.toString()}`);
+        logger.http(`POST /preimage_received preimage=${req.body.preimage.toString()}`);
 
         // To do
         // For a more stable operating environment,
         // it would be necessary to consider organizing the pool
         // using the database instead of the array.
-        this.pending = this.pending.then(() => { return this.task({type: "pre_image", data: body.preimage}); });
+        this.pending = this.pending.then(() => { return this.task({type: "pre_image", data: req.body.preimage}); });
 
         res.status(200).send();
     }

--- a/src/modules/agora/AgoraClient.ts
+++ b/src/modules/agora/AgoraClient.ts
@@ -91,14 +91,12 @@ export class AgoraClient implements FullNodeAPI
                 .addSearch("block_height", block_height.toString())
                 .addSearch("max_blocks", max_blocks);
 
-            this.client.get(uri.toString(), { transformResponse: (r) => r })
+            this.client.get(uri.toString())
                 .then((response: AxiosResponse) =>
                 {
                     if (response.status == 200)
                     {
-                        // Change the number to a string to preserve the precision of UInt64
-                        let text = response.data.replace(/([\[:])?(\d+)([,\}\]])/g, "$1\"$2\"$3");
-                        resolve(JSON.parse(text));
+                        resolve(response.data);
                     }
                     else
                     {

--- a/src/modules/data/schemas/BitField.json
+++ b/src/modules/data/schemas/BitField.json
@@ -4,7 +4,7 @@
   "properties": {
     "_storage": {
       "items": {
-        "type": "string"
+        "type": "number"
       },
       "type": "array"
     }

--- a/src/modules/data/schemas/Enrollment.json
+++ b/src/modules/data/schemas/Enrollment.json
@@ -9,7 +9,7 @@
       "type": "string"
     },
     "cycle_length": {
-      "type": "string"
+      "type": "number"
     },
     "enroll_sig": {
       "type": "string"

--- a/src/modules/data/schemas/Transaction.json
+++ b/src/modules/data/schemas/Transaction.json
@@ -3,7 +3,7 @@
   "type": "object",
   "properties": {
     "type": {
-      "type": "string"
+      "type": "number"
     },
     "inputs": {
       "items": {

--- a/src/modules/data/schemas/TxInputs.json
+++ b/src/modules/data/schemas/TxInputs.json
@@ -6,7 +6,7 @@
       "type": "string"
     },
     "index": {
-      "type": "string"
+      "type": "number"
     },
     "signature": {
       "type": "string"

--- a/tests/Storage.test.ts
+++ b/tests/Storage.test.ts
@@ -15,7 +15,7 @@ import * as assert from 'assert';
 import { LedgerStorage } from '../src/modules/storage/LedgerStorage';
 import { Block, Hash, Height } from '../src/modules/data';
 import { PreImageInfo } from '../src/modules/data';
-import { sample_data_raw, sample_preImageInfo } from "./Utils";
+import { sample_data, sample_preImageInfo } from "./Utils";
 import { Endian } from "../src/modules/utils/buffer";
 
 describe ('Test ledger storage and inquiry function.', () =>
@@ -38,12 +38,9 @@ describe ('Test ledger storage and inquiry function.', () =>
         {
             try
             {
-                for (let elem of sample_data_raw)
+                for (let elem of sample_data)
                 {
-                    const block = JSON.parse(
-                        elem.replace(/([\[:])?(\d+)([,\}\]])/g, "$1\"$2\"$3"),
-                        Block.reviver);
-                    await ledger_storage.putBlocks(block);
+                    await ledger_storage.putBlocks(Block.reviver("", elem));
                 }
             }
             catch (error)
@@ -218,9 +215,7 @@ describe ('Test for storing block data in the database', () =>
 
     it ('Error-handling test when writing a transaction.', async () =>
     {
-        const block = JSON.parse(
-            sample_data_raw[0].replace(/([\[:])?(\d+)([,\}\]])/g, "$1\"$2\"$3"),
-            Block.reviver);
+        let block = Block.reviver("", sample_data[0]);
 
         await ledger_storage.putTransactions(block);
         await assert.rejects(ledger_storage.putTransactions(block),
@@ -232,9 +227,7 @@ describe ('Test for storing block data in the database', () =>
 
     it ('Error-handling test when writing a enrollment.', async () =>
     {
-        const block = JSON.parse(
-            sample_data_raw[0].replace(/([\[:])?(\d+)([,\}\]])/g, "$1\"$2\"$3"),
-            Block.reviver);
+        let block = Block.reviver("", sample_data[0]);
 
         await ledger_storage.putEnrollments(block);
         await assert.rejects(ledger_storage.putEnrollments(block),
@@ -246,9 +239,7 @@ describe ('Test for storing block data in the database', () =>
 
     it ('Error-handling test when writing a block.', async () =>
     {
-        const block = JSON.parse(
-            sample_data_raw[0].replace(/([\[:])?(\d+)([,\}\]])/g, "$1\"$2\"$3"),
-            Block.reviver);
+        const block = Block.reviver("", sample_data[0]);
         await ledger_storage.putBlocks(block);
         await assert.rejects(ledger_storage.putBlocks(block),
             {
@@ -258,9 +249,7 @@ describe ('Test for storing block data in the database', () =>
 
     it ('DB transaction test when writing a block', async () =>
     {
-        const block = JSON.parse(
-            sample_data_raw[0].replace(/([\[:])?(\d+)([,\}\]])/g, "$1\"$2\"$3"),
-            Block.reviver);
+        const block = Block.reviver("", sample_data[0]);
 
         await ledger_storage.putEnrollments(block);
         await assert.rejects(ledger_storage.putBlocks(block),
@@ -279,12 +268,8 @@ describe ('Test for storing block data in the database', () =>
 
     it ('Test for writing the block hash', async () =>
     {
-        const block0 = JSON.parse(
-            sample_data_raw[0].replace(/([\[:])?(\d+)([,\}\]])/g, "$1\"$2\"$3"),
-            Block.reviver);
-        const block1 = JSON.parse(
-            sample_data_raw[1].replace(/([\[:])?(\d+)([,\}\]])/g, "$1\"$2\"$3"),
-            Block.reviver);
+        const block0 = Block.reviver("", sample_data[0]);
+        const block1 = Block.reviver("", sample_data[1]);
 
         // Write the Genesis block.
         await ledger_storage.putBlocks(block0);
@@ -311,12 +296,9 @@ describe ('Tests that sending a pre-image', () =>
             .then((result) => { ledger_storage = result; return result; })
             // Then fill it with sample data
             .then(async (result) => {
-                for (let elem of sample_data_raw)
+                for (let elem of sample_data)
                 {
-                    const block = JSON.parse(
-                        elem.replace(/([\[:])?(\d+)([,\}\]])/g, "$1\"$2\"$3"),
-                        Block.reviver);
-                    await result.putBlocks(block);
+                    await result.putBlocks(Block.reviver("", elem));
                 }
                 return result;
             })

--- a/tests/ValidationJSON.test.ts
+++ b/tests/ValidationJSON.test.ts
@@ -35,7 +35,7 @@ describe ('Test that validation with JSON schema', () =>
             // When attribute `inputs` is not an array
             Validator.isValidOtherwiseThrow<ITransaction>
             ("Transaction", {
-                "type": "1",
+                "type": 1,
                 "inputs": {},
                 "outputs": []
             });
@@ -51,7 +51,7 @@ describe ('Test that validation with JSON schema', () =>
         // When attribute `inputs` is not an array
         assert.ok(!Validator.isValidOtherwiseNoThrow<ITransaction>
         ("Transaction", {
-            "type": "1",
+            "type": 1,
             "inputs": {},
             "outputs": []
         }));
@@ -60,7 +60,7 @@ describe ('Test that validation with JSON schema', () =>
         assert.ok(Validator.isValidOtherwiseThrow<ITransaction>
         ("Transaction",
         {
-            "type": "0",
+            "type": 0,
             "inputs": [],
             "outputs": [
                 {
@@ -75,13 +75,13 @@ describe ('Test that validation with JSON schema', () =>
         assert.ok(Validator.isValidOtherwiseThrow<ITransaction>
         ("Transaction",
         {
-            "type": "0",
+            "type": 0,
             "inputs": [
                 {
                     "previous": "0x5d7f6a7a30f7ff591c8649f61eb8a35d034824ed5" +
                         "cd252c2c6f10cdbd2236713dc369ef2a44b62ba113814a9d819" +
                         "a276ff61582874c9aee9c98efa2aa1f10d73",
-                    "index": "1",
+                    "index": 1,
                     "signature": "0x07557ce0845a7ccbba61643b95e310bd3ae06c41" +
                         "fab9e8761ff3b0e5d28a5d625a3b951223c618910b239e7b779" +
                         "c6c671252a78edff4d0f37bdb25982e4f4228"
@@ -108,7 +108,7 @@ describe ('Test that validation with JSON schema', () =>
                 "random_seed": "0xfb05e20321ae11b2f799a71a736fd172c5dec39540" +
                     "f53d6213cd1b7522898c8bfb86445c6b6db9437899f5917bb5f9c9b" +
                     "e7358ba0ecaa37675692f7d08766950",
-                "cycle_length": "1008",
+                "cycle_length": 1008,
                 "enroll_sig": "0x0c48e78972e1b138a37e37ae27a01d5ebdea193088d" +
                     "def2d9883446efe63086925e8803400d7b93d22b1eef5c475098ce0" +
                     "8a5b47e8125cf6b04274cc4db34bfd"
@@ -122,7 +122,7 @@ describe ('Test that validation with JSON schema', () =>
             "random_seed": "0xfb05e20321ae11b2f799a71a736fd172c5dec39540f53d" +
                 "6213cd1b7522898c8bfb86445c6b6db9437899f5917bb5f9c9be7358ba0" +
                 "ecaa37675692f7d08766950",
-            "cycle_length": "1008",
+            "cycle_length": 1008,
             "enroll_sig": "0x0c48e78972e1b138a37e37ae27a01d5ebdea193088ddef2" +
                 "d9883446efe63086925e8803400d7b93d22b1eef5c475098ce08a5b47e8" +
                 "125cf6b04274cc4db34bfd"
@@ -137,7 +137,7 @@ describe ('Test that validation with JSON schema', () =>
             "random_seed": "0xfb05e20321ae11b2f799a71a736fd172c5dec39540f53d" +
                 "6213cd1b7522898c8bfb86445c6b6db9437899f5917bb5f9c9be7358ba0" +
                 "ecaa37675692f7d08766950",
-            "cycle_length": "1008",
+            "cycle_length": 1008,
             "enroll_sig": "0x0c48e78972e1b138a37e37ae27a01d5ebdea193088ddef2" +
                 "d9883446efe63086925e8803400d7b93d22b1eef5c475098ce08a5b47e8" +
                 "125cf6b04274cc4db34bfd"

--- a/tests/hash.test.ts
+++ b/tests/hash.test.ts
@@ -12,7 +12,7 @@
 *******************************************************************************/
 
 import { Block, Hash, hash, hashFull, hashMulti, makeUTXOKey } from '../src/modules/data'
-import { sample_data_raw } from './Utils';
+import { sample_data } from './Utils';
 
 import * as assert from 'assert';
 
@@ -80,15 +80,8 @@ describe ('Test for hash value of block data', () =>
 
     before ('Prepare test for block data hash', () =>
     {
-        const block1 = JSON.parse(
-            sample_data_raw[0].replace(/([\[:])?(\d+)([,\}\]])/g, "$1\"$2\"$3"),
-            Block.reviver);
-        const block2 = JSON.parse(
-            sample_data_raw[1].replace(/([\[:])?(\d+)([,\}\]])/g, "$1\"$2\"$3"),
-            Block.reviver);
-
-        blocks.push(block1);
-        blocks.push(block2);
+        blocks.push(Block.reviver("", sample_data[0]));
+        blocks.push(Block.reviver("", sample_data[1]));
     });
 
     it ('Test that hash of block header', () =>


### PR DESCRIPTION
We received the data as a string, replaced the number with a string, and then did JSON.parse.
But this part is not necessary because UInt64 is no longer used. So I removed this.

The reason for the error in the issue is that the attribute value was numbered only when it was written in letters.
I think this is a problem caused by receiving mixed data in various forms. This will also be resolved by removing the obvious substitution of this part.


Relates to #165 

