### PR TITLE
Implement /pending_transactions endpoint

### DIFF
--- a/src/Types.ts
+++ b/src/Types.ts
@@ -200,6 +200,17 @@ export interface ITxOverviewElement
     utxo: string;
 }
 
+/**
+ * The interface of the pending transactions
+ */
+export interface IPendingTxs
+{
+    tx_hash: string;
+    submission_time: number;
+    address: string;
+    amount: string;
+    fee: string;
+}
 
 /**
  * Define the types of transactions to be displayed in various applications

--- a/tests/Stoa.test.ts
+++ b/tests/Stoa.test.ts
@@ -367,4 +367,29 @@ describe ('Test of Stoa API Server', () =>
             }, 100);
         });
     });
+
+    it ('Test of the path /pending_transactions/:address', (doneIt: () => void) =>
+    {
+        let uri = URI(host)
+            .port(port)
+            .directory("pending_transactions")
+            .filename("GDAGR22X4IWNEO6FHNY3PYUJDXPUCRCKPNGACETAUVGE3GAWVFPS7VUJ");
+
+        client.get (uri.toString())
+            .then((response) =>
+            {
+                assert.strictEqual(response.data.length, 1);
+                assert.strictEqual(response.data[0].tx_hash, '0x42febd46e93ace' +
+                    'bfc7f81e7a8b0228c5c4fed42de29bb5b4872b09699c28bb3b29e8dbb' +
+                    'c65eb3a46b60ccb688e8a6d4ffbc341a0d59f7de13d28de2fede5566d');
+                assert.strictEqual(response.data[0].address, 'GCOMMONBGUXXP4RFCYGEF74JDJVPUW2GUENGTKKJECDNO6AGO32CUWGU');
+                assert.strictEqual(response.data[0].amount, '1663400000');
+                assert.strictEqual(response.data[0].fee, '0');
+            })
+            .catch((error) =>
+            {
+                assert.ok(!error, error);
+            })
+            .finally(doneIt);
+    });
 });


### PR DESCRIPTION
The pending transactions list is output to an array and can be in the form of transaction JSON.
The lookup target is based on the `publicKey` of the input's utxo

Related to #228 