### PR TITLE
Fix bug where catching up does not work in special case

### DIFF
--- a/src/Stoa.ts
+++ b/src/Stoa.ts
@@ -625,7 +625,7 @@ class Stoa extends WebService
             {
                 let expected_height = await this.ledger_storage.getExpectedBlockHeight();
 
-                if (height.value > expected_height.value) {
+                if (height.value >= expected_height.value) {
                     while (true) {
                         if (await this.recoverBlock(null, height, expected_height))
                             break;


### PR DESCRIPTION
Special case:
Agora only has Genesis blocks, and Stoa doesn't have any.