### PR TITLE
Change error status code for Get request

### DIFF
--- a/src/Stoa.ts
+++ b/src/Stoa.ts
@@ -133,8 +133,7 @@ class Stoa extends WebService
         if ((req.query.height !== undefined) &&
             !Utils.isPositiveInteger(req.query.height.toString()))
         {
-            res.status(400).send({
-                statusMessage: `Invalid value for parameter 'height': ${req.query.height.toString()}`});
+            res.status(400).send(`Invalid value for parameter 'height': ${req.query.height.toString()}`);
             return;
         }
 
@@ -152,7 +151,11 @@ class Stoa extends WebService
                 // Nothing found
                 if (!rows.length)
                 {
-                    res.status(204).send();
+                    if (height !== null)
+                        res.status(400).send("No validator exists for block height.");
+                    else
+                        res.status(503).send("Stoa is currently unavailable.");
+
                     return;
                 }
 
@@ -218,8 +221,7 @@ class Stoa extends WebService
         if ((req.query.height !== undefined) &&
             !Utils.isPositiveInteger(req.query.height.toString()))
         {
-            res.status(400).send({
-                statusMessage: `Invalid value for parameter 'height': ${req.query.height.toString()}`});
+            res.status(400).send(`Invalid value for parameter 'height': ${req.query.height.toString()}`);
             return;
         }
 
@@ -239,7 +241,8 @@ class Stoa extends WebService
                 // Nothing to show
                 if (!rows.length)
                 {
-                    res.status(204).send();
+                    res.status(400).send(`The validator data not found.` +
+                    `'address': (${address}), 'height': (${height?.toString()})`);
                     return;
                 }
 

--- a/tests/Stoa.test.ts
+++ b/tests/Stoa.test.ts
@@ -97,6 +97,20 @@ describe ('Test of Stoa API Server', () =>
             .filename("GDNODE4KTE7VQUHVBLXIGD7VEFY57X4XV547P72D37SDG7UEO7MWOSNY")
             .setSearch("height", "10");
 
+        let fail_uri = URI(host)
+            .port(port)
+            .directory("validator")
+            .filename("GDNODE4KTE7VQUHVBLXIGD7VEFY57X4XV547P72D37SDG7UEO7MWOSNY")
+            .setSearch("height", "99");
+
+        (async () =>
+        {
+            await assert.rejects(
+                client.get(fail_uri.toString()),
+                {message: "Request failed with status code 400"}
+            )
+        })();
+
         client.get (uri.toString())
             .then((response) =>
             {
@@ -222,8 +236,10 @@ describe ('Test of Stoa API Server', () =>
             .directory("validators")
             .setSearch("height", "41");
 
-            response = await client.get (uri9.toString());
-            assert.strictEqual(response.data.length, 0);
+            await assert.rejects(
+                client.get(uri9.toString()),
+                {message: "Request failed with status code 400"}
+            );
 
             doneIt();
         }, 200);


### PR DESCRIPTION
The GET /validators call should always be successful,
but Stoa cannot be serviced if Stoa is listening to the block or if there is a problem with the DB.
The GET /validator may request an incorrect height.
In this case, return the 400 status code and respond that there is no data.

Fixed #139