### PR TITLE
Logging only when a new pre-image is updated in the database

### DIFF
--- a/src/Stoa.ts
+++ b/src/Stoa.ts
@@ -597,9 +597,10 @@ class Stoa extends WebService
                 try
                 {
                     let pre_image = PreImageInfo.reviver("", stored_data.data);
+                    let changes = await this.ledger_storage.updatePreImage(pre_image);
 
-                    await this.ledger_storage.updatePreImage(pre_image);
-                    logger.info(`Saved a pre-image enroll_key : ${pre_image.enroll_key.toString().substr(0, 18)}, ` +
+                    if (changes)
+                        logger.info(`Saved a pre-image enroll_key : ${pre_image.enroll_key.toString().substr(0, 18)}, ` +
                         `hash : ${pre_image.hash.toString().substr(0, 18)}, distance : ${pre_image.distance}`);
                     resolve();
                 }

--- a/src/modules/storage/LedgerStorage.ts
+++ b/src/modules/storage/LedgerStorage.ts
@@ -16,6 +16,7 @@ import {
     TxInput, TxOutput, makeUTXOKey, hashFull, TxType,
     Utils, Endian
 } from 'boa-sdk-ts';
+import { logger } from '../common/Logger';
 import { Storages } from './Storages';
 
 /**
@@ -340,10 +341,10 @@ export class LedgerStorage extends Storages
     /**
      * Update a preImage to database
      */
-    public updatePreImage (pre_image: PreImageInfo): Promise<void>
+    public updatePreImage (pre_image: PreImageInfo): Promise<number>
     {
         let enroll_key = pre_image.enroll_key.toBinary(Endian.Little);
-        return new Promise<void>((resolve, reject) =>
+        return new Promise<number>((resolve, reject) =>
         {
             this.run(
                 `UPDATE validators
@@ -374,9 +375,9 @@ export class LedgerStorage extends Storages
                     pre_image.distance,
                     pre_image.distance
                 ])
-                .then(() =>
+                .then((result) =>
                 {
-                    resolve();
+                    resolve(result.changes);
                 })
                 .catch((err) =>
                 {

--- a/src/modules/storage/Storages.ts
+++ b/src/modules/storage/Storages.ts
@@ -116,10 +116,10 @@ export class Storages
     {
         return new Promise<sqlite.RunResult>((resolve, reject) =>
         {
-            this.db.run(sql, params, (err: Error | null, result: sqlite.RunResult) =>
+            this.db.run(sql, params, function(err: Error)
             {
                 if (!err)
-                    resolve(result);
+                    resolve(this);
                 else
                     reject(err);
             });


### PR DESCRIPTION
The problem was that It used fat arrow for callback declaration
Using the otherwise anonymous function, this is bounded in dynamic scope and 
so `this.changes` is valued.

If it updated the pre-image, return the updated count.
This corrects the error of printing the log that has always been saved.

Related to https://github.com/bpfkorea/agora/issues/1322