### PR TITLE
Bug fix: Add the ability to validate Hash received with the HTTP parameter

### DIFF
--- a/src/Stoa.ts
+++ b/src/Stoa.ts
@@ -344,9 +344,20 @@ class Stoa extends WebService
      */
     private getTransactionStatus (req: express.Request, res: express.Response)
     {
-        let tx_hash: string = String(req.params.hash);
+        let hash: string = String(req.params.hash);
 
-        logger.http(`GET /transaction/status/${tx_hash}}`);
+        logger.http(`GET /transaction/status/${hash}}`);
+
+        let tx_hash: Hash;
+        try
+        {
+            tx_hash = new Hash(hash);
+        }
+        catch (error)
+        {
+            res.status(400).send(`Invalid value for parameter 'hash': ${hash}`);
+            return;
+        }
 
         this.ledger_storage.getTransactionStatus(tx_hash)
             .then((data: any) => {
@@ -669,9 +680,20 @@ class Stoa extends WebService
      */
     private getWalletTransactionOverview (req: express.Request, res: express.Response)
     {
-        let tx_hash: string = String(req.params.hash);
+        let hash: string = String(req.params.hash);
 
-        logger.http(`GET /wallet/transaction/overview/${tx_hash}}`);
+        logger.http(`GET /wallet/transaction/overview/${hash}}`);
+
+        let tx_hash: Hash;
+        try
+        {
+            tx_hash = new Hash(hash);
+        }
+        catch (error)
+        {
+            res.status(400).send(`Invalid value for parameter 'hash': ${hash}`);
+            return;
+        }
 
         this.ledger_storage.getWalletTransactionOverview(tx_hash)
             .then((data: any) => {

--- a/src/modules/storage/LedgerStorage.ts
+++ b/src/modules/storage/LedgerStorage.ts
@@ -1252,9 +1252,9 @@ export class LedgerStorage extends Storages
      * Provides a overview of a transaction.
      * @param tx_hash The hash of the transaction
      */
-    public getWalletTransactionOverview (tx_hash: string): Promise<any[]>
+    public getWalletTransactionOverview (tx_hash: Hash): Promise<any[]>
     {
-        let hash = new Hash(tx_hash).toBinary(Endian.Little);
+        let hash = tx_hash.toBinary(Endian.Little);
 
         let sql_tx =
             `SELECT
@@ -1349,9 +1349,9 @@ export class LedgerStorage extends Storages
      * Provides a status of a transaction.
      * @param tx_hash The hash of the transaction
      */
-    public getTransactionStatus (tx_hash: string): Promise<any>
+    public getTransactionStatus (tx_hash: Hash): Promise<any>
     {
-        let hash = new Hash(tx_hash).toBinary(Endian.Little);
+        let hash = tx_hash.toBinary(Endian.Little);
 
         let sql_tx =
             `SELECT


### PR DESCRIPTION
I added an exception handler because an exception occurs when a string of different lengths is entered.