### PR TITLE
SPV: Implement endpoint `verifyPayment`

### DIFF
--- a/src/Types.ts
+++ b/src/Types.ts
@@ -345,3 +345,19 @@ export interface ITransactionFee
      */
     low: string;
 }
+
+ /**
+  * The status of the SPV
+  */
+export interface ISPVStatus
+{
+    /**
+     * True or false
+     */
+    result: boolean;
+
+    /**
+     * The message
+     */
+    message: string;
+}

--- a/src/modules/agora/AgoraClient.ts
+++ b/src/modules/agora/AgoraClient.ts
@@ -11,7 +11,7 @@
 
 *******************************************************************************/
 
-import { Block, Hash, Height, PreImageInfo, handleNetworkError } from 'boa-sdk-ts';
+import { Block, Hash, Height, PreImageInfo, handleNetworkError, hashMulti } from 'boa-sdk-ts';
 
 import axios, { AxiosInstance, AxiosResponse } from 'axios';
 import URI from 'urijs';
@@ -154,5 +154,20 @@ export class AgoraClient implements FullNodeAPI
                     reject(handleNetworkError(reason));
                 });
         });
+    }
+
+    public static checkMerklePath (merkle_path: Array<Hash>, tx_hash: Hash, tx_index: number): Hash
+    {
+        let root: Hash = tx_hash;
+        for (const otherside of merkle_path)
+        {
+            if (tx_index & 1)
+                root = hashMulti(otherside.data, root.data);
+            else
+                root = hashMulti(root.data, otherside.data);
+
+            tx_index >>= 1;
+        }
+        return root;
     }
 }

--- a/tests/Stoa.test.ts
+++ b/tests/Stoa.test.ts
@@ -971,4 +971,55 @@ describe ('Test of the path /merkle_path', () =>
 
         assert.deepStrictEqual(merkle_path, expected);
     });
+
+    it ('Test of the path /spv with a Merkle path transaction', async () =>
+    {
+        let uri = URI(host)
+            .port(port)
+            .directory("spv")
+            .filename("0x535b358337d919474f3043db1f292a1ac44a4f4dbbaa6d89226c7abd96c38bf96018e67828ec539623e475d480af99499368780ae346dfb6cb048b377cbc92d0");
+
+        let response = await client.get(uri.toString());
+
+        let expected = {
+            result: true,
+            message: "Success"
+        }
+
+        assert.deepStrictEqual(response.data, expected);
+    })
+
+    it ('Test of the path /spv with a non-Merkle path transaction', async () =>
+    {
+        let uri = URI(host)
+            .port(port)
+            .directory("spv")
+            .filename("0x7440a29292bb43361c049168c0efacf0dc3df7aa6657af59e61642f38e2a61988e4db9f59d23bc2c47b6b92dc02c3c974e8778552274f3a55498d9fce2aa3536");
+
+        let response = await client.get(uri.toString());
+
+        let expected = {
+            result: false,
+            message: "Verification failed"
+        }
+
+        assert.deepStrictEqual(response.data, expected);
+    })
+
+    it ('Test of the path /spv with an invalid transaction ', async () =>
+    {
+        let uri = URI(host)
+            .port(port)
+            .directory("spv")
+            .filename("0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
+
+        let response = await client.get(uri.toString());
+
+        let expected = {
+            result: false,
+            message: "Transaction does not exist in block"
+        }
+
+        assert.deepStrictEqual(response.data, expected);
+    })
 });


### PR DESCRIPTION
- `checkMerklePath` takes `merkle_path`, `tx_hash`, `tx_index` and returns the Merkle root, as in Agora.

- `verifyPayment` is the main function for the SPV. It checks whether the provided transaction is included in a block.

Solution for #300 / [agora#239](https://github.com/bosagora/agora/issues/239)