### PR TITLE
Add a field to the results of an endpoint

### DIFF
--- a/docs/Database_Schema.md
+++ b/docs/Database_Schema.md
@@ -100,6 +100,7 @@ CREATE TABLE IF NOT EXISTS "transactions" (
 | block_height      | INTEGER   | Y  | Y        |          | The height of the block|
 | tx_index          | INTEGER   | Y  | Y        |          | The index of this transaction in the block's transactions array|
 | in_index          | INTEGER   | Y  | Y        |          | The index of this input in the Transaction's inputs array|
+| tx_hash           | BLOB      |    | Y        |          | The hash of transaction |
 | utxo              | BLOB      | Y  | Y        |          | The hash of the UTXO to be spent|
 | signature         | BLOB      |    | Y        |          | The signature of this transaction input|
 ### _Create Script_
@@ -109,6 +110,7 @@ CREATE TABLE IF NOT EXISTS "tx_inputs" (
     "block_height"          INTEGER NOT NULL,
     "tx_index"              INTEGER NOT NULL,
     "in_index"              INTEGER NOT NULL,
+    "tx_hash"               BLOB    NOT NULL,
     "utxo"                  BLOB    NOT NULL,
     "signature"             BLOB    NOT NULL,
     PRIMARY KEY("block_height","tx_index","in_index","utxo")

--- a/src/Stoa.ts
+++ b/src/Stoa.ts
@@ -4,7 +4,8 @@ import { LedgerStorage } from './modules/storage/LedgerStorage';
 import { logger } from './modules/common/Logger';
 import { Height, PreImageInfo, Hash, hash, Block, Utils, Endian } from 'boa-sdk-ts';
 import { WebService } from './modules/service/WebService';
-import { ValidatorData, IPreimage, IUnspentTxOutput, ITxHistoryElement, ITxOverview } from './Types';
+import { ValidatorData, IPreimage, IUnspentTxOutput,
+    ITxHistoryElement, ITxOverview, ConvertTypes } from './Types';
 
 import bodyParser from 'body-parser';
 import cors from 'cors';
@@ -436,20 +437,21 @@ class Stoa extends WebService
                     return;
                 }
 
-                // TODO We should apply the block's timestamp to this method when it is added.
                 let out_put: Array<ITxHistoryElement> = [];
-                let base_time = Date.UTC(2020, 0);
                 for (const row of rows)
                 {
                     out_put.push({
+                        display_tx_type: ConvertTypes.DisplayTxTypeToString(row.display_tx_type),
                         address: row.address,
+                        peer: row.peer,
+                        peer_count: row.peer_count,
                         height: BigInt(row.height).toString(),
-                        time: base_time + row.height * 10 * 60000,
+                        time: row.block_time,
                         tx_hash: new Hash(row.tx_hash, Endian.Little).toString(),
-                        type: row.type,
+                        tx_type: ConvertTypes.TxTypeToString(row.type),
                         amount: BigInt(row.amount).toString(),
                         unlock_height: BigInt(row.unlock_height).toString(),
-                        unlock_time: base_time + row.unlock_height * 10 * 60000
+                        unlock_time: row.unlock_time
                     });
                 }
                 res.status(200).send(JSON.stringify(out_put));

--- a/src/Stoa.ts
+++ b/src/Stoa.ts
@@ -474,7 +474,7 @@ class Stoa extends WebService
     {
         let tx_hash: string = String(req.params.hash);
 
-        logger.http(`GET //wallet/transaction/overview/${tx_hash}}`);
+        logger.http(`GET /wallet/transaction/overview/${tx_hash}}`);
 
         this.ledger_storage.getWalletTransactionOverview(tx_hash)
             .then((data: any) => {
@@ -491,25 +491,24 @@ class Stoa extends WebService
                     return;
                 }
 
-                let base_time = Date.UTC(2020, 0);
-
                 let overview: ITxOverview = {
                     height: BigInt(data.tx[0].height).toString(),
-                    time: base_time + data.tx[0].height * 10 * 60000,
+                    time: data.tx[0].block_time,
                     tx_hash: new Hash(data.tx[0].tx_hash, Endian.Little).toString(),
-                    type: data.tx[0].type,
+                    tx_type: ConvertTypes.TxTypeToString(data.tx[0].type),
                     unlock_height: BigInt(data.tx[0].unlock_height).toString(),
-                    unlock_time: base_time + data.tx[0].unlock_height * 10 * 60000,
+                    unlock_time: data.tx[0].unlock_time,
+                    payload: (data.tx[0].payload !== null) ? new Hash(data.tx[0].payload, Endian.Little).toString() : "",
                     senders: [],
                     receivers: [],
                     fee: "0"
                 };
 
                 for (let elem of data.senders)
-                    overview.senders.push({address: elem.address, amount: elem.amount});
+                    overview.senders.push({address: elem.address, amount: elem.amount, utxo: new Hash(elem.utxo, Endian.Little).toString()});
 
                 for (let elem of data.receivers)
-                    overview.receivers.push({address: elem.address, amount: elem.amount});
+                    overview.receivers.push({address: elem.address, amount: elem.amount, utxo: new Hash(elem.utxo, Endian.Little).toString()});
 
                 res.status(200).send(JSON.stringify(overview));
             })

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -11,7 +11,7 @@
 
  *******************************************************************************/
 
-import { Height } from 'boa-sdk-ts';
+import { Height, TxType } from 'boa-sdk-ts';
 
 /**
  * The interface of the Validator
@@ -68,9 +68,24 @@ export interface IUnspentTxOutput
 export interface ITxHistoryElement
 {
     /**
+     * The transaction type of wallet ('inbound', 'outbound', 'freeze', 'payload')
+     */
+    display_tx_type: string;
+
+    /**
      * Address, Public key
      */
     address: string;
+
+    /**
+     * The address that sent (or received) the funds
+     */
+    peer: string;
+
+    /**
+     * The number of the peer
+     */
+    peer_count: number;
 
     /**
      * Block height
@@ -90,7 +105,7 @@ export interface ITxHistoryElement
     /**
      * Transaction type
      */
-    type: number;
+    tx_type: string;
 
     /**
      * Amount
@@ -173,4 +188,41 @@ export interface ITxOverviewElement
      * Amount
      */
     amount: string;
+}
+
+
+/**
+ * Define the types of transactions to be displayed in various applications
+ */
+export enum DisplayTxType
+{
+    Inbound = 0,
+    Outbound = 1,
+    Freeze = 2,
+    Payload = 3
+}
+
+/**
+ * Class that converts various enum values into strings
+ */
+export class ConvertTypes
+{
+    static tx_types: Array<string> = ["payment", "freeze"];
+    static display_tx_type: Array<string> = ["inbound", "outbound", "freeze", "payload"];
+
+    public static DisplayTxTypeToString (type: TxType): string
+    {
+        if (type < ConvertTypes.display_tx_type.length)
+            return ConvertTypes.display_tx_type[type];
+        else
+            return "";
+    }
+
+    public static TxTypeToString (type: TxType): string
+    {
+        if (type < ConvertTypes.tx_types.length)
+            return ConvertTypes.tx_types[type];
+        else
+            return "";
+    }
 }

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -146,7 +146,7 @@ export interface ITxOverview
     /**
      * Transaction type
      */
-    type: number;
+    tx_type: string;
 
     /**
      * Block height at which the output of the transaction becomes available
@@ -157,6 +157,11 @@ export interface ITxOverview
      * Time at which the output of the transaction becomes available
      */
     unlock_time: number;
+
+    /**
+     * The transaction data payload
+     */
+    payload: string;
 
     /**
      * The address and amount of the output associated with the transaction input
@@ -188,6 +193,11 @@ export interface ITxOverviewElement
      * Amount
      */
     amount: string;
+
+    /**
+     * The hash of UTXO
+     */
+    utxo: string;
 }
 
 

--- a/tests/WalletAPI.test.ts
+++ b/tests/WalletAPI.test.ts
@@ -100,38 +100,40 @@ describe ('Test of Stoa API for the wallet', () =>
             });
     });
 
-    it ('Test of the path /wallet/transaction/overview', (doneIt: () => void) =>
+    it ('Test of the path /wallet/transaction/overview', () =>
     {
         let uri = URI(host)
             .port(port)
             .directory("/wallet/transaction/overview")
             .filename("0x6f2e7b2cb25a2146970e6e495ba1cec378a90acdc7817804dd9f41e1ba34a6c55fad4b24395d2da4f6a8d14a4fb2cfbc1cdbb486acda8094e0ab936d56e031c5")
 
-        client.get (uri.toString())
+        return client.get (uri.toString())
             .then((response) => {
                 let expected = {
                     height: '9',
                     time: 1577842200000,
                     tx_hash: '0x6f2e7b2cb25a2146970e6e495ba1cec378a90acdc7817804dd9f41e1ba34a6c55fad4b24395d2da4f6a8d14a4fb2cfbc1cdbb486acda8094e0ab936d56e031c5',
-                    type: 0,
+                    tx_type: "payment",
                     unlock_height: '10',
                     unlock_time: 1577842800000,
+                    payload: '',
                     senders: [
                         {
                             address: 'GDI22L72RGWY3BEFK2VUBWMJMSZU5SQNCQLN5FCF467RFIYN5KMY3YJT',
-                            amount: 610000000000000
+                            amount: 610000000000000,
+                            utxo: '0x73d7f7994156c073c764e59ad65522ea58d28992ac5a857a59475168745f1b9ac160a059e77a7f342d2a6b12f20b8f4b42e7131aeb65dd1cf912069532c045a3'
                         }
                     ],
                     receivers: [
                         {
                             address: 'GDA225RGC4GOCVASSAMROSWJSGNOZX2IGPXZG52ESDSKQW2VN6UJFKWI',
-                            amount: 610000000000000
+                            amount: 610000000000000,
+                            utxo: '0x71c16727e6eb2ca6c8244b8071a78c5bb4ec9253234e51b3f9c8e901cb1c71ee34dd0c4c09bbc16591bf09ecbe962280d8b5e45945490ebe8e6a9fc49f8530dd'
                         }
                     ],
                     fee: '0'
                 };
                 assert.deepStrictEqual(expected, response.data);
             })
-            .finally(doneIt);
     });
 });


### PR DESCRIPTION
GET /wallet/transactions/history/:addresses
Three additional fields have been added:

```
    // The transaction type of wallet ('inbound', 'outbound', 'freeze', 'payload')
    wallet_tx_type: string
    // The address that sent (or received) the funds
    peer: string;
    // The number of peers
    peer_count: number;
```

GET /wallet/transaction/overview/:hash
The following field has been added
```
    // The hash of UTXO
    utxo: string;
    // The transaction data payload
    payload: string;

```