### PR TITLE
Wallet: Change address of the endpoint (transactions/pending)

### DIFF
--- a/src/Stoa.ts
+++ b/src/Stoa.ts
@@ -125,7 +125,7 @@ class Stoa extends WebService
         this.app.get("/utxo/:address", this.getUTXO.bind(this));
         this.app.get("/wallet/transactions/history/:address", this.getWalletTransactionsHistory.bind(this));
         this.app.get("/wallet/transaction/overview/:hash", this.getWalletTransactionOverview.bind(this));
-        this.app.get("/transactions/pending/:address", this.getTransactionsPending.bind(this));
+        this.app.get("/wallet/transactions/pending/:address", this.getWalletTransactionsPending.bind(this));
         this.app.post("/block_externalized", this.postBlock.bind(this));
         this.app.post("/preimage_received", this.putPreImage.bind(this));
         this.app.post("/transaction_received", this.putTransaction.bind(this));
@@ -671,19 +671,19 @@ class Stoa extends WebService
     }
 
     /**
-     * GET /transactions/pending/:address
+     * GET /wallet/transactions/pending/:address
      *
      * Called when a request is received through the `/transactions/pending/:address` handler
      *
      * Returns List the total by output address of the pending transaction.
      */
-    private getTransactionsPending (req: express.Request, res: express.Response)
+    private getWalletTransactionsPending (req: express.Request, res: express.Response)
     {
         let address: string = String(req.params.address);
 
-        logger.http(`GET /transactions/pending/${address}}`);
+        logger.http(`GET /wallet/transactions/pending/${address}}`);
 
-        this.ledger_storage.getTransactionsPending(address)
+        this.ledger_storage.getWalletTransactionsPending(address)
             .then((rows: any[]) => {
                 if (!rows.length)
                 {

--- a/src/modules/storage/LedgerStorage.ts
+++ b/src/modules/storage/LedgerStorage.ts
@@ -1289,7 +1289,7 @@ export class LedgerStorage extends Storages
      * Lists the total by output address of the pending transactions.
      * @param address The input address of the pending transaction
      */
-    public getTransactionsPending (address: string): Promise<any[]>
+    public getWalletTransactionsPending (address: string): Promise<any[]>
     {
         let sql =
             `SELECT

--- a/tests/Stoa.test.ts
+++ b/tests/Stoa.test.ts
@@ -300,29 +300,21 @@ describe ('Test of Stoa API Server', () =>
         await delay(100);
     });
 
-    it ('Test of the path /pending_transactions/:address', (doneIt: () => void) =>
+    it ('Test of the path /wallet/transactions/pending/:address', async () =>
     {
         let uri = URI(host)
             .port(port)
-            .directory("pending_transactions")
+            .directory("/wallet/transactions/pending")
             .filename("GDAGR22X4IWNEO6FHNY3PYUJDXPUCRCKPNGACETAUVGE3GAWVFPS7VUJ");
 
-        client.get (uri.toString())
-            .then((response) =>
-            {
-                assert.strictEqual(response.data.length, 1);
-                assert.strictEqual(response.data[0].tx_hash, '0x42febd46e93ace' +
-                    'bfc7f81e7a8b0228c5c4fed42de29bb5b4872b09699c28bb3b29e8dbb' +
-                    'c65eb3a46b60ccb688e8a6d4ffbc341a0d59f7de13d28de2fede5566d');
-                assert.strictEqual(response.data[0].address, 'GCOMMONBGUXXP4RFCYGEF74JDJVPUW2GUENGTKKJECDNO6AGO32CUWGU');
-                assert.strictEqual(response.data[0].amount, '1663400000');
-                assert.strictEqual(response.data[0].fee, '0');
-            })
-            .catch((error) =>
-            {
-                assert.ok(!error, error);
-            })
-            .finally(doneIt);
+        let response = await client.get (uri.toString())
+        assert.strictEqual(response.data.length, 2);
+        assert.strictEqual(response.data[0].tx_hash, '0x42febd46e93ace' +
+            'bfc7f81e7a8b0228c5c4fed42de29bb5b4872b09699c28bb3b29e8dbb' +
+            'c65eb3a46b60ccb688e8a6d4ffbc341a0d59f7de13d28de2fede5566d');
+        assert.strictEqual(response.data[0].address, 'GCOMMONBGUXXP4RFCYGEF74JDJVPUW2GUENGTKKJECDNO6AGO32CUWGU');
+        assert.strictEqual(response.data[0].amount, '1663400000');
+        assert.strictEqual(response.data[0].fee, '0');
     });
 });
 


### PR DESCRIPTION
This endpoint is renamed because it needs to be specialized in wallets.