### PR TITLE
Add DB Trigger for Transaction Pool

### DIFF
--- a/docs/Database_Schema.md
+++ b/docs/Database_Schema.md
@@ -252,7 +252,7 @@ CREATE TABLE IF NOT EXISTS "transaction_pool" (
 
 ----
 
-## 4. Table **tx_input_pool**
+## 10. Table **tx_input_pool**
 
 ### _Schema_
 
@@ -276,7 +276,7 @@ CREATE TABLE IF NOT EXISTS "tx_input_pool" (
 
 ----
 
-## 5. Table **tx_output_pool**
+## 11. Table **tx_output_pool**
 
 ### _Schema_
 

--- a/docs/Database_Schema.md
+++ b/docs/Database_Schema.md
@@ -227,7 +227,7 @@ CREATE TABLE IF NOT EXISTS information (
 
 ----
 
-## 9. Table **transactionPool**
+## 9. Table **transaction_pool**
 
 ### _Schema_
 
@@ -241,7 +241,7 @@ CREATE TABLE IF NOT EXISTS information (
 ### _Create Script_
 
 ```sql
-CREATE TABLE IF NOT EXISTS "transactionPool" (
+CREATE TABLE IF NOT EXISTS "transaction_pool" (
     "tx_hash"               BLOB    NOT NULL,
     "type"                  INTEGER NOT NULL,
     "payload"               BLOB    NOT NULL,
@@ -252,7 +252,7 @@ CREATE TABLE IF NOT EXISTS "transactionPool" (
 
 ----
 
-## 4. Table **txInputPool**
+## 4. Table **tx_input_pool**
 
 ### _Schema_
 
@@ -265,7 +265,7 @@ CREATE TABLE IF NOT EXISTS "transactionPool" (
 ### _Create Script_
 
 ```sql
-CREATE TABLE IF NOT EXISTS "txInputPool" (
+CREATE TABLE IF NOT EXISTS "tx_input_pool" (
     "tx_hash"               BLOB    NOT NULL,
     "input_index"           INTEGER NOT NULL,
     "utxo"                  BLOB    NOT NULL,
@@ -276,7 +276,7 @@ CREATE TABLE IF NOT EXISTS "txInputPool" (
 
 ----
 
-## 5. Table **txOutputPool**
+## 5. Table **tx_output_pool**
 
 ### _Schema_
 
@@ -290,7 +290,7 @@ CREATE TABLE IF NOT EXISTS "txInputPool" (
 ### _Create Script_
 
 ```sql
-CREATE TABLE IF NOT EXISTS "txOutputPool" (
+CREATE TABLE IF NOT EXISTS "tx_output_pool" (
     "tx_hash"               BLOB    NOT NULL,
     "output_index"          INTEGER NOT NULL,
     "amount"                NUMERIC NOT NULL,

--- a/src/modules/storage/LedgerStorage.ts
+++ b/src/modules/storage/LedgerStorage.ts
@@ -143,7 +143,7 @@ export class LedgerStorage extends Storages
             PRIMARY KEY(key)
         );
 
-        CREATE TABLE IF NOT EXISTS transactionPool (
+        CREATE TABLE IF NOT EXISTS transaction_pool (
             tx_hash             BLOB    NOT NULL,
             type                INTEGER NOT NULL,
             payload             BLOB    NOT NULL,
@@ -151,7 +151,7 @@ export class LedgerStorage extends Storages
             PRIMARY KEY(tx_hash)
         );
 
-        CREATE TABLE IF NOT EXISTS txInputPool (
+        CREATE TABLE IF NOT EXISTS tx_input_pool (
             tx_hash             BLOB    NOT NULL,
             input_index         INTEGER NOT NULL,
             utxo                BLOB    NOT NULL,
@@ -159,7 +159,7 @@ export class LedgerStorage extends Storages
             PRIMARY KEY(tx_hash, input_index)
         );
 
-        CREATE TABLE IF NOT EXISTS txOutputPool (
+        CREATE TABLE IF NOT EXISTS tx_output_pool (
             tx_hash             BLOB    NOT NULL,
             output_index        INTEGER NOT NULL,
             amount              NUMERIC NOT NULL,
@@ -682,7 +682,7 @@ export class LedgerStorage extends Storages
             return new Promise<number>((resolve, reject) =>
             {
                 storage.run(
-                    `INSERT INTO transactionPool
+                    `INSERT INTO transaction_pool
                         (tx_hash, type, payload, time)
                     VALUES
                         (?, ?, ?, strftime('%s', 'now', 'UTC'))`,
@@ -708,7 +708,7 @@ export class LedgerStorage extends Storages
             return new Promise<number>((resolve, reject) =>
             {
                 storage.run(
-                    `INSERT INTO txInputPool
+                    `INSERT INTO tx_input_pool
                         (tx_hash, input_index, utxo, signature)
                     VALUES
                         (?, ?, ?, ?)`,
@@ -736,7 +736,7 @@ export class LedgerStorage extends Storages
             return new Promise<number>((resolve, reject) =>
             {
                 storage.run(
-                    `INSERT INTO txOutputPool
+                    `INSERT INTO tx_output_pool
                         (tx_hash, output_index, amount, address)
                     VALUES
                         (?, ?, ?, ?)`,


### PR DESCRIPTION
A trigger occurs when a new block is received and a new transaction is inserted into the transaction table.
The trigger deletes the transactions in the transaction pool.
This knows whether a transaction in a transaction pool is in a pendding state.


Related to #227 