### PR TITLE
Fix the preimage display at height=0

### DIFF
--- a/src/Stoa.ts
+++ b/src/Stoa.ts
@@ -167,14 +167,14 @@ class Stoa extends WebService
                     let preimage_distance: number = row.preimage_distance;
                     let target_height: Height = new Height(row.height);
                     let result_preimage_hash = Hash.NULL;
-                    let start_index: bigint = BigInt(row.enrolled_at) + 1n;
+                    let avail_height: bigint = BigInt(row.avail_height);
 
                     // Hashing preImage
-                    if (target_height.value >= start_index &&
-                        (start_index + BigInt(preimage_distance)) >= target_height.value)
+                    if (target_height.value >= avail_height &&
+                        (avail_height + BigInt(preimage_distance)) >= target_height.value)
                     {
                         result_preimage_hash.fromBinary(preimage_hash, Endian.Little);
-                        let count = start_index + BigInt(preimage_distance) - target_height.value;
+                        let count = avail_height + BigInt(preimage_distance) - target_height.value;
                         for (let i = 0; i < count; i++)
                         {
                             result_preimage_hash = hash(result_preimage_hash.data);
@@ -183,8 +183,16 @@ class Stoa extends WebService
                     }
                     else
                     {
-                        preimage_distance = NaN;
-                        result_preimage_hash = Hash.NULL;
+                        if (target_height.value == row.enrolled_at)
+                        {
+                            preimage_distance = 0;
+                            result_preimage_hash.fromBinary(row.random_seed, Endian.Little);
+                        }
+                        else
+                        {
+                            preimage_distance = NaN;
+                            result_preimage_hash = Hash.NULL;
+                        }
                     }
 
                     let preimage: IPreimage = {
@@ -254,14 +262,13 @@ class Stoa extends WebService
                     let preimage_distance: number = row.preimage_distance;
                     let target_height: Height = new Height(BigInt(row.height));
                     let result_preimage_hash = Hash.NULL;
-                    let start_index: bigint = BigInt(row.enrolled_at) +1n;
-
+                    let avail_height: bigint = BigInt(row.avail_height);
                     // Hashing preImage
-                    if (target_height.value >= start_index &&
-                        start_index + BigInt(preimage_distance) >= target_height.value)
+                    if (target_height.value >= avail_height &&
+                        avail_height + BigInt(preimage_distance) >= target_height.value)
                     {
                         result_preimage_hash.fromBinary(preimage_hash, Endian.Little);
-                        let count = start_index + BigInt(preimage_distance) - target_height.value;
+                        let count = avail_height + BigInt(preimage_distance) - target_height.value;
                         for (let i = 0; i < count; i++)
                         {
                             result_preimage_hash = hash(result_preimage_hash.data);
@@ -270,8 +277,16 @@ class Stoa extends WebService
                     }
                     else
                     {
-                        preimage_distance = NaN;
-                        result_preimage_hash = Hash.NULL;
+                        if (target_height.value == row.avail_height)
+                        {
+                            preimage_distance = 0;
+                            result_preimage_hash.fromBinary(row.random_seed, Endian.Little);
+                        }
+                        else
+                        {
+                            preimage_distance = NaN;
+                            result_preimage_hash = Hash.NULL;
+                        }
                     }
 
                     let preimage: IPreimage = {

--- a/src/modules/storage/LedgerStorage.ts
+++ b/src/modules/storage/LedgerStorage.ts
@@ -619,19 +619,24 @@ export class LedgerStorage extends Storages
                 enrollments.enrolled_at,
                 enrollments.utxo_key as stake,
                 enrollments.random_seed,
+                enrollments.avail_height,
                 ` + cur_height + ` as height,
                 validators.preimage_distance,
-                validators.preimage_hash,
-                (` + cur_height + ` - (enrollments.enrolled_at + 1)) as test
+                validators.preimage_hash
         FROM (SELECT MAX(block_height) as enrolled_at,
+                (CASE WHEN block_height = 0 THEN
+                      block_height
+                 ELSE
+                      block_height + 1
+                 END) as avail_height,
                 enrollment_index,
                 utxo_key,
                 random_seed,
                 cycle_length,
                 enroll_sig
              FROM enrollments
-             WHERE (block_height + 1) <= ` + cur_height + `
-               AND ` + cur_height + ` <= (block_height + cycle_length)
+             WHERE avail_height <= ` + cur_height + `
+               AND ` + cur_height + ` < (avail_height + cycle_length)
              GROUP BY utxo_key) as enrollments
         INNER JOIN tx_outputs
             ON enrollments.utxo_key = tx_outputs.utxo_key

--- a/tests/Stoa.test.ts
+++ b/tests/Stoa.test.ts
@@ -140,17 +140,29 @@ describe ('Test of Stoa API Server', () =>
         // Wait for the data added to the pool to be processed.
         setTimeout(async () =>
         {
+            let uri1 = URI(host)
+            .port(port)
+            .directory("validator")
+            .filename("GDNODE4KTE7VQUHVBLXIGD7VEFY57X4XV547P72D37SDG7UEO7MWOSNY")
+            .setSearch("height", "0");
+
+            let response = await client.get (uri1.toString());
+            assert.strictEqual(response.data.length, 1);
+            assert.strictEqual(response.data[0].preimage.distance, 0);
+            assert.strictEqual(response.data[0].preimage.hash,
+            "0x0a8201f9f5096e1ce8e8de4147694940a57a188b78293a55144fc8777a774f2349b3a910fb1fb208514fb16deaf49eb05882cdb6796a81f913c6daac3eb74328");
+
             let uri2 = URI(host)
                 .port(port)
                 .directory("validator")
                 .filename("GDNODE4KTE7VQUHVBLXIGD7VEFY57X4XV547P72D37SDG7UEO7MWOSNY")
-                .setSearch("height", "7");
+                .setSearch("height", "6");
 
-            let response = await client.get (uri2.toString());
+            response = await client.get (uri2.toString());
             assert.strictEqual(response.data.length, 1);
             assert.strictEqual(response.data[0].preimage.distance, 6);
             assert.strictEqual(response.data[0].preimage.hash,
-                "0x0a8201f9f5096e1ce8e8de4147694940a57a188b78293a55144fc8777a774f2349b3a910fb1fb208514fb16deaf49eb05882cdb6796a81f913c6daac3eb74328");
+                "0x790ab7c8f8ddbf012561e70c944c1835fd1a873ca55c973c828164906f8b35b924df7bddcafade688ad92cfb4414b2cf69a02d115dc214bbd00d82167f645e7e");
 
             let uri3 = URI(host)
                 .port(port)
@@ -159,9 +171,9 @@ describe ('Test of Stoa API Server', () =>
                 .setSearch("height", "1");
             response = await client.get (uri3.toString());
             assert.strictEqual(response.data.length, 1);
-            assert.strictEqual(response.data[0].preimage.distance, 0);
+            assert.strictEqual(response.data[0].preimage.distance, 1);
             assert.strictEqual(response.data[0].preimage.hash,
-                "0x00b72d857beb3f5b3dd378fed5df1f20dad68a3710082b10d48d47d1ac09fabfd0d4463ee1a34ef499d7c0dd09f644e32fc1f315f68f67c35b9d99b228be6377");
+                "0x314e30482fd0b498361e8537961d875e52b7e82edb8260cd548d3edacb451c80f41dd0ba9c5700adfb646066d41b0031120b65cba2df91def9bd83263fb306bd");
 
             let uri4 = URI(host)
                 .port(port)
@@ -178,9 +190,9 @@ describe ('Test of Stoa API Server', () =>
                 .directory("validators");
             response = await client.get (uri5.toString());
             assert.strictEqual(response.data.length, 6);
-            assert.strictEqual(response.data[0].preimage.distance, 0);
+            assert.strictEqual(response.data[0].preimage.distance, 1);
             assert.strictEqual(response.data[0].preimage.hash,
-                "0x00b72d857beb3f5b3dd378fed5df1f20dad68a3710082b10d48d47d1ac09fabfd0d4463ee1a34ef499d7c0dd09f644e32fc1f315f68f67c35b9d99b228be6377");
+                "0x314e30482fd0b498361e8537961d875e52b7e82edb8260cd548d3edacb451c80f41dd0ba9c5700adfb646066d41b0031120b65cba2df91def9bd83263fb306bd");
 
             // re-enrollment
             const enroll_sig =
@@ -191,7 +203,7 @@ describe ('Test of Stoa API Server', () =>
                 new Hash("0xe0c04a5bd47ffc5b065b7d397e251016310c43dc77220bf803b73f1183da00b0e67602b1f95cb18a0059aa1cdf2f9adafe979998364b38cd5c15d92b9b8fd815");
             const enrollment = new Enrollment(utxo_key, random_seed, 20, enroll_sig);
             const header = new BlockHeader(
-                Hash.NULL, new Height(20n), Hash.NULL, new BitField([]),
+                Hash.NULL, new Height(19n), Hash.NULL, new BitField([]),
                 new Signature(Buffer.alloc(Signature.Width)), [ enrollment ]);
             const block = new Block(header, [], []);
 
@@ -201,7 +213,7 @@ describe ('Test of Stoa API Server', () =>
             let uri6 = URI(host)
             .port(port)
             .directory("validators")
-            .setSearch("height", "20");
+            .setSearch("height", "19");
 
             response = await client.get (uri6.toString());
             assert.strictEqual(response.data.length, 6);
@@ -212,29 +224,29 @@ describe ('Test of Stoa API Server', () =>
             let uri7 = URI(host)
             .port(port)
             .directory("validators")
-            .setSearch("height", "21");
+            .setSearch("height", "20");
 
             response = await client.get (uri7.toString());
             assert.strictEqual(response.data.length, 1);
 
             assert.strictEqual(response.data[0].stake, enrollment.utxo_key.toString());
-            assert.strictEqual(response.data[0].enrolled_at, "20");
+            assert.strictEqual(response.data[0].enrolled_at, "19");
 
             let uri8 = URI(host)
             .port(port)
             .directory("validators")
-            .setSearch("height", "40");
+            .setSearch("height", "39");
 
             response = await client.get (uri8.toString());
             assert.strictEqual(response.data.length, 1);
 
             assert.strictEqual(response.data[0].stake, enrollment.utxo_key.toString());
-            assert.strictEqual(response.data[0].enrolled_at, "20");
+            assert.strictEqual(response.data[0].enrolled_at, "19");
 
             let uri9 = URI(host)
             .port(port)
             .directory("validators")
-            .setSearch("height", "41");
+            .setSearch("height", "40");
 
             await assert.rejects(
                 client.get(uri9.toString()),

--- a/tests/Utils.ts
+++ b/tests/Utils.ts
@@ -37,14 +37,14 @@ export const sample_data =
 export const sample_preImageInfo =
     {
         "enroll_key": "0x46883e83778481d640a95fcffd6e1a1b6defeaac5a8001cd3f99e17576b809c7e9bc7a44c3917806765a5ff997366e217ff54cd4da09c0c51dc339c47052a3ac",
-        "hash": "0x0a8201f9f5096e1ce8e8de4147694940a57a188b78293a55144fc8777a774f2349b3a910fb1fb208514fb16deaf49eb05882cdb6796a81f913c6daac3eb74328",
+        "hash": "0x790ab7c8f8ddbf012561e70c944c1835fd1a873ca55c973c828164906f8b35b924df7bddcafade688ad92cfb4414b2cf69a02d115dc214bbd00d82167f645e7e",
         "distance": 6
     };
 
 export const sample_reEnroll_preImageInfo =
     {
         "enroll_key": "0x46883e83778481d640a95fcffd6e1a1b6defeaac5a8001cd3f99e17576b809c7e9bc7a44c3917806765a5ff997366e217ff54cd4da09c0c51dc339c47052a3ac",
-        "hash": "0x25677ee5a05590d68276d1967cbe37e3cf3e731502afd043fafc82b0181cd120cef6272e5aea2dafaca0236a4ce7c1edd4fe21ae770930a8e206bd7080066a4c",
+        "hash": "0xe51e1cc8dfdcdcd02586c9648c6977504eade2dffc8f3289e7ae7e501c2879f99af6a199ccad499be02a66d409ca4ab51b35f1c3a06a82464ce4efcfeb3ade33",
         "distance": 6
     };
 


### PR DESCRIPTION
At height=0, the distance = 0 and the `preimage` is displayed as `randomHash`

The enrollments of the Genesis block starts with zero avail_height.

Fixed #167