### PR TITLE
Rename and add fields in table `tx_inputs`

### DIFF
--- a/docs/Database_Schema.md
+++ b/docs/Database_Schema.md
@@ -99,17 +99,17 @@ CREATE TABLE IF NOT EXISTS "transactions" (
 |:----------------- |:--------- |:--:|:--------:| -------- | --------- |
 | block_height      | INTEGER   | Y  | Y        |          | The height of the block|
 | tx_index          | INTEGER   | Y  | Y        |          | The index of this transaction in the block's transactions array|
+| in_index          | INTEGER   | Y  | Y        |          | The index of this input in the Transaction's inputs array|
 | utxo              | BLOB      | Y  | Y        |          | The hash of the UTXO to be spent|
-| out_index         | INTEGER   |    | Y        |          | The index of the output in the previous transaction|
 ### _Create Script_
 
 ```sql
 CREATE TABLE IF NOT EXISTS "tx_inputs" (
     "block_height"          INTEGER NOT NULL,
     "tx_index"              INTEGER NOT NULL,
+    "in_index"              INTEGER NOT NULL,
     "utxo"                  BLOB    NOT NULL,
-    "out_index"             INTEGER NOT NULL,
-    PRIMARY KEY("block_height","tx_index","utxo")
+    PRIMARY KEY("block_height","tx_index","in_index","utxo")
 )
 ```
 ----

--- a/docs/Database_Schema.md
+++ b/docs/Database_Schema.md
@@ -101,6 +101,7 @@ CREATE TABLE IF NOT EXISTS "transactions" (
 | tx_index          | INTEGER   | Y  | Y        |          | The index of this transaction in the block's transactions array|
 | in_index          | INTEGER   | Y  | Y        |          | The index of this input in the Transaction's inputs array|
 | utxo              | BLOB      | Y  | Y        |          | The hash of the UTXO to be spent|
+| signature         | BLOB      |    | Y        |          | The signature of this transaction input|
 ### _Create Script_
 
 ```sql
@@ -109,6 +110,7 @@ CREATE TABLE IF NOT EXISTS "tx_inputs" (
     "tx_index"              INTEGER NOT NULL,
     "in_index"              INTEGER NOT NULL,
     "utxo"                  BLOB    NOT NULL,
+    "signature"             BLOB    NOT NULL,
     PRIMARY KEY("block_height","tx_index","in_index","utxo")
 )
 ```

--- a/src/modules/storage/LedgerStorage.ts
+++ b/src/modules/storage/LedgerStorage.ts
@@ -98,6 +98,7 @@ export class LedgerStorage extends Storages
             tx_index            INTEGER NOT NULL,
             in_index            INTEGER NOT NULL,
             utxo                BLOB    NOT NULL,
+            signature           BLOB    NOT NULL,
             PRIMARY KEY(block_height, tx_index, in_index, utxo)
         );
 
@@ -497,14 +498,15 @@ export class LedgerStorage extends Storages
             {
                 storage.run(
                     `INSERT INTO tx_inputs
-                        (block_height, tx_index, in_index, utxo)
+                        (block_height, tx_index, in_index, utxo, signature)
                     VALUES
-                        (?, ?, ?, ?)`,
+                        (?, ?, ?, ?, ?)`,
                     [
                         height.toString(),
                         tx_idx,
                         in_idx,
-                        input.utxo.toBinary(Endian.Little)
+                        input.utxo.toBinary(Endian.Little),
+                        input.signature.toBinary(Endian.Little)
                     ]
                 )
                     .then(() =>
@@ -683,7 +685,7 @@ export class LedgerStorage extends Storages
     {
         let sql =
         `SELECT
-            block_height, tx_index, in_index, utxo
+            block_height, tx_index, in_index, utxo, signature
         FROM
             tx_inputs
         WHERE block_height = ? AND tx_index = ?`;


### PR DESCRIPTION
In table `tx_inputs`, `block_height`, `tx_index`, and `in_index` are the basic data for restoring block data from the data.
The remaining `utxo` is the data about the input of the transaction.
Added missing `signature` field.