### PR TITLE
Refactory data modules

### DIFF
--- a/src/Stoa.ts
+++ b/src/Stoa.ts
@@ -195,7 +195,7 @@ class Stoa extends WebService
                     let preimage_hash: Buffer = row.preimage_hash;
                     let preimage_distance: number = row.preimage_distance;
                     let target_height: Height = new Height(row.height);
-                    let result_preimage_hash = Hash.NULL;
+                    let result_preimage_hash = Hash.init;
                     let avail_height: bigint = BigInt(row.avail_height);
 
                     // Hashing preImage
@@ -220,7 +220,7 @@ class Stoa extends WebService
                         else
                         {
                             preimage_distance = NaN;
-                            result_preimage_hash = Hash.NULL;
+                            result_preimage_hash = Hash.init;
                         }
                     }
 
@@ -290,7 +290,7 @@ class Stoa extends WebService
                     let preimage_hash: Buffer = row.preimage_hash;
                     let preimage_distance: number = row.preimage_distance;
                     let target_height: Height = new Height(BigInt(row.height));
-                    let result_preimage_hash = Hash.NULL;
+                    let result_preimage_hash = Hash.init;
                     let avail_height: bigint = BigInt(row.avail_height);
                     // Hashing preImage
                     if (target_height.value >= avail_height &&
@@ -314,7 +314,7 @@ class Stoa extends WebService
                         else
                         {
                             preimage_distance = NaN;
-                            result_preimage_hash = Hash.NULL;
+                            result_preimage_hash = Hash.init;
                         }
                     }
 

--- a/src/modules/data/DataPayload.ts
+++ b/src/modules/data/DataPayload.ts
@@ -115,4 +115,12 @@ export class DataPayload
     {
         buffer.writeBuffer(this.data)
     }
+
+    /**
+     * Converts this object to its JSON representation
+     */
+    public toJSON (key?: string): string
+    {
+        return this.toString();
+    }
 }

--- a/src/modules/data/DataPayload.ts
+++ b/src/modules/data/DataPayload.ts
@@ -123,4 +123,13 @@ export class DataPayload
     {
         return this.toString();
     }
+
+    /**
+     * The data payload consisting of zero values for all bytes.
+     * @returns The instance of DataPayload
+     */
+    static get init(): DataPayload
+    {
+        return new DataPayload(Buffer.alloc(0));
+    }
 }

--- a/src/modules/data/Hash.ts
+++ b/src/modules/data/Hash.ts
@@ -33,15 +33,6 @@ export class Hash
     public static Width: number = 64;
 
     /**
-     * The hash consisting of zero values for all bytes.
-     * @returns The instance of Hash
-     */
-    static get NULL(): Hash
-    {
-        return new Hash(Buffer.alloc(Hash.Width));
-    }
-
-    /**
      * Construct a new instance of this class
      *
      * @param data   The string or binary representation of the hash
@@ -125,6 +116,15 @@ export class Hash
     {
         return this.toString();
     }
+
+    /**
+     * The hash consisting of zero values for all bytes.
+     * @returns The instance of Hash
+     */
+    static get init(): Hash
+    {
+        return new Hash(Buffer.alloc(Hash.Width));
+    }
 }
 
 /**
@@ -182,7 +182,7 @@ export function makeUTXOKey (h: Hash, index: bigint): Hash
 export function hashFull (record: any): Hash
 {
     if ((record === null) || (record === undefined))
-        return Hash.NULL;
+        return Hash.init;
 
     let buffer = new SmartBuffer();
     hashPart(record, buffer);

--- a/src/modules/data/Hash.ts
+++ b/src/modules/data/Hash.ts
@@ -117,6 +117,14 @@ export class Hash
     {
         buffer.writeBuffer(this.data);
     }
+
+    /**
+     * Converts this object to its JSON representation
+     */
+    public toJSON (key?: string): string
+    {
+        return this.toString();
+    }
 }
 
 /**

--- a/src/modules/data/PublicKey.ts
+++ b/src/modules/data/PublicKey.ts
@@ -104,6 +104,15 @@ export class PublicKey
     {
         return this.toString();
     }
+
+    /**
+     * The public key consisting of zero values for all bytes.
+     * @returns The instance of PublicKey
+     */
+    static get init(): PublicKey
+    {
+        return new PublicKey(Buffer.alloc(PublicKey.Width));
+    }
 }
 
 /**

--- a/src/modules/data/PublicKey.ts
+++ b/src/modules/data/PublicKey.ts
@@ -96,6 +96,14 @@ export class PublicKey
     {
         buffer.writeBuffer(this.data);
     }
+
+    /**
+     * Converts this object to its JSON representation
+     */
+    public toJSON (key?: string): string
+    {
+        return this.toString();
+    }
 }
 
 /**

--- a/src/modules/data/Signature.ts
+++ b/src/modules/data/Signature.ts
@@ -105,4 +105,13 @@ export class Signature
     {
         return this.toString();
     }
+
+    /**
+     * The signature consisting of zero values for all bytes.
+     * @returns The instance of Signature
+     */
+    static get init(): Signature
+    {
+        return new Signature(Buffer.alloc(Signature.Width));
+    }
 }

--- a/src/modules/data/Signature.ts
+++ b/src/modules/data/Signature.ts
@@ -97,4 +97,12 @@ export class Signature
         else
             return this.data;
     }
+
+    /**
+     * Converts this object to its JSON representation
+     */
+    public toJSON (key?: string): string
+    {
+        return this.toString();
+    }
 }

--- a/src/modules/data/Transaction.ts
+++ b/src/modules/data/Transaction.ts
@@ -11,8 +11,8 @@
 
 *******************************************************************************/
 
-import { TxInputs } from './TxInputs';
-import { TxOutputs } from './TxOutputs';
+import { TxInput } from './TxInput';
+import { TxOutput } from './TxOutput';
 import { DataPayload } from './DataPayload';
 import { Validator, ITransaction } from './validator'
 
@@ -42,12 +42,12 @@ export class Transaction
     /**
      * The array of references to the unspent output of the previous transaction
      */
-    public inputs: TxInputs[];
+    public inputs: TxInput[];
 
     /**
      * The array of newly created outputs
      */
-    public outputs: TxOutputs[];
+    public outputs: TxOutput[];
 
     /**
      * The data payload to store
@@ -61,7 +61,7 @@ export class Transaction
      * @param outputs - The array of newly created outputs
      * @param payload - The data payload to store
      */
-    constructor (type: number, inputs: TxInputs[], outputs: TxOutputs[], payload: DataPayload)
+    constructor (type: number, inputs: TxInput[], outputs: TxOutput[], payload: DataPayload)
     {
         this.type = type;
         this.inputs = inputs;
@@ -88,8 +88,8 @@ export class Transaction
 
         return new Transaction(
             Number(value.type),
-            value.inputs.map((elem: any) => TxInputs.reviver("", elem)),
-            value.outputs.map((elem: any) => TxOutputs.reviver("", elem)),
+            value.inputs.map((elem: any) => TxInput.reviver("", elem)),
+            value.outputs.map((elem: any) => TxOutput.reviver("", elem)),
             DataPayload.reviver("", value.payload));
     }
 

--- a/src/modules/data/Transaction.ts
+++ b/src/modules/data/Transaction.ts
@@ -106,4 +106,17 @@ export class Transaction
             elem.computeHash(buffer);
         this.payload.computeHash(buffer);
     }
+
+    /**
+     * Converts this object to its JSON representation
+     */
+    public toJSON (key?: string): object
+    {
+        return {
+            "type": this.type,
+            "inputs": this.inputs,
+            "outputs": this.outputs,
+            "payload": this.payload
+        }
+    }
 }

--- a/src/modules/data/TxInput.ts
+++ b/src/modules/data/TxInput.ts
@@ -84,4 +84,13 @@ export class TxInput
             "signature": this.signature
         }
     }
+
+    /**
+     * The instance consisting of zero values for all bytes.
+     * @returns The instance of TxInput
+     */
+    static get init(): TxInput
+    {
+        return new TxInput(Hash.init, Signature.init);
+    }
 }

--- a/src/modules/data/TxInput.ts
+++ b/src/modules/data/TxInput.ts
@@ -13,7 +13,7 @@
 
 import { Hash } from './Hash';
 import { Signature } from './Signature';
-import { Validator, ITxInputs } from './validator';
+import { Validator, ITxInput } from './validator';
 
 import { SmartBuffer } from 'smart-buffer';
 
@@ -22,7 +22,7 @@ import { SmartBuffer } from 'smart-buffer';
  * Convert JSON object to TypeScript's instance.
  * An exception occurs if the required property is not present.
  */
-export class TxInputs
+export class TxInput
 {
     /**
      * The hash of the UTXO to be spent
@@ -60,8 +60,8 @@ export class TxInputs
         if (key !== "")
             return value;
 
-        Validator.isValidOtherwiseThrow<ITxInputs>('TxInputs', value);
-        return new TxInputs(
+        Validator.isValidOtherwiseThrow<ITxInput>('TxInput', value);
+        return new TxInput(
             new Hash(value.utxo), new Signature(value.signature));
     }
 

--- a/src/modules/data/TxInput.ts
+++ b/src/modules/data/TxInput.ts
@@ -11,8 +11,9 @@
 
 *******************************************************************************/
 
-import { Hash } from './Hash';
+import { Hash, hashFull, makeUTXOKey } from './Hash';
 import { Signature } from './Signature';
+import { Transaction } from './Transaction';
 import { Validator, ITxInput } from './validator';
 
 import { SmartBuffer } from 'smart-buffer';
@@ -36,13 +37,45 @@ export class TxInput
 
     /**
      * Constructor
-     * @param utxo - The hash of the UTXO to be spent
-     * @param signature - A signature that should be verified using public key of the output in the previous transaction
+     * @param first  UTXO or hash of transaction or instance of Transaction
+     * @param second Instance of Signature or index of Outputs
      */
-    constructor (utxo: Hash, signature: Signature)
+    constructor (first: Hash | Transaction, second?: Signature | bigint)
     {
-        this.utxo = utxo;
-        this.signature = signature;
+        // constructor (first: Hash, second: Signature) {}
+        // first is the hash of the utxo
+        // second is the instance of the Signature
+        if ((first instanceof Hash) && (second instanceof Signature))
+        {
+            this.utxo = first;
+            this.signature = second;
+        }
+        // constructor (first: Transaction, second: bigint) {}
+        // first is the instance of the previous transaction
+        // second is the index of the output in the previous transaction
+        else if ((first instanceof Transaction) && (typeof second === 'bigint'))
+        {
+            this.utxo = makeUTXOKey(hashFull(first), second);
+            this.signature = Signature.init;
+        }
+        // constructor (first: Hash, second: bigint) {}
+        // first is the hash of the transaction
+        // second is the index of the output in the previous transaction
+        else if ((first instanceof Hash) && (typeof second === 'bigint'))
+        {
+            this.utxo = makeUTXOKey(first, second);
+            this.signature = Signature.init;
+        }
+        // constructor (first: Hash) {}
+        // first is the hash of the utxo
+        // second is undefined
+        else if (first instanceof Hash)
+        {
+            this.utxo = first;
+            this.signature = Signature.init;
+        }
+        else
+            throw new Error("The entered parameters are not supported by the constructor of TxInput.")
     }
 
     /**

--- a/src/modules/data/TxInputs.ts
+++ b/src/modules/data/TxInputs.ts
@@ -73,4 +73,15 @@ export class TxInputs
     {
         this.utxo.computeHash(buffer);
     }
+
+    /**
+     * Converts this object to its JSON representation
+     */
+    public toJSON (key?: string): object
+    {
+        return {
+            "utxo": this.utxo,
+            "signature": this.signature
+        }
+    }
 }

--- a/src/modules/data/TxOutput.ts
+++ b/src/modules/data/TxOutput.ts
@@ -87,4 +87,15 @@ export class TxOutput
             "address": this.address
         }
     }
+
+    /**
+     * The instance consisting of zero values for all bytes.
+     * @returns The instance of TxOutput
+     */
+    static get init(): TxOutput
+    {
+        let res = new TxOutput(BigInt(1), PublicKey.init);
+        res.value = BigInt(0);
+        return res;
+    }
 }

--- a/src/modules/data/TxOutput.ts
+++ b/src/modules/data/TxOutput.ts
@@ -12,7 +12,7 @@
 *******************************************************************************/
 
 import { PublicKey } from './PublicKey';
-import { Validator, ITxOutputs } from './validator';
+import { Validator, ITxOutput } from './validator';
 
 import { SmartBuffer } from 'smart-buffer';
 
@@ -21,7 +21,7 @@ import { SmartBuffer } from 'smart-buffer';
  * Convert JSON object to TypeScript's instance.
  * An exception occurs if the required property is not present.
  */
-export class TxOutputs
+export class TxOutput
 {
     /**
      * The monetary value of this output, in 1/10^7
@@ -61,8 +61,8 @@ export class TxOutputs
         if (key !== "")
             return value;
 
-        Validator.isValidOtherwiseThrow<ITxOutputs>('TxOutputs', value);
-        return new TxOutputs(BigInt(value.value), new PublicKey(value.address));
+        Validator.isValidOtherwiseThrow<ITxOutput>('TxOutput', value);
+        return new TxOutput(BigInt(value.value), new PublicKey(value.address));
     }
 
     /**

--- a/src/modules/data/TxOutputs.ts
+++ b/src/modules/data/TxOutputs.ts
@@ -12,7 +12,6 @@
 *******************************************************************************/
 
 import { PublicKey } from './PublicKey';
-import { Utils } from '../utils/Utils';
 import { Validator, ITxOutputs } from './validator';
 
 import { SmartBuffer } from 'smart-buffer';
@@ -76,5 +75,16 @@ export class TxOutputs
         buf.writeBigUInt64LE(this.value);
         buffer.writeBuffer(buf);
         this.address.computeHash(buffer);
+    }
+
+    /**
+     * Converts this object to its JSON representation
+     */
+    public toJSON (key?: string): object
+    {
+        return {
+            "value": this.value.toString(),
+            "address": this.address
+        }
     }
 }

--- a/src/modules/data/index.ts
+++ b/src/modules/data/index.ts
@@ -21,6 +21,6 @@ export { PreImageInfo } from './PreImageInfo';
 export { PublicKey } from './PublicKey';
 export { Signature } from './Signature';
 export { Transaction, TxType } from './Transaction';
-export { TxInputs } from './TxInputs';
-export { TxOutputs } from './TxOutputs';
+export { TxInput } from './TxInput';
+export { TxOutput } from './TxOutput';
 export { DataPayload } from './DataPayload';

--- a/src/modules/data/schemas/TxInput.json
+++ b/src/modules/data/schemas/TxInput.json
@@ -1,14 +1,14 @@
 {
-  "title": "ITxOutputs",
+  "title": "ITxInput",
   "type": "object",
   "properties": {
-    "value": {
+    "utxo": {
       "type": "string"
     },
-    "address": {
+    "signature": {
       "type": "string"
     }
   },
   "additionalProperties": false,
-  "required": ["value", "address"]
+  "required": ["utxo", "signature"]
 }

--- a/src/modules/data/schemas/TxOutput.json
+++ b/src/modules/data/schemas/TxOutput.json
@@ -1,14 +1,14 @@
 {
-  "title": "ITxInputs",
+  "title": "ITxOutput",
   "type": "object",
   "properties": {
-    "utxo": {
+    "value": {
       "type": "string"
     },
-    "signature": {
+    "address": {
       "type": "string"
     }
   },
   "additionalProperties": false,
-  "required": ["utxo", "signature"]
+  "required": ["value", "address"]
 }

--- a/src/modules/data/validator/index.ts
+++ b/src/modules/data/validator/index.ts
@@ -17,8 +17,8 @@ export { IBlockHeader } from '../types/BlockHeader';
 export { IEnrollment } from '../types/Enrollment';
 export { IPreImageInfo } from '../types/PreImageInfo';
 export { ITransaction } from '../types/Transaction';
-export { ITxInputs } from '../types/TxInputs';
-export { ITxOutputs } from '../types/TxOutputs';
+export { ITxInput } from '../types/TxInput';
+export { ITxOutput } from '../types/TxOutput';
 export { IDataPayload } from '../types/DataPayload';
 
 import Ajv from 'ajv';

--- a/src/modules/storage/LedgerStorage.ts
+++ b/src/modules/storage/LedgerStorage.ts
@@ -13,7 +13,7 @@
 
 import {
     Block, Enrollment, Hash, Height, PreImageInfo, Transaction,
-    TxInputs, TxOutputs, makeUTXOKey, hashFull, TxType
+    TxInput, TxOutput, makeUTXOKey, hashFull, TxType
 } from '../data';
 import { Storages } from './Storages';
 import { Utils, Endian } from '../utils/Utils';
@@ -492,7 +492,7 @@ export class LedgerStorage extends Storages
         }
 
         function save_input (storage: LedgerStorage, height: Height, tx_idx: number,
-            in_idx: number, input: TxInputs): Promise<void>
+            in_idx: number, input: TxInput): Promise<void>
         {
             return new Promise<void>((resolve, reject) =>
             {
@@ -521,7 +521,7 @@ export class LedgerStorage extends Storages
         }
 
         function update_spend_output (storage: LedgerStorage,
-            input: TxInputs): Promise<void>
+            input: TxInput): Promise<void>
         {
             return new Promise<void>((resolve, reject) =>
             {
@@ -542,7 +542,7 @@ export class LedgerStorage extends Storages
 
         function save_output (storage: LedgerStorage, height: Height, tx_idx: number,
             out_idx: number, hash: Hash, utxo_key: Hash,
-            output: TxOutputs): Promise<void>
+            output: TxOutput): Promise<void>
         {
             return new Promise<void>((resolve, reject) =>
             {

--- a/tests/Stoa.test.ts
+++ b/tests/Stoa.test.ts
@@ -211,7 +211,7 @@ describe ('Test of Stoa API Server', () =>
             response = await client.get (uri4.toString());
             assert.strictEqual(response.data.length, 1);
             assert.strictEqual(response.data[0].preimage.distance, null);
-            assert.strictEqual(response.data[0].preimage.hash, Hash.NULL.toString());
+            assert.strictEqual(response.data[0].preimage.hash, Hash.init.toString());
 
             let uri5 = URI(host)
                 .port(port)
@@ -231,7 +231,7 @@ describe ('Test of Stoa API Server', () =>
                 new Hash("0xe0c04a5bd47ffc5b065b7d397e251016310c43dc77220bf803b73f1183da00b0e67602b1f95cb18a0059aa1cdf2f9adafe979998364b38cd5c15d92b9b8fd815");
             const enrollment = new Enrollment(utxo_key, random_seed, 20, enroll_sig);
             const header = new BlockHeader(
-                Hash.NULL, new Height(19n), Hash.NULL, new BitField([]),
+                Hash.init, new Height(19n), Hash.init, new BitField([]),
                 new Signature(Buffer.alloc(Signature.Width)), [ enrollment ]);
             const block = new Block(header, [], []);
 

--- a/tests/ValidationJSON.test.ts
+++ b/tests/ValidationJSON.test.ts
@@ -11,7 +11,7 @@
 
 *******************************************************************************/
 
-import { Transaction, TxInputs, TxOutputs, TxType, PublicKey, DataPayload, Hash, Signature } from "../src/modules/data";
+import { Transaction, TxInput, TxOutput, TxType, PublicKey, DataPayload, Hash, Signature } from "../src/modules/data";
 import { Validator, ITransaction, IEnrollment } from '../src/modules/data/validator';
 
 import * as assert from 'assert';
@@ -158,16 +158,16 @@ describe ('Test that JSON.stringify of Transaction', () =>
         let tx = new Transaction(
             TxType.Payment,
             [
-                new TxInputs(
+                new TxInput(
                     new Hash("0xd9482016835acc6defdfd060216a5890e00cf8f0a79ab0b83d3385fc723cd45bfea66eb3587a684518ff1756951d38bf4f07abda96dcdea1c160a4f83e377c32"),
                     new Signature("0x09039e412cd8bf8cb0364454f6737aaeee9e403e69198e418e87589ea6b3acd6171fe8d29fd6e5d5abc62390fbad0649f62e392be0c3228abd069c14c3fea5bd"))
             ],
             [
-                new TxOutputs(
+                new TxOutput(
                     BigInt("1663400000"),
                     new PublicKey("GCOMMONBGUXXP4RFCYGEF74JDJVPUW2GUENGTKKJECDNO6AGO32CUWGU")
                 ),
-                new TxOutputs(
+                new TxOutput(
                     BigInt("24398336600000"),
                     new PublicKey("GDID227ETHPOMLRLIHVDJSNSJVLDS4D4ANYOUHXPMG2WWEZN5JO473ZO")
                 )

--- a/tests/ValidationJSON.test.ts
+++ b/tests/ValidationJSON.test.ts
@@ -11,6 +11,7 @@
 
 *******************************************************************************/
 
+import { Transaction, TxInputs, TxOutputs, TxType, PublicKey, DataPayload, Hash, Signature } from "../src/modules/data";
 import { Validator, ITransaction, IEnrollment } from '../src/modules/data/validator';
 
 import * as assert from 'assert';
@@ -147,5 +148,32 @@ describe ('Test that validation with JSON schema', () =>
                 "d9883446efe63086925e8803400d7b93d22b1eef5c475098ce08a5b47e8" +
                 "125cf6b04274cc4db34bfd"
         }));
+    });
+});
+
+describe ('Test that JSON.stringify of Transaction', () =>
+{
+    it ('Test that JSON of Transaction', () =>
+    {
+        let tx = new Transaction(
+            TxType.Payment,
+            [
+                new TxInputs(
+                    new Hash("0xd9482016835acc6defdfd060216a5890e00cf8f0a79ab0b83d3385fc723cd45bfea66eb3587a684518ff1756951d38bf4f07abda96dcdea1c160a4f83e377c32"),
+                    new Signature("0x09039e412cd8bf8cb0364454f6737aaeee9e403e69198e418e87589ea6b3acd6171fe8d29fd6e5d5abc62390fbad0649f62e392be0c3228abd069c14c3fea5bd"))
+            ],
+            [
+                new TxOutputs(
+                    BigInt("1663400000"),
+                    new PublicKey("GCOMMONBGUXXP4RFCYGEF74JDJVPUW2GUENGTKKJECDNO6AGO32CUWGU")
+                ),
+                new TxOutputs(
+                    BigInt("24398336600000"),
+                    new PublicKey("GDID227ETHPOMLRLIHVDJSNSJVLDS4D4ANYOUHXPMG2WWEZN5JO473ZO")
+                )
+            ],
+            new DataPayload("0x0001")
+        )
+        assert.strictEqual(JSON.stringify(tx), `{"type":0,"inputs":[{"utxo":"0xd9482016835acc6defdfd060216a5890e00cf8f0a79ab0b83d3385fc723cd45bfea66eb3587a684518ff1756951d38bf4f07abda96dcdea1c160a4f83e377c32","signature":"0x09039e412cd8bf8cb0364454f6737aaeee9e403e69198e418e87589ea6b3acd6171fe8d29fd6e5d5abc62390fbad0649f62e392be0c3228abd069c14c3fea5bd"}],"outputs":[{"value":"1663400000","address":"GCOMMONBGUXXP4RFCYGEF74JDJVPUW2GUENGTKKJECDNO6AGO32CUWGU"},{"value":"24398336600000","address":"GDID227ETHPOMLRLIHVDJSNSJVLDS4D4ANYOUHXPMG2WWEZN5JO473ZO"}],"payload":"0x0001"}`);
     });
 });

--- a/tests/hash.test.ts
+++ b/tests/hash.test.ts
@@ -12,6 +12,7 @@
 *******************************************************************************/
 
 import { Block, Hash, hash, hashFull, hashMulti, makeUTXOKey } from '../src/modules/data'
+import { Transaction, TxInput, TxOutput, TxType, PublicKey, DataPayload, Signature } from "../src/modules/data";
 import { sample_data } from './Utils';
 
 import * as assert from 'assert';
@@ -71,6 +72,40 @@ describe('Hash', () => {
             '0x7c95c29b184e47fbd32e58e5abd42c6e22e8bd5a7e934ab049d21df545e09' +
             'c2e33bb2b89df2e59ee01eb2519b1508284b577f66a76d42546b65a6813e592' +
             'bb84');
+    });
+
+    // See_Also: https://github.com/bpfkorea/agora/blob/dac8b3ea6500af68a99c0248c3ade8ab821ee9ef/source/agora/consensus/data/Transaction.d#L203-L229
+    it ('Test for hash value of transaction data', () =>
+    {
+        let payment_tx = new Transaction(
+            TxType.Payment,
+            [
+                new TxInput(Hash.init, BigInt(0))
+            ],
+            [
+                TxOutput.init
+            ],
+            DataPayload.init
+        );
+
+        assert.strictEqual(hashFull(payment_tx).toString(),
+            "0x35927f79ab7f2c8273f5dc24bb1efa5ebe3ac050fd4fd84d014b51124d0322ed" +
+            "709225b92ba28b3ee6b70144d4acafb9a5289fc48ecb4a4f273b537837c78cb0");
+
+        let freeze_tx = new Transaction(
+            TxType.Freeze,
+            [
+                new TxInput(Hash.init, BigInt(0))
+            ],
+            [
+                TxOutput.init
+            ],
+            DataPayload.init
+        );
+
+        assert.strictEqual(hashFull(freeze_tx).toString(),
+            "0x0277044f0628605485a8f8a999f9a2519231e8c59c1568ef2dac2f241ce569d8" +
+            "54e15f950e0fd3d88460309d3e0ef3fbd57b8f5af998f8bacbe391ddb9aea328");
     });
 });
 


### PR DESCRIPTION
I worked on the ability to easily create a Transaction object and also convert it to JSON.
I added the methods `toJSON` for JSON serialization.
I renamed TxOutputs to TxOutput, TxInputs to TxInput.
I added a method that returns an instance with initialized values.
I enabled the constructor of `TxInput` to be overload.

Relates to #180 