### PR TITLE
Stoa can store and get Merkle Trees

### DIFF
--- a/docs/Database_Schema.md
+++ b/docs/Database_Schema.md
@@ -253,7 +253,29 @@ CREATE TABLE IF NOT EXISTS "payloads" (
 
 ----
 
-## 9. Table **information**
+## 9. Table **merkle_trees**
+
+### _Schema_
+
+| Column            | Data Type | PK | Not NULL | Default  |Description|
+|:----------------- |:--------- |:--:|:--------:| -------- | --------- |
+| block_height      | INTEGER   | Y  | Y        |          | The height of the block |
+| merkle_index      | INTEGER   | Y  | Y        |          | The index of merkleTree in the block |
+| merkle_hash       | BLOB      |    | Y        |          | The merkle tree |
+
+### _Create Script_
+
+```sql
+CREATE TABLE IF NOT EXISTS "merkle_trees" (
+    "block_height"          INTEGER NOT NULL,
+    "merkle_index"          INTEGER NOT NULL,
+    "merkle_hash"           BLOB    NOT NULL,
+    PRIMARY KEY("block_height","merkle_index")
+)
+```
+----
+
+## 10. Table **information**
 
 It can store information that is required for operation.
 The following data is recorded when the most recently recorded block height is 100.
@@ -279,7 +301,7 @@ CREATE TABLE IF NOT EXISTS information (
 
 ----
 
-## 10. Table **transaction_pool**
+## 11. Table **transaction_pool**
 
 ### _Schema_
 
@@ -314,7 +336,7 @@ CREATE TABLE IF NOT EXISTS "transaction_pool" (
 
 ----
 
-## 11. Table **tx_input_pool**
+## 12. Table **tx_input_pool**
 
 ### _Schema_
 
@@ -340,7 +362,7 @@ CREATE TABLE IF NOT EXISTS "tx_input_pool" (
 
 ----
 
-## 12. Table **tx_output_pool**
+## 13. Table **tx_output_pool**
 
 ### _Schema_
 

--- a/tests/Storage.test.ts
+++ b/tests/Storage.test.ts
@@ -128,6 +128,22 @@ describe ('Test ledger storage and inquiry function.', () =>
         assert.strictEqual(rows[0].distance, undefined);
     });
 
+    it ('Test for merkle tree', async () =>
+    {
+        let height_value = 0;
+        let height = new Height(JSBI.BigInt(height_value));
+        let rows = await ledger_storage.getMerkleTree(height);
+        assert.strictEqual(rows.length, 3);
+        assert.strictEqual(rows[0].block_height, height_value);
+        assert.strictEqual(rows[0].merkle_index, 0);
+        assert.strictEqual(new Hash(rows[0].merkle_hash, Endian.Little).toString(),
+            '0x5208f03b3b95e90b3bff5e0daa1d657738839624d6605845d6e2ef3cf73d0d0' +
+            'ef5aff7d58bde1e00e1ccd5a502b26f569021324a4b902b7e66594e94f05e074c');
+        assert.strictEqual(new Hash(rows[1].merkle_hash, Endian.Little).toString(),
+            '0xb3aaf405f53560a6f6d5dd9dd83d7b031da480c0640a2897f2e2562c4670dfe' +
+            '84552d84daf5b1b7c63ce249d06bf54747cc5fdc98178a932fff99ab1372e873b');
+    });
+
     it ('Test for LedgerStorage.getWalletBlocksHeaderInfo()', async () =>
     {
         let rows = await ledger_storage.getWalletBlocksHeaderInfo(null);


### PR DESCRIPTION
It stores the Merkle tree of the block.
This is required for later verification of transactions or for querying blocks.

Related to #266 