### PR TITLE
Prevent freezing of refund output in freeze transactions

### DIFF
--- a/docs/Database_Schema.md
+++ b/docs/Database_Schema.md
@@ -168,6 +168,8 @@ CREATE TABLE IF NOT EXISTS "tx_outputs" (
 |:----------------- |:--------- |:--:|:--------:| -------- | --------- |
 |  utxo_key         | BLOB      | Y  | Y        |          | The hash of the UTXO|
 |  tx_hash          | BLOB      |    | Y        |          | The hash of transaction |
+|  type             | INTEGER   |    | Y        |          | The type of UTXO (0: Payment, 1: Freeze) If the type of transaction is `Freeze` and the refund output is less than 40,000 BOA, it is `Payment`. Others are the same as the transaction type. |
+|  unlock_height    | INTEGER   |    | Y        |          | Height of the block to be unlock|
 |  amount           | NUMERIC   |    | Y        |          | The monetary value of this output, in 1/10^7|
 |  lock_type        | INTEGER   |    | Y        |          | (0: Key; 1: Hash of Key; 2: Script; 3: Hash of Script) |
 |  lock_bytes       | BLOB      |    | Y        |          | The bytes of lock |
@@ -179,6 +181,8 @@ CREATE TABLE IF NOT EXISTS "tx_outputs" (
 CREATE TABLE IF NOT EXISTS "utxos" (
     "utxo_key"              BLOB    NOT NULL,
     "tx_hash"               BLOB    NOT NULL,
+    "type"                  INTEGER NOT NULL,
+    "unlock_height"         INTEGER NOT NULL,
     "amount"                NUMERIC NOT NULL,
     "lock_type"             INTEGER NOT NULL,
     "lock_bytes"            BLOB    NOT NULL,

--- a/docs/Database_Schema.md
+++ b/docs/Database_Schema.md
@@ -141,7 +141,6 @@ CREATE TABLE IF NOT EXISTS "tx_inputs" (
 |  lock_type        | INTEGER   |    | Y        |          | (0: Key; 1: Hash of Key; 2: Script; 3: Hash of Script) |
 |  lock_bytes       | BLOB      |    | Y        |          | The bytes of lock |
 |  address          | TEXT      |    | Y        |          | The public key, Valid only when lock type is 0. Other than that, it's a blank.|
-|  used             | INTEGER   |    | Y        | 0        | Whether this output was used or not(1: used, 0: not used)|
 
 ### _Create Script_
 
@@ -156,13 +155,40 @@ CREATE TABLE IF NOT EXISTS "tx_outputs" (
     "lock_type"             INTEGER NOT NULL,
     "lock_bytes"            BLOB    NOT NULL,
     "address"               TEXT    NOT NULL,
-    "used"                  INTEGER NOT NULL DEFAULT 0,
     PRIMARY KEY("block_height","tx_index","output_index")
 )
 ```
 ----
 
-## 6. Table **validators**
+## 6. Table **utxos**
+
+### _Schema_
+
+| Column            | Data Type | PK | Not NULL | Default  |Description|
+|:----------------- |:--------- |:--:|:--------:| -------- | --------- |
+|  utxo_key         | BLOB      | Y  | Y        |          | The hash of the UTXO|
+|  tx_hash          | BLOB      |    | Y        |          | The hash of transaction |
+|  amount           | NUMERIC   |    | Y        |          | The monetary value of this output, in 1/10^7|
+|  lock_type        | INTEGER   |    | Y        |          | (0: Key; 1: Hash of Key; 2: Script; 3: Hash of Script) |
+|  lock_bytes       | BLOB      |    | Y        |          | The bytes of lock |
+|  address          | TEXT      |    | Y        |          | The public key, Valid only when lock type is 0. Other than that, it's a blank.|
+
+### _Create Script_
+
+```sql
+CREATE TABLE IF NOT EXISTS "utxos" (
+    "utxo_key"              BLOB    NOT NULL,
+    "tx_hash"               BLOB    NOT NULL,
+    "amount"                NUMERIC NOT NULL,
+    "lock_type"             INTEGER NOT NULL,
+    "lock_bytes"            BLOB    NOT NULL,
+    "address"               TEXT    NOT NULL,
+    PRIMARY KEY("utxo_key")
+)
+```
+----
+
+## 7. Table **validators**
 
 ### _Schema_
 
@@ -190,7 +216,7 @@ CREATE TABLE IF NOT EXISTS "validators" (
 ```
 ----
 
-## 7. Table **payloads**
+## 8. Table **payloads**
 
 ### _Schema_
 
@@ -211,7 +237,7 @@ CREATE TABLE IF NOT EXISTS "payloads" (
 
 ----
 
-## 8. Table **information**
+## 9. Table **information**
 
 It can store information that is required for operation.
 The following data is recorded when the most recently recorded block height is 100.
@@ -237,7 +263,7 @@ CREATE TABLE IF NOT EXISTS information (
 
 ----
 
-## 9. Table **transaction_pool**
+## 10. Table **transaction_pool**
 
 ### _Schema_
 
@@ -264,7 +290,7 @@ CREATE TABLE IF NOT EXISTS "transaction_pool" (
 
 ----
 
-## 10. Table **tx_input_pool**
+## 11. Table **tx_input_pool**
 
 ### _Schema_
 
@@ -290,7 +316,7 @@ CREATE TABLE IF NOT EXISTS "tx_input_pool" (
 
 ----
 
-## 11. Table **tx_output_pool**
+## 12. Table **tx_output_pool**
 
 ### _Schema_
 

--- a/src/modules/storage/LedgerStorage.ts
+++ b/src/modules/storage/LedgerStorage.ts
@@ -493,9 +493,8 @@ export class LedgerStorage extends Storages
                 let unlock_height_query: string;
                 if ((tx.type == TxType.Payment) && (tx.inputs.length > 0))
                 {
-                    let utxo: Array<string> = [];
-                    for (let input of tx.inputs)
-                        utxo.push(`'${input.utxo.toString().substring(2).toUpperCase()}'`);
+                    let utxo = tx.inputs
+                        .map(m => `x'${m.utxo.toBinary(Endian.Little).toString("hex")}'`);
 
                     unlock_height_query =
                         `(
@@ -509,7 +508,7 @@ export class LedgerStorage extends Storages
                                 WHERE
                                     a.tx_hash = b.tx_hash
                                     and b.type = 1
-                                    and hex(a.utxo_key) in (${utxo.join(',')})
+                                    and a.utxo_key in (${utxo.join(',')})
                             )
                             UNION ALL
                             SELECT '${JSBI.add(height.value, JSBI.BigInt(1)).toString()}' AS unlock_height

--- a/tests/Storage.test.ts
+++ b/tests/Storage.test.ts
@@ -76,7 +76,6 @@ describe ('Test ledger storage and inquiry function.', () =>
             '0xb3aaf405f53560a6f6d5dd9dd83d7b031da480c0640a2897f2e2562c4670dfe' +
             '84552d84daf5b1b7c63ce249d06bf54747cc5fdc98178a932fff99ab1372e873b');
         assert.strictEqual(rows5[0].address, 'GCOQEOHAUFYUAC6G22FJ3GZRNLGVCCLESEJ2AXBIJ5BJNUVTAERPLRIJ');
-        assert.strictEqual(rows5[0].used, 1);
     });
 
     it ('Test for enrollment', async () =>

--- a/tests/WalletAPI.test.ts
+++ b/tests/WalletAPI.test.ts
@@ -268,7 +268,7 @@ describe ('Test of Stoa API for the wallet with `sample_data`', () => {
         await client.post(url, {block: sample_data[0]});
         await client.post(url, {block: sample_data[1]});
         await client.post(url, {block: sample_data2});
-        await delay(100);
+        await delay(500);
     });
 
     it('Test of the path /wallet/transaction/overview with payload', async () => {


### PR DESCRIPTION
I implemented the processing in the same way as Agora to prevent the refund output from freezing in a freeze transaction.

Relates to https://github.com/bpfkorea/stoa/issues/280