### PR TITLE
Change status code if data does not exist on endpoint `/utxo:address`

### DIFF
--- a/src/Stoa.ts
+++ b/src/Stoa.ts
@@ -353,7 +353,7 @@ class Stoa extends WebService
             .then((rows: any[]) => {
                 if (!rows.length)
                 {
-                    res.status(400).send(`The UTXO not found. address': (${address})`);
+                    res.status(204).send(`The UTXO not found. address': (${address})`);
                     return;
                 }
 


### PR DESCRIPTION
Change the status code from 400 to 204 because it is not an error if endpoint `/utxo:address` has no data.