### PR TITLE
Implement block_height API endpoint

### DIFF
--- a/src/Stoa.ts
+++ b/src/Stoa.ts
@@ -94,6 +94,7 @@ class Stoa extends WebService
         this.app.options('*', cors(cors_options));
 
         // Prepare routes
+        this.app.get("/block_height", this.getBlockHeight.bind(this));
         this.app.get("/validators", this.getValidators.bind(this));
         this.app.get("/validator/:address", this.getValidator.bind(this));
         this.app.post("/block_externalized", this.putBlock.bind(this));
@@ -359,6 +360,29 @@ class Stoa extends WebService
 
         res.status(200).send();
     }
+
+    /**
+     * GET /block_height
+     *
+     * Return the highest block height stored in Stoa
+     */
+    private getBlockHeight (req: express.Request, res: express.Response)
+    {
+        logger.http(`GET /block_height`);
+
+        this.ledger_storage.getBlockHeight()
+            .then((row: Height | null) => {
+                if (row == null)
+                    res.status(400).send(`The block height not found.`);
+                else
+                    res.status(200).send(JSON.stringify(row));
+            })
+            .catch((err) => {
+                logger.error("Failed to data lookup to the DB: " + err);
+                res.status(500).send("Failed to data lookup");
+            }
+            );
+    };
 
     /**
      * Extract the block height from JSON.

--- a/src/modules/storage/LedgerStorage.ts
+++ b/src/modules/storage/LedgerStorage.ts
@@ -219,6 +219,32 @@ export class LedgerStorage extends Storages
     }
 
     /**
+     * Get the highest block height in this Stoa DB
+     * @returns Returns the Promise. If it is finished successfully the `.then`
+     * of the returned Promise is called with the block height
+     * and if an error occurs the `.catch` is called with an error.
+     */
+    public getBlockHeight (): Promise<Height | null>
+    {
+        return new Promise<Height | null>((resolve, reject) =>
+        {
+            let sql = `SELECT MAX(height) as height FROM blocks`;
+            this.query(sql, [])
+                .then((row: any[]) =>
+                {
+                    if (row[0].height !== null)
+                        resolve(new Height(BigInt(row[0].height)));
+                    else
+                        resolve(null);
+                })
+                .catch((err) =>
+                {
+                    reject(err);
+                });
+        });
+    }
+
+    /**
      * Puts all enrollments
      * @param block: The instance of the `Block`
      */

--- a/tests/Stoa.test.ts
+++ b/tests/Stoa.test.ts
@@ -67,6 +67,25 @@ describe ('Test of Stoa API Server', () =>
         });
     });
 
+    it ('Test of the path /block_height', (doneIt: () => void) =>
+    {
+        let uri = URI(host)
+            .port(port)
+            .filename("block_height");
+
+        let url = uri.toString();
+        client.get (url)
+            .then((response) =>
+            {
+                assert.strictEqual(response.data, '1');
+            })
+            .catch((error) =>
+            {
+                assert.ok(!error, error);
+            })
+            .finally(doneIt);
+    });
+
     it ('Test of the path /validators', (doneIt: () => void) =>
     {
         let uri = URI(host)


### PR DESCRIPTION
It is necessary to provide height information for the received blocks of the Stoa.

Related to #183 