### PR TITLE
Fix failures that occur in test code

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -35,19 +35,24 @@ const stoa: Stoa = new Stoa(config.database.filename,
     config.server.address
     );
 
-stoa.start().then(() => {
-    logger.info(`Listening to requests on: ${config.server.address}:${config.server.port}`);
+stoa.createStorage().then(() => {
+    stoa.start().then(() => {
+        logger.info(`Listening to requests on: ${config.server.address}:${config.server.port}`);
+    }).catch((error) => {
+        // handle specific listen errors with friendly messages
+        switch (error.code) {
+            case 'EACCES':
+                logger.error(`${config.server.port} requires elevated privileges`);
+                break;
+            case 'EADDRINUSE':
+                logger.error(`Port ${config.server.port} is already in use`);
+                break;
+            default:
+                logger.error(`An error occured while starting the server: ${error.stack}`);
+        }
+        process.exit(1);
+    })
 }).catch((error) => {
-    // handle specific listen errors with friendly messages
-    switch (error.code) {
-        case 'EACCES':
-            logger.error(`${config.server.port} requires elevated privileges`);
-            break;
-        case 'EADDRINUSE':
-            logger.error(`Port ${config.server.port} is already in use`);
-            break;
-        default:
-            logger.error(`An error occured while starting the server: ${error.stack}`);
-    }
+    logger.error(`Failed to create LedgerStorage: ${error}`);
     process.exit(1);
 });

--- a/tests/Recovery.test.ts
+++ b/tests/Recovery.test.ts
@@ -84,9 +84,14 @@ describe ('Test of Recovery', () =>
         return agora_node.stop();
     });
 
-    beforeEach ('Start TestStoa', () =>
+    beforeEach ('Create TestStoa', () =>
     {
         stoa_server = new TestRecoveryStoa(agora_addr, stoa_addr.port);
+        return stoa_server.createStorage();
+    });
+
+    beforeEach ('Start TestStoa', () =>
+    {
         return stoa_server.start();
     });
 

--- a/tests/Stoa.test.ts
+++ b/tests/Stoa.test.ts
@@ -42,9 +42,14 @@ describe ('Test of Stoa API Server', () =>
         });
     });
 
-    before ('Start Stoa API Server', () =>
+    before ('Create TestStoa', () =>
     {
         stoa_server = new TestStoa(new URL("http://127.0.0.1:2826"), port);
+        return stoa_server.createStorage();
+    });
+
+    before ('Start TestStoa', () =>
+    {
         return stoa_server.start();
     });
 

--- a/tests/Stoa.test.ts
+++ b/tests/Stoa.test.ts
@@ -35,13 +35,17 @@ describe ('Test of Stoa API Server', () =>
     let agora_server: TestAgora;
     let client = axios.create();
 
-    before ('Start Stoa API Server and a fake Agora', () =>
+    before ('Start a fake Agora', () =>
     {
-        let prom = new Promise<void>((resolve, reject) => {
+        return new Promise<void>((resolve, reject) => {
             agora_server = new TestAgora("2826", sample_data, resolve);
         });
+    });
+
+    before ('Start Stoa API Server', () =>
+    {
         stoa_server = new TestStoa(new URL("http://127.0.0.1:2826"), port);
-        return prom.then(() => { return stoa_server.start() });
+        return stoa_server.start();
     });
 
     after ('Stop Stoa and Agora server instances', () =>


### PR DESCRIPTION
1. I changed to separate fake Agora and Stoa when preparing for the test.
    This is to avoid using the Promise-chain in Mocha.
2. I detached a method for creating LedgerStorage from the Stoa constructor
    This is to proceed with follow-up work after the creation of LedgerStorage is completed. 
    Because Promise cannot be returned from the constructor of Stoa, a separate method was implemented.

Relates to #190 