### PR TITLE
Store a transaction on the transaction pool

### DIFF
--- a/tests/Stoa.test.ts
+++ b/tests/Stoa.test.ts
@@ -16,6 +16,7 @@ import {
 } from 'boa-sdk-ts';
 import {
     sample_data,
+    sample_data2,
     sample_preImageInfo,
     sample_reEnroll_preImageInfo,
     TestAgora,
@@ -346,5 +347,24 @@ describe ('Test of Stoa API Server', () =>
                 assert.ok(!error, error);
             })
             .finally(doneIt);
+    });
+
+    it ('Test of the path /transaction_received', (doneIt: () => void) =>
+    {
+        let uri = URI(host)
+            .port(port)
+            .directory("transaction_received");
+
+        let url = uri.toString();
+        assert.doesNotThrow(async () =>
+        {
+            const block = Block.reviver("", sample_data2);
+            await client.post(url, {transaction: block.txs[0]})
+
+            setTimeout(() =>
+            {
+                doneIt();
+            }, 100);
+        });
     });
 });

--- a/tests/Storage.test.ts
+++ b/tests/Storage.test.ts
@@ -14,7 +14,7 @@
 import * as assert from 'assert';
 import { LedgerStorage } from '../src/modules/storage/LedgerStorage';
 import { Block, Hash, Height, DataPayload, PreImageInfo, SodiumHelper, Endian } from 'boa-sdk-ts';
-import { sample_data, sample_preImageInfo } from "./Utils";
+import { sample_data, sample_data2, sample_preImageInfo } from "./Utils";
 
 import * as fs from 'fs';
 
@@ -449,6 +449,43 @@ describe ('Tests that sending a pre-image', () =>
                         assert.ok(!err, err);
                         doneIt();
                     });
+            })
+            .catch((err) =>
+            {
+                assert.ok(!err, err);
+                doneIt();
+            });
+    });
+});
+
+describe ('Tests storing transaction pools of a transaction', () =>
+{
+    let ledger_storage: LedgerStorage;
+
+    before('Wait for the package libsodium to finish loading', () =>
+    {
+        return SodiumHelper.init();
+    });
+
+    before ('Preparation the ledgerStorage', () =>
+    {
+        return LedgerStorage.make(":memory:")
+            .then((result) => { ledger_storage = result })
+    });
+
+    after ('Close Storage', () =>
+    {
+        ledger_storage.close();
+    });
+
+    it ('Tests to store a transaction on the transaction pool', (doneIt: () => void) =>
+    {
+        const block = Block.reviver("", sample_data2);
+        ledger_storage.putTransactionPool(block.txs[0])
+            .then((changes) =>
+            {
+                assert.strictEqual(changes, 1);
+                doneIt();
             })
             .catch((err) =>
             {

--- a/tests/Utils.ts
+++ b/tests/Utils.ts
@@ -34,6 +34,12 @@ export const sample_data =
         return record;
     })();
 
+export const sample_data2 =
+    (() => {
+        let data: string = fs.readFileSync('tests/data/Block.2.sample1.json', 'utf-8');
+        return JSON.parse(data);
+    })();
+
 export const sample_preImageInfo =
     {
         "enroll_key": "0x46883e83778481d640a95fcffd6e1a1b6defeaac5a8001cd3f99e17576b809c7e9bc7a44c3917806765a5ff997366e217ff54cd4da09c0c51dc339c47052a3ac",


### PR DESCRIPTION
Store information, inputs, and outputs of received transactions on the tables.
Add endpoint /transaction_received

Related to #221 