### PR TITLE
Increase the maximum request body size of `bodyParser` (200MByte)

### DIFF
--- a/src/Stoa.ts
+++ b/src/Stoa.ts
@@ -111,9 +111,9 @@ class Stoa extends WebService
         // Prepare middleware
 
         // parse application/x-www-form-urlencoded
-        this.app.use(bodyParser.urlencoded({ extended: false }))
+        this.app.use(bodyParser.urlencoded({ extended: false, limit: '1mb' }))
         // parse application/json
-        this.app.use(bodyParser.json())
+        this.app.use(bodyParser.json({ limit: '1mb' }))
         this.app.use(cors(cors_options));
 
         // Prepare routes


### PR DESCRIPTION
An error occurred when a transaction with an output of 1000 was sent.
This was due to the size of the data exceeding the maximum capacity set in bodyParser.
I've increased the maximum capacity of bodyParser.


Related to https://github.com/bosagora/stoa/issues/271