### PR TITLE
Reset start height in an incomplete recovery

### DIFF
--- a/src/Stoa.ts
+++ b/src/Stoa.ts
@@ -454,9 +454,11 @@ class Stoa extends WebService
                     else if (height.value > expected_height.value)
                     {
                         // Recovery is required for blocks that are not received.
-                        let success: boolean = false;
-                        while (!success)
-                            success = await this.recoverBlock(block, height, expected_height);
+                        while (true) {
+                            if (await this.recoverBlock(block, height, expected_height))
+                                break;
+                            expected_height = await this.ledger_storage.getExpectedBlockHeight();
+                        }
                     }
                     else
                     {


### PR DESCRIPTION
If the number of blocks to be recovered is too large only a part of them will be recovered.
Therefore, the height of the block to start the recovery is taken from the database.

Currently, I have found a problem that does not stop when the number of blocks to be restored is greater than 64(Stoa._max_count_on_recovery).