### PR TITLE
Make getBlocksFrom return type typed

### DIFF
--- a/src/Stoa.ts
+++ b/src/Stoa.ts
@@ -778,14 +778,13 @@ class Stoa extends WebService
                         let blocks = await this.agora.getBlocksFrom(expected_height, Number(max_blocks));
 
                         // Save previous block
-                        for (let elem of blocks)
+                        for (let block of blocks)
                         {
-                            let element_height = Stoa.getJsonBlockHeight(elem);
-                            if (element_height.value == expected_height.value)
+                            if (block.header.height.value == expected_height.value)
                             {
-                                await this.ledger_storage.putBlocks(Block.reviver("", elem));
+                                await this.ledger_storage.putBlocks(block);
                                 expected_height.value += 1n;
-                                logger.info(`Recovered a block with block height of ${element_height.toString()}`);
+                                logger.info(`Recovered a block with block height of ${block.header.height.toString()}`);
                             }
                             else
                             {

--- a/src/modules/agora/AgoraClient.ts
+++ b/src/modules/agora/AgoraClient.ts
@@ -11,7 +11,7 @@
 
 *******************************************************************************/
 
-import { Height } from 'boa-sdk-ts';
+import { Block, Height } from 'boa-sdk-ts';
 
 import axios, { AxiosInstance, AxiosResponse, AxiosError } from 'axios';
 import URI from 'urijs';
@@ -28,7 +28,7 @@ export interface FullNodeAPI
     // getLocalTime (): bigint;
 
     getBlockHeight (): Promise<Height>;
-    getBlocksFrom (block_height: Height, max_blocks: number): Promise<any[]>;
+    getBlocksFrom (block_height: Height, max_blocks: number): Promise<Block[]>;
     // getMerklePath (block_height: Height, hash: Hash): Hash[];
     // hasTransactionHash (tx: Hash): boolean;
     // putTransaction (tx: Transaction): void;
@@ -83,9 +83,9 @@ export class AgoraClient implements FullNodeAPI
      * @param block_height - The height of the block
      * @param max_blocks - The maximum number of block to request
      */
-    public getBlocksFrom (block_height: Height, max_blocks: number): Promise<Array<any>>
+    public getBlocksFrom (block_height: Height, max_blocks: number): Promise<Block[]>
     {
-        return new Promise<Array<any>>((resolve, reject) =>
+        return new Promise<Block[]>((resolve, reject) =>
         {
             let uri = URI("/blocks_from")
                 .addSearch("block_height", block_height.toString())
@@ -96,7 +96,7 @@ export class AgoraClient implements FullNodeAPI
                 {
                     if (response.status == 200)
                     {
-                        resolve(response.data);
+                        resolve(response.data.map((entry: any) => Block.reviver("", entry)));
                     }
                     else
                     {

--- a/tests/Recovery.test.ts
+++ b/tests/Recovery.test.ts
@@ -111,14 +111,13 @@ describe ('Test of Recovery', () =>
         await assert.doesNotReject(async () =>
         {
             await agora_client.getBlocksFrom(new Height(1n), 3)
-                .then((response) =>
+                .then((blocks) =>
                 {
                     // The number of blocks is three.
-                    assert.strictEqual(response.length, 3);
+                    assert.strictEqual(blocks.length, 3);
                     let expected_height : Height = new Height(1n);
-                    for (let elem of response)
+                    for (let block of blocks)
                     {
-                        let block = Block.reviver("", elem);
                         // Make sure that the received block height is equal to the expected value.
                         assert.deepEqual(block.header.height, expected_height);
                         expected_height.value += 1n;
@@ -137,14 +136,13 @@ describe ('Test of Recovery', () =>
 
         assert.doesNotThrow(async () =>
         {
-            let response = await agora_client.getBlocksFrom(new Height(8n), 3);
+            const blocks = await agora_client.getBlocksFrom(new Height(8n), 3);
             // The number of blocks is two.
             // Because the total number is 10. The last block height is 9.
-            assert.strictEqual(response.length, 2);
+            assert.strictEqual(blocks.length, 2);
             let expected_height : Height = new Height(8n);
-            for (let elem of response)
+            for (let block of blocks)
             {
-                let block = Block.reviver("", elem);
                 // Make sure that the received block height is equal to the expected value.
                 assert.deepEqual(block.header.height, expected_height);
                 expected_height.value += 1n;


### PR DESCRIPTION
Since everyone needs to call Block.reviver otherwise.

Extracted from https://github.com/bpfkorea/stoa/pull/210