### PR TITLE
[WIP] Remove the catch-up function from the test code

### DIFF
--- a/src/Stoa.ts
+++ b/src/Stoa.ts
@@ -116,7 +116,7 @@ class Stoa extends WebService
             .then(
                 () =>
                 {
-                    return this.pending = this.pending.then(() => { return this.catchup(height); });
+                    return this.catchup(height);
                 });
     }
 

--- a/tests/Stoa.test.ts
+++ b/tests/Stoa.test.ts
@@ -35,13 +35,17 @@ describe ('Test of Stoa API Server', () =>
     let agora_server: TestAgora;
     let client = axios.create();
 
-    before ('Start Stoa API Server and a fake Agora', () =>
+    before ('Start a fake Agora', () =>
     {
-        let prom = new Promise<void>((resolve, reject) => {
+        return new Promise<void>((resolve, reject) => {
             agora_server = new TestAgora("2826", sample_data, resolve);
         });
+    });
+
+    before ('Start Stoa API Server', () =>
+    {
         stoa_server = new TestStoa(new URL("http://127.0.0.1:2826"), port);
-        return prom.then(() => { return stoa_server.start() });
+        return stoa_server.start();
     });
 
     after ('Stop Stoa and Agora server instances', () =>


### PR DESCRIPTION
I checked late after seeing intermittent errors in some test codes when github's CI was executed due to the catch-up function.

I was able to remove the catch-up function from the test code to solve this problem.