### PR TITLE
Wallet: Add the lock data in the transaction output (/utxo)

### DIFF
--- a/src/Stoa.ts
+++ b/src/Stoa.ts
@@ -370,7 +370,9 @@ class Stoa extends WebService
                         unlock_height: BigInt(row.unlock_height).toString(),
                         amount: BigInt(row.amount).toString(),
                         height: BigInt(row.block_height).toString(),
-                        time: row.block_time
+                        time: row.block_time,
+                        lock_type: row.lock_type,
+                        lock_bytes: row.lock_bytes.toString('base64')
                     }
                     utxo_array.push(utxo);
                 }

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -85,6 +85,16 @@ export interface IUnspentTxOutput
      * Block time on created
      */
     time: number;
+
+    /**
+     * The type of lock script in transaction output
+     */
+    lock_type: number;
+
+    /**
+     * The bytes of lock script in transaction output
+     */
+    lock_bytes: string;
 }
 
 /**

--- a/src/modules/storage/LedgerStorage.ts
+++ b/src/modules/storage/LedgerStorage.ts
@@ -1049,6 +1049,8 @@ export class LedgerStorage extends Storages
             `SELECT
                 O.utxo_key as utxo,
                 O.amount,
+                O.lock_type,
+                O.lock_bytes,
                 T.block_height,
                 B.time_stamp as block_time,
                 T.type,

--- a/tests/Stoa.test.ts
+++ b/tests/Stoa.test.ts
@@ -386,6 +386,8 @@ describe ('Test of the path /utxo', () =>
                 utxo: '0x831e492f4401df05832b5958e54a7d248b69b7366e1e5723e36da97559a8213ac313ac32526001e4ae72f83f3bb7553d616049838b91f31be1daeab935eee82e',
                 amount: '24400000000000',
                 height: '1',
+                lock_bytes: "wGjrV+Is0jvFO3G34okd30FESntMARJgpUxNmBapXy8=",
+                lock_type: 0,
                 time: 1596753600,
                 unlock_height: '2'
             }];


### PR DESCRIPTION
I updated an endpoint `/utxo`
I added the `lock_type` and `lock_bytes` that UTXO has to the response data.
This is added because it is necessary to sign new transactions created using UTXO.