### PR TITLE
Implement `getBlockHeaderByTxHash` function

### DIFF
--- a/src/modules/storage/LedgerStorage.ts
+++ b/src/modules/storage/LedgerStorage.ts
@@ -147,7 +147,7 @@ export class LedgerStorage extends Storages
             address             TEXT    NOT NULL,
             PRIMARY KEY(utxo_key)
         );
-        
+
         CREATE TABLE IF NOT EXISTS payloads (
             tx_hash             BLOB    NOT NULL,
             payload             BLOB    NOT NULL,
@@ -233,7 +233,7 @@ export class LedgerStorage extends Storages
     public putBlocks (block: Block): Promise<void>
     {
         let genesis_timestamp: number = this.genesis_timestamp;
-        
+
         function saveBlock (storage: LedgerStorage, block: Block, genesis_timestamp: number): Promise<void>
         {
             return new Promise<void>((resolve, reject) =>
@@ -1805,5 +1805,29 @@ export class LedgerStorage extends Storages
                 blocks
             WHERE height = ${cur_height};`;
         return this.query(sql, []);
+    }
+
+    /**
+     * Gets block height and merkle root
+     * @param tx_hash The hash of the transaction
+     * @returns Returns the Promise. If it is finished successfully the `.then`
+     * of the returned Promise is called with the records
+     * and if an error occurs the `.catch` is called with an error.
+     */
+    public getBlockHeaderByTxHash (tx_hash: Hash): Promise<any[]>
+    {
+        let sql =
+        `SELECT
+            height, merkle_root
+        FROM
+            transactions T
+        INNER JOIN
+            blocks B
+        ON
+            T.block_height = B.height
+        AND
+            T.tx_hash = ?`;
+
+        return this.query(sql, [tx_hash.toBinary(Endian.Little)]);
     }
 }

--- a/tests/Storage.test.ts
+++ b/tests/Storage.test.ts
@@ -202,6 +202,17 @@ describe ('Test ledger storage and inquiry function.', () =>
             '0x245286d66621523ea08aba56a34526a5cad5d9ddff367f52268ddcba57f7ae9' +
             'a83a1fdb101d87fdebccdf2b5039003e3c162232a15c50528d82ab34f8d8f5f17');
     });
+
+    it ('Test for getting block height and merkle root with transaction hash', async () => {
+        let tx_hash = new Hash('0xc0dd3f9e1c37ec1ac037685ce96417339b5d97bb4a9560e4e7ad7dd79f3f8d5' +
+                               '646c6c7bbc3473502aa8fea6ad0e691992e5e7fa1c73c44d174dfc4196a52d84f');
+        let rows = await ledger_storage.getBlockHeaderByTxHash(tx_hash);
+        assert.strictEqual(rows.length, 1);
+        assert.strictEqual(rows[0].height, 1);
+        assert.strictEqual(new Hash(rows[0].merkle_root, Endian.Little).toString(),
+            '0x911890b2ff4429e1beccb4ab5ba7458cc469e8fc455c5df67291ada2c5818cc' +
+            '65a3d11220e877b746a284c95294488d4c7e8ed47b02213e3ce74389c442d9cc1');
+    });
 });
 
 describe ('Test for storing block data in the database', () =>


### PR DESCRIPTION
The purpose of this method is to check whether the provided `tx_hash` exists in the blockchain.
If it exists, then return the corresponding `block_height`, and the `merkle_root` of the block of that height.

Solution for #296
Part of [agora#239](https://github.com/bosagora/agora/issues/239)