### PR TITLE
Add filtering capabilities for wallet endpoint `/wallet/transactions/history/:address` 

### DIFF
--- a/docs/Database_Schema.md
+++ b/docs/Database_Schema.md
@@ -74,6 +74,7 @@ CREATE TABLE IF NOT EXISTS "enrollments" (
 | unlock_height     | INTEGER   |    | Y        |          | Height of the block to be unlock|
 | inputs_count      | INTEGER   |    | Y        |          | The number of inputs in the transaction |
 | outputs_count     | INTEGER   |    | Y        |          | The number of outputs in the transaction |
+| payload_size      | INTEGER   |    | Y        |          | The size of data payload in the transaction |
 
 ### _Create Script_
 
@@ -86,6 +87,7 @@ CREATE TABLE IF NOT EXISTS "transactions" (
     "unlock_height"         INTEGER NOT NULL,
     "inputs_count"          INTEGER NOT NULL,
     "outputs_count"         INTEGER NOT NULL,
+    "payload_size"          INTEGER NOT NULL,
     PRIMARY KEY("block_height","tx_index")
 )
 ```

--- a/src/Stoa.ts
+++ b/src/Stoa.ts
@@ -124,7 +124,7 @@ class Stoa extends WebService
         this.app.get("/validators", this.getValidators.bind(this));
         this.app.get("/validator/:address", this.getValidator.bind(this));
         this.app.get("/utxo/:address", this.getUTXO.bind(this));
-        this.app.get("/wallet/transactions/history/:addresses", this.getWalletTransactionsHistory.bind(this));
+        this.app.get("/wallet/transactions/history/:address", this.getWalletTransactionsHistory.bind(this));
         this.app.get("/wallet/transaction/overview/:hash", this.getWalletTransactionOverview.bind(this));
         this.app.post("/block_externalized", this.putBlock.bind(this));
         this.app.post("/preimage_received", this.putPreImage.bind(this));
@@ -381,11 +381,11 @@ class Stoa extends WebService
     }
 
     /**
-     * GET /wallet/transactions/history/:addresses
+     * GET /wallet/transactions/history/:address
      *
-     * Called when a request is received through the `/wallet/transactions/history/:addresses` handler
+     * Called when a request is received through the `/wallet/transactions/history/:address` handler
      * ```
-     * The parameter `addresses` are the form of multiple addresses separated by `,`.
+     * The parameter `address` are the address to query.
      * The parameter `pageSize` is the maximum size that can be obtained
      *      from one query, default is 10
      * The parameter `page` is the number on the page, this value begins with 1,
@@ -409,9 +409,9 @@ class Stoa extends WebService
      */
     private getWalletTransactionsHistory (req: express.Request, res: express.Response)
     {
-        let params_addresses: string = String(req.params.addresses);
+        let address: string = String(req.params.address);
 
-        logger.http(`GET /wallet/transactions/history/${params_addresses}}`);
+        logger.http(`GET /wallet/transactions/history/${address}}`);
 
         let filter_begin: number | undefined;
         let filter_end: number | undefined;
@@ -505,19 +505,12 @@ class Stoa extends WebService
             ? req.query.peer.toString()
             : undefined;
 
-        let addresses:Array<string> = params_addresses.split(',');
-        if (addresses.length > 10)
-        {
-            res.status(400).send(`The number of addresses cannot be a number greater than 10: ${addresses.length}`);
-            return;
-        }
-
-        this.ledger_storage.getWalletTransactionsHistory(addresses, page_size, page,
+        this.ledger_storage.getWalletTransactionsHistory(address, page_size, page,
             filter_type, filter_begin, filter_end, filter_peer)
             .then((rows: any[]) => {
                 if (!rows.length)
                 {
-                    res.status(204).send(`The data not exist. 'addresses': (${params_addresses})`);
+                    res.status(204).send(`The data not exist. 'addresses': (${address})`);
                     return;
                 }
 

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -235,4 +235,9 @@ export class ConvertTypes
         else
             return "";
     }
+
+    public static toDisplayTxType (type: string): DisplayTxType
+    {
+        return ConvertTypes.display_tx_type.findIndex(m => (m === type.trim().toLowerCase()));
+    }
 }

--- a/src/modules/storage/LedgerStorage.ts
+++ b/src/modules/storage/LedgerStorage.ts
@@ -859,7 +859,7 @@ export class LedgerStorage extends Storages
      * Returns data sorted in descending order by block height.
      * The most recent transaction is located at the front.
      *
-     * @param addresses An array of addresses that want to be inquired.
+     * @param address   An address that want to be inquired.
      * @param page_size Maximum record count that can be obtained from one query
      * @param page      The number on the page, this value begins with 1
      * @param type      The parameter `type` is the type of transaction to query.
@@ -869,11 +869,9 @@ export class LedgerStorage extends Storages
      * Peer is the withdrawal address in the inbound transaction and a deposit address
      * in the outbound transaction address of their counterparts.
      */
-    public getWalletTransactionsHistory (addresses: string[], page_size: number, page: number,
+    public getWalletTransactionsHistory (address: string, page_size: number, page: number,
         type: Array<number>, begin?: number, end?: number, peer?: string) : Promise<any[]>
     {
-        let accounts = addresses.map((n) => `'${n}'`).join(',');
-
         // TODO We should apply the block's timestamp to this method when it is added
         let filter_type = 'AND FTX.display_tx_type in (' + type.map(n =>`${n}`).join(',') + ')'
         let filter_date = ((begin !== undefined) && (end !== undefined))
@@ -978,7 +976,7 @@ export class LedgerStorage extends Storages
                         INNER JOIN transactions T ON (T.tx_hash = I.tx_hash)
                         INNER JOIN blocks B ON (B.height = T.block_height)
                     WHERE
-                        S.address IN (${accounts})
+                        S.address = '${address}'
                         ${filter_date}
                     GROUP BY T.tx_hash, S.address
 
@@ -999,7 +997,7 @@ export class LedgerStorage extends Storages
                         INNER JOIN transactions T ON (T.tx_hash = O.tx_hash)
                         INNER JOIN blocks B ON (B.height = T.block_height)
                     WHERE
-                        O.address IN (${accounts})
+                        O.address = '${address}'
                         ${filter_date}
                     GROUP BY T.tx_hash, O.address
                 ) AS TX

--- a/tests/WalletAPI.test.ts
+++ b/tests/WalletAPI.test.ts
@@ -75,14 +75,14 @@ describe ('Test of Stoa API for the wallet', () =>
         let uri = URI(host)
             .port(port)
             .directory("/wallet/transactions/history")
-            .filename("GDG22B5FTPXE5THQMCTGDUC4LF2N4DFF44PGX2LIFG4WNUZZAT4L6ZGD,GDA225RGC4GOCVASSAMROSWJSGNOZX2IGPXZG52ESDSKQW2VN6UJFKWI")
+            .filename("GDG22B5FTPXE5THQMCTGDUC4LF2N4DFF44PGX2LIFG4WNUZZAT4L6ZGD")
             .setSearch("pageSize", "10")
             .setSearch("page", "1");
 
         return client.get (uri.toString())
             .then((response) =>
             {
-                assert.strictEqual(response.data.length, 10);
+                assert.strictEqual(response.data.length, 9);
                 assert.strictEqual(response.data[0].display_tx_type, "inbound");
                 assert.strictEqual(response.data[0].address,
                     "GDG22B5FTPXE5THQMCTGDUC4LF2N4DFF44PGX2LIFG4WNUZZAT4L6ZGD");
@@ -162,7 +162,7 @@ describe ('Test of Stoa API for the wallet', () =>
         let uri = URI(host)
             .port(port)
             .directory("/wallet/transactions/history")
-            .filename("GDG22B5FTPXE5THQMCTGDUC4LF2N4DFF44PGX2LIFG4WNUZZAT4L6ZGD,GDA225RGC4GOCVASSAMROSWJSGNOZX2IGPXZG52ESDSKQW2VN6UJFKWI")
+            .filename("GDG22B5FTPXE5THQMCTGDUC4LF2N4DFF44PGX2LIFG4WNUZZAT4L6ZGD")
             .setSearch("pageSize", "10")
             .setSearch("page", "1")
             .setSearch("type", "outbound");
@@ -170,7 +170,7 @@ describe ('Test of Stoa API for the wallet', () =>
         return client.get (uri.toString())
             .then((response) =>
             {
-                assert.strictEqual(response.data.length, 8);
+                assert.strictEqual(response.data.length, 4);
                 assert.strictEqual(response.data[0].display_tx_type, "outbound");
                 assert.strictEqual(response.data[0].address,
                     "GDG22B5FTPXE5THQMCTGDUC4LF2N4DFF44PGX2LIFG4WNUZZAT4L6ZGD");
@@ -192,7 +192,7 @@ describe ('Test of Stoa API for the wallet', () =>
         let uri = URI(host)
             .port(port)
             .directory("/wallet/transactions/history")
-            .filename("GDG22B5FTPXE5THQMCTGDUC4LF2N4DFF44PGX2LIFG4WNUZZAT4L6ZGD,GDA225RGC4GOCVASSAMROSWJSGNOZX2IGPXZG52ESDSKQW2VN6UJFKWI")
+            .filename("GDG22B5FTPXE5THQMCTGDUC4LF2N4DFF44PGX2LIFG4WNUZZAT4L6ZGD")
             .setSearch("pageSize", "10")
             .setSearch("page", "1")
             .setSearch("beginDate", "1577837400000")
@@ -201,10 +201,10 @@ describe ('Test of Stoa API for the wallet', () =>
         return client.get (uri.toString())
             .then((response) =>
             {
-                assert.strictEqual(response.data.length, 2);
+                assert.strictEqual(response.data.length, 1);
                 assert.strictEqual(response.data[0].display_tx_type, "inbound");
                 assert.strictEqual(response.data[0].address,
-                    "GDA225RGC4GOCVASSAMROSWJSGNOZX2IGPXZG52ESDSKQW2VN6UJFKWI");
+                    "GDG22B5FTPXE5THQMCTGDUC4LF2N4DFF44PGX2LIFG4WNUZZAT4L6ZGD");
                 assert.strictEqual(response.data[0].peer,
                     "GCOQEOHAUFYUAC6G22FJ3GZRNLGVCCLESEJ2AXBIJ5BJNUVTAERPLRIJ");
                 assert.strictEqual(response.data[0].peer_count, 1);
@@ -212,9 +212,9 @@ describe ('Test of Stoa API for the wallet', () =>
                 assert.strictEqual(response.data[0].tx_type, "payment");
                 assert.strictEqual(response.data[0].amount, "610000000000000");
                 assert.strictEqual(response.data[0].tx_hash,
-                    "0x70afa99af2b052d86716b88270ee3561125953026660ce7920e6726" +
-                    "824810c6c8ff2024f0b273e47bd39d4adf98f2725d78ce21fb02c6916" +
-                    "fe7a770b5b01d75b");
+                    "0x5091c6120ebc2c85ff1414225f3813ab80e13275507f2a3d2c82248" +
+                    "0ca7fa6247a48f5addcefd8193eca836054a9a12fcc6aabbc8e1675bc" +
+                    "749213d7771cde44");
             });
     });
 

--- a/tests/WalletAPI.test.ts
+++ b/tests/WalletAPI.test.ts
@@ -136,4 +136,115 @@ describe ('Test of Stoa API for the wallet', () =>
                 assert.deepStrictEqual(expected, response.data);
             })
     });
+
+    it ('Test of the path /wallet/transactions/history - Filtering - Wrong TransactionType', () =>
+    {
+        let uri = URI(host)
+            .port(port)
+            .directory("/wallet/transactions/history")
+            .filename("GDG22B5FTPXE5THQMCTGDUC4LF2N4DFF44PGX2LIFG4WNUZZAT4L6ZGD")
+            .setSearch("pageSize", "10")
+            .setSearch("page", "1")
+            .setSearch("type", "in,out");
+
+        return client.get (uri.toString())
+            .then((response) =>
+            {
+                assert.strictEqual(response.data.length, 0);
+            })
+            .catch((error) => {
+                assert.strictEqual(error.response.data, "Invalid transaction type: in,out");
+            });
+    });
+
+    it ('Test of the path /wallet/transactions/history - Filtering - TransactionType', () =>
+    {
+        let uri = URI(host)
+            .port(port)
+            .directory("/wallet/transactions/history")
+            .filename("GDG22B5FTPXE5THQMCTGDUC4LF2N4DFF44PGX2LIFG4WNUZZAT4L6ZGD,GDA225RGC4GOCVASSAMROSWJSGNOZX2IGPXZG52ESDSKQW2VN6UJFKWI")
+            .setSearch("pageSize", "10")
+            .setSearch("page", "1")
+            .setSearch("type", "outbound");
+
+        return client.get (uri.toString())
+            .then((response) =>
+            {
+                assert.strictEqual(response.data.length, 8);
+                assert.strictEqual(response.data[0].display_tx_type, "outbound");
+                assert.strictEqual(response.data[0].address,
+                    "GDG22B5FTPXE5THQMCTGDUC4LF2N4DFF44PGX2LIFG4WNUZZAT4L6ZGD");
+                assert.strictEqual(response.data[0].peer,
+                    "GDO22PFYWMU3YFLKDYP2PVM4PLX2D4BLJ2IRQMIHWJHFS3TZ6ITJMGPU");
+                assert.strictEqual(response.data[0].peer_count, 1);
+                assert.strictEqual(response.data[0].height, "8");
+                assert.strictEqual(response.data[0].tx_type, "payment");
+                assert.strictEqual(response.data[0].amount, "-610000000000000");
+                assert.strictEqual(response.data[0].tx_hash,
+                    "0x4c9b7ff106dde2a2ee1e44bddccae7a660800a7146858c6f7338f79" +
+                    "f5eb7009b5617f9e747e99d9cdcf898209b3470c3e952256a21b5daee" +
+                    "e79f488141558af8");
+            });
+    });
+
+    it ('Test of the path /wallet/transactions/history - Filtering - Date', () =>
+    {
+        let uri = URI(host)
+            .port(port)
+            .directory("/wallet/transactions/history")
+            .filename("GDG22B5FTPXE5THQMCTGDUC4LF2N4DFF44PGX2LIFG4WNUZZAT4L6ZGD,GDA225RGC4GOCVASSAMROSWJSGNOZX2IGPXZG52ESDSKQW2VN6UJFKWI")
+            .setSearch("pageSize", "10")
+            .setSearch("page", "1")
+            .setSearch("beginDate", "1577837400000")
+            .setSearch("endDate", "1577837400000");
+
+        return client.get (uri.toString())
+            .then((response) =>
+            {
+                assert.strictEqual(response.data.length, 2);
+                assert.strictEqual(response.data[0].display_tx_type, "inbound");
+                assert.strictEqual(response.data[0].address,
+                    "GDA225RGC4GOCVASSAMROSWJSGNOZX2IGPXZG52ESDSKQW2VN6UJFKWI");
+                assert.strictEqual(response.data[0].peer,
+                    "GCOQEOHAUFYUAC6G22FJ3GZRNLGVCCLESEJ2AXBIJ5BJNUVTAERPLRIJ");
+                assert.strictEqual(response.data[0].peer_count, 1);
+                assert.strictEqual(response.data[0].height, "1");
+                assert.strictEqual(response.data[0].tx_type, "payment");
+                assert.strictEqual(response.data[0].amount, "610000000000000");
+                assert.strictEqual(response.data[0].tx_hash,
+                    "0x70afa99af2b052d86716b88270ee3561125953026660ce7920e6726" +
+                    "824810c6c8ff2024f0b273e47bd39d4adf98f2725d78ce21fb02c6916" +
+                    "fe7a770b5b01d75b");
+            });
+    });
+
+    it ('Test of the path /wallet/transactions/history - Filtering - Peer', () =>
+    {
+        let uri = URI(host)
+            .port(port)
+            .directory("/wallet/transactions/history")
+            .filename("GDG22B5FTPXE5THQMCTGDUC4LF2N4DFF44PGX2LIFG4WNUZZAT4L6ZGD")
+            .setSearch("pageSize", "10")
+            .setSearch("page", "1")
+            .setSearch("peer", "GCOQEOHAU");
+
+        return client.get (uri.toString())
+            .then((response) =>
+            {
+                assert.strictEqual(response.data.length, 1);
+                assert.strictEqual(response.data[0].display_tx_type, "inbound");
+                assert.strictEqual(response.data[0].address,
+                    "GDG22B5FTPXE5THQMCTGDUC4LF2N4DFF44PGX2LIFG4WNUZZAT4L6ZGD");
+                assert.strictEqual(response.data[0].peer,
+                    "GCOQEOHAUFYUAC6G22FJ3GZRNLGVCCLESEJ2AXBIJ5BJNUVTAERPLRIJ");
+                assert.strictEqual(response.data[0].peer_count, 1);
+                assert.strictEqual(response.data[0].height, "1");
+                assert.strictEqual(response.data[0].tx_type, "payment");
+                assert.strictEqual(response.data[0].amount, "610000000000000");
+                assert.strictEqual(response.data[0].tx_hash,
+                    "0x5091c6120ebc2c85ff1414225f3813ab80e13275507f2a3d2c82248" +
+                    "0ca7fa6247a48f5addcefd8193eca836054a9a12fcc6aabbc8e1675bc" +
+                    "749213d7771cde44");
+            });
+    });
 });


### PR DESCRIPTION
Based on wallet requirements, it implements filtering capabilities for endpoint `/wallet/transactions/history/:addresses` implemented for wallets.

### From `Wallet Requirements Documentation` 
**Filters**
● The ability to filter by **​Transaction type**​. The list show be additive, e.g. one can select both inbound and
outbound transaction, excluding freeze and data;
● A **date range**, comprising of a start date and an end date;
● The ability to filter by a single **peer**, which can be specified by name, or by address. Partial addresses (a
substring of the address) must be supported;

**A detailed description of the field**
● Transaction type​: A visual representation (through a colored icon) of the type of transaction. If the transaction is inbound (funds are added), a green plus sign (“+”) is used. For outbound funds, a red minus sign (“-“) is used. For freezing transactions, a blue snowflake icon should be used. For data storage, the icon and color are not yet defined.
● Peer​: The address that sent (or received) the funds. If there is an associated name, the name must be
displayed.


Dependent on #217 