### PR TITLE
Wallet: Modify the filtering function of the Transaction Type

### DIFF
--- a/src/Stoa.ts
+++ b/src/Stoa.ts
@@ -623,8 +623,7 @@ class Stoa extends WebService
 
         filter_type = (req.query.type !== undefined)
             ? req.query.type.toString().split(',').map((m) => ConvertTypes.toDisplayTxType(m))
-            : [0, 1];
-        filter_type.push(...[DisplayTxType.Freeze, DisplayTxType.Payload].filter(n => filter_type.find(m => m == n) === undefined));
+            : [0, 1, 2, 3];
 
         if (filter_type.find(m => (m === -1)) !== undefined)
         {

--- a/tests/WalletAPI.test.ts
+++ b/tests/WalletAPI.test.ts
@@ -310,4 +310,30 @@ describe ('Test of Stoa API for the wallet with `sample_data`', () => {
 
         assert.deepStrictEqual(expected, response.data);
     });
+
+    it ('Test of the path /wallet/transactions/history - Filtering - exclude DataPayload in specific filter', async () =>
+    {
+        let uri = URI(host)
+            .port(port)
+            .directory("/wallet/transactions/history")
+            .filename("GDID227ETHPOMLRLIHVDJSNSJVLDS4D4ANYOUHXPMG2WWEZN5JO473ZO")
+            .setSearch("pageSize", "10")
+            .setSearch("page", "1")
+            .setSearch("type", "payload");
+
+        let response = await client.get (uri.toString());
+        assert.strictEqual(response.data.length, 1);
+
+
+        uri = URI(host)
+            .port(port)
+            .directory("/wallet/transactions/history")
+            .filename("GDID227ETHPOMLRLIHVDJSNSJVLDS4D4ANYOUHXPMG2WWEZN5JO473ZO")
+            .setSearch("pageSize", "10")
+            .setSearch("page", "1")
+            .setSearch("type", "outbound");
+
+        response = await client.get (uri.toString());
+        assert.strictEqual(response.data.length, 0);
+    });
 });


### PR DESCRIPTION
If a special filter exists, payload and freeze are excluded, and all types of transactions are returned only when there is no filter.