### PR TITLE
TxFee: Add fees and size of the transaction in the table `transactions`

### DIFF
--- a/docs/Database_Schema.md
+++ b/docs/Database_Schema.md
@@ -75,6 +75,9 @@ CREATE TABLE IF NOT EXISTS "enrollments" (
 | type              | INTEGER   |    | Y        |          | The type of transaction |
 | unlock_height     | INTEGER   |    | Y        |          | Height of the block to be unlock|
 | lock_height       | INTEGER   |    | Y        |          | This transaction may only be included in a block with `block_height >= lock_height`|
+| tx_fee            | INTEGER   |    | Y        |          | The fee of this transaction |
+| payload_fee       | INTEGER   |    | Y        |          | The payload fee of this transaction  |
+| tx_size           | INTEGER   |    | Y        |          | The size of this transaction  |
 | inputs_count      | INTEGER   |    | Y        |          | The number of inputs in the transaction |
 | outputs_count     | INTEGER   |    | Y        |          | The number of outputs in the transaction |
 | payload_size      | INTEGER   |    | Y        |          | The size of data payload in the transaction |
@@ -89,6 +92,9 @@ CREATE TABLE IF NOT EXISTS "transactions" (
     "type"                  INTEGER NOT NULL,
     "unlock_height"         INTEGER NOT NULL,
     "lock_height"           INTEGER NOT NULL,
+    "tx_fee"                INTEGER NOT NULL,
+    "payload_fee"           INTEGER NOT NULL,
+    "tx_size"               INTEGER NOT NULL,
     "inputs_count"          INTEGER NOT NULL,
     "outputs_count"         INTEGER NOT NULL,
     "payload_size"          INTEGER NOT NULL,

--- a/docs/Database_Schema.md
+++ b/docs/Database_Schema.md
@@ -284,6 +284,9 @@ CREATE TABLE IF NOT EXISTS information (
 | payload           | BLOB      |    | Y        |          | The transaction data payload |
 | lock_height       | INTEGER   |    | Y        |          | This transaction may only be included in a block with `block_height >= lock_height`|
 | time              | INTEGER   |    | Y        |          | Received time |
+| tx_fee            | INTEGER   |    | Y        |          | The fee of this transaction |
+| payload_fee       | INTEGER   |    | Y        |          | The payload fee of this transaction  |
+| tx_size           | INTEGER   |    | Y        |          | The size of this transaction  |
 
 ### _Create Script_
 
@@ -294,6 +297,9 @@ CREATE TABLE IF NOT EXISTS "transaction_pool" (
     "payload"               BLOB    NOT NULL,
     "lock_height"           INTEGER NOT NULL,
     "time"                  INTEGER NOT NULL,
+    "tx_fee"                INTEGER NOT NULL,
+    "payload_fee"           INTEGER NOT NULL,
+    "tx_size"               INTEGER NOT NULL,
     PRIMARY KEY("tx_hash")
 )
 ```

--- a/src/Stoa.ts
+++ b/src/Stoa.ts
@@ -719,7 +719,7 @@ class Stoa extends WebService
                     payload: (data.tx[0].payload !== null) ? new DataPayload(data.tx[0].payload, Endian.Little).toString() : "",
                     senders: [],
                     receivers: [],
-                    fee: "0"
+                    fee: JSBI.add(JSBI.BigInt(data.tx[0].tx_fee), JSBI.BigInt(data.tx[0].payload_fee)).toString()
                 };
 
                 for (let elem of data.senders)

--- a/src/Stoa.ts
+++ b/src/Stoa.ts
@@ -837,7 +837,7 @@ class Stoa extends WebService
                         submission_time: row.time,
                         address: row.address,
                         amount: JSBI.BigInt(row.amount).toString(),
-                        fee: JSBI.BigInt(0).toString()
+                        fee: JSBI.add(JSBI.BigInt(row.tx_fee), JSBI.BigInt(row.payload_fee)).toString()
                     }
                     pending_array.push(tx);
                 }

--- a/src/modules/storage/LedgerStorage.ts
+++ b/src/modules/storage/LedgerStorage.ts
@@ -1433,7 +1433,9 @@ export class LedgerStorage extends Storages
                 T.type,
                 T.unlock_height,
                 (B.time_stamp + (T.unlock_height - T.block_height) * 10 * 60) as unlock_time,
-                P.payload
+                P.payload,
+                T.tx_fee,
+                T.payload_fee
             FROM
                 blocks B
                 INNER JOIN transactions T ON (B.height = T.block_height and T.tx_hash = ?)

--- a/src/modules/storage/LedgerStorage.ts
+++ b/src/modules/storage/LedgerStorage.ts
@@ -1502,7 +1502,9 @@ export class LedgerStorage extends Storages
                 T.tx_hash,
                 T.time,
                 O.address,
-                IFNULL(SUM(O.amount), 0) as amount
+                IFNULL(SUM(O.amount), 0) as amount,
+                T.tx_fee,
+                T.payload_fee
             FROM
                 transaction_pool T
                 LEFT OUTER JOIN tx_output_pool O


### PR DESCRIPTION
I added the following fields.
Size of Transaction
Fee for Transaction
Payload Fee
I also modified the code on the endpoint where the transaction fee should be provided.
In addition to providing the fee information, they will also be used for statistical work on appropriate fees depending on the size of the transaction in the future.

Relates to #274 