### PR TITLE
Set tx type for each tx output

### DIFF
--- a/docs/Database_Schema.md
+++ b/docs/Database_Schema.md
@@ -149,6 +149,7 @@ CREATE TABLE IF NOT EXISTS "tx_inputs" (
 |  output_index     | INTEGER   | Y  | Y        |          | The index of output in the outputs.|
 |  tx_hash          | BLOB      |    | Y        |          | The hash of transaction |
 |  utxo_key         | BLOB      |    | Y        |          | The hash of the UTXO|
+|  type             | INTEGER   |    | Y        |          | The type of transaction output  |
 |  amount           | NUMERIC   |    | Y        |          | The monetary value of this output, in 1/10^7|
 |  lock_type        | INTEGER   |    | Y        |          | (0: Key; 1: Hash of Key; 2: Script; 3: Hash of Script) |
 |  lock_bytes       | BLOB      |    | Y        |          | The bytes of lock |
@@ -163,6 +164,7 @@ CREATE TABLE IF NOT EXISTS "tx_outputs" (
     "output_index"          INTEGER NOT NULL,
     "tx_hash"               BLOB    NOT NULL,
     "utxo_key"              BLOB    NOT NULL,
+    "type"                  INTEGER NOT NULL,
     "amount"                NUMERIC NOT NULL,
     "lock_type"             INTEGER NOT NULL,
     "lock_bytes"            BLOB    NOT NULL,
@@ -370,6 +372,7 @@ CREATE TABLE IF NOT EXISTS "tx_input_pool" (
 |:----------------- |:--------- |:--:|:--------:| -------- | --------- |
 |  tx_hash          | BLOB      | Y  | Y        |          | The hash of transaction|
 |  output_index     | INTEGER   | Y  | Y        |          | The index of output in the outputs|
+|  type             | INTEGER   |    | Y        |          | The type of transaction output |
 |  amount           | NUMERIC   |    | Y        |          | The monetary value of this output, in 1/10^7|
 |  lock_type        | INTEGER   |    | Y        |          | (0: Key; 1: Hash of Key; 2: Script; 3: Hash of Script) |
 |  lock_bytes       | BLOB      |    | Y        |          | The bytes of lock |
@@ -381,6 +384,7 @@ CREATE TABLE IF NOT EXISTS "tx_input_pool" (
 CREATE TABLE IF NOT EXISTS "tx_output_pool" (
     "tx_hash"               BLOB    NOT NULL,
     "output_index"          INTEGER NOT NULL,
+    "type"                  INTEGER NOT NULL,
     "amount"                NUMERIC NOT NULL,
     "lock_type"             INTEGER NOT NULL,
     "lock_bytes"            BLOB    NOT NULL,

--- a/package-lock.json
+++ b/package-lock.json
@@ -336,9 +336,9 @@
       "dev": true
     },
     "boa-sdk-ts": {
-      "version": "0.0.46",
-      "resolved": "https://registry.npmjs.org/boa-sdk-ts/-/boa-sdk-ts-0.0.46.tgz",
-      "integrity": "sha512-jh2Lcly1SSXN6o6X8tI9GByV7HtcKPl14bcmsGmH3sCEuLGEJFJGLsEbLP7UAC2GT7EpMxFGzRuPWZ5l2H87Gg==",
+      "version": "0.0.47",
+      "resolved": "https://registry.npmjs.org/boa-sdk-ts/-/boa-sdk-ts-0.0.47.tgz",
+      "integrity": "sha512-Lv46sGywo4NHubZ1BDtzRqrc4DDvfiO5JaBv5xIn2kAJBcl04nK8boCPKkORwhRYEwhdo2ZllVLNp7tGDVVf6A==",
       "requires": {
         "@ctrl/ts-base32": "^1.2.1",
         "ajv": "^6.12.6",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "argparse": "^2.0.1",
     "assert": "^2.0.0",
     "axios": "^0.21.1",
-    "boa-sdk-ts": "^0.0.46",
+    "boa-sdk-ts": "^0.0.47",
     "body-parser": "^1.19.0",
     "coingecko-api-v3": "0.0.11",
     "cors": "^2.8.5",

--- a/src/Stoa.ts
+++ b/src/Stoa.ts
@@ -766,7 +766,7 @@ class Stoa extends WebService
                     overview.senders.push({address: elem.address, amount: elem.amount, utxo: new Hash(elem.utxo, Endian.Little).toString(), signature: new Hash(elem.signature, Endian.Little).toString(), index: elem.in_index, unlock_age: elem.unlock_age, bytes: new Hash(elem.bytes, Endian.Little).toString() });
 
                 for (let elem of data.receivers)
-                    overview.receivers.push({address: elem.address, lock_type: elem.lock_type, amount: elem.amount, utxo: new Hash(elem.utxo, Endian.Little).toString(), index: elem.output_index, bytes: hash(elem.bytes).toString()});
+                    overview.receivers.push({type: elem.type, address: elem.address, lock_type: elem.lock_type, amount: elem.amount, utxo: new Hash(elem.utxo, Endian.Little).toString(), index: elem.output_index, bytes: hash(elem.bytes).toString()});
 
                 res.status(200).send(JSON.stringify(overview));
             })

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -168,33 +168,33 @@ export interface IBOAStats
      * Latest height of block
      */
     height: number;
-     
+
     /**
      * Total no. of transactions
      */
     transactions: number;
-         
+
     /**
      * Total no. of validators
      */
     validators: number;
-          
+
     /**
      * Total no. of frozen coins
      */
     frozen_coin: number;
-            
+
     /**
      * Total no. of active validators
      */
     active_validators: number;
-             
+
     /**
      * Circulating supply
      */
     circulating_supply: number;
  }
- 
+
 /**
  * The interface of the block overview
  */
@@ -239,32 +239,32 @@ export interface IBlockOverview
      * Transaction hash
      */
     time: number;
-    
+
     /**
      * total amount sent in block
      */
     total_sent: string;
-    
+
     /**
      * total recieved amount
      */
     total_recieved: string;
-   
+
     /**
      * total rewards
      */
     total_reward: string
-   
+
     /**
      * total fee for the block
      */
     total_fee: string
-    
+
     /**
      * total size of the block
      */
     total_size: number
-    
+
     /**
      * Agora version
      */
@@ -285,17 +285,17 @@ export interface IBlockEnrollmentElements
      * The hash of UTXO
      */
     utxo: string;
-    
+
     /**
      * Random seed
      */
     commitment: string,
-     
+
     /**
      * Enroll signature
      */
     enroll_sig: string,
-         
+
     /**
      * Cycle length
      */
@@ -321,12 +321,12 @@ export interface IBlockTransactionElements
      * Transaction hash
      */
     tx_hash: string;
-    
+
     /**
      * Block height
      */
     height: string;
-    
+
     /**
      * Transaction amount
      */
@@ -372,12 +372,12 @@ export interface IBlockTransactionElements
       * Transactions record
       */
      tx: Array<IBlockTransactionElements>;
-     
+
      /**
       * Total record
       */
      total_data: string;
- 
+
  }
 
 /**
@@ -460,6 +460,7 @@ export interface ITxOverviewOutputElement
      * Address, Public key
      */
     address: string;
+
     /**
      * Lock type
      */
@@ -661,36 +662,41 @@ export interface IBlock {
     /**
      * block height
      */
-    height: string,
+    height: string;
+
     /**
      * hash of block
     */
-    hash: string,
+    hash: string;
+
     /**
      * merkle root of block
      */
-    merkle_root: string,
+    merkle_root: string;
 
     /**
-     * validators of block 
+     * validators of block
      */
-    validators: string
+    validators: string;
+
     /**
      * signature of blcok
      */
-    signature: string
+    signature: string;
     /**
      * no of transactions in the block
      */
-    tx_count: number
+    tx_count: number;
+
     /**
      * enrollemnet counts in that block
      */
-    enrollment_count: string
+    enrollment_count: string;
+
     /**
      * timestamp of the block
      */
-    time_stamp: string
+    time_stamp: string;
 }
 
 /**
@@ -702,37 +708,37 @@ export interface ITransaction
     /**
     * Block height
     */
-    height: string,
-  
+    height: string;
+
    /**
     * Hash of the transaction
     */
-    tx_hash: string,
-  
+    tx_hash: string;
+
    /**
     * Type of the transaction
     */
-    type: string,
+    type: string;
 
    /**
     * amount of transaction
     */
-    amount: string
-   
+    amount: string;
+
    /**
-    * tranaction fee 
+    * tranaction fee
     */
-    tx_fee: string
-   
+    tx_fee: string;
+
    /**
     * size of the tranaction
     */
-    tx_size: string
-   
+    tx_size: string;
+
     /**
     * timestamp of the tranasaction
     */
-    time_stamp: string
+    time_stamp: string;
 }
 
 /**
@@ -742,14 +748,14 @@ export interface ITransaction
 export interface IPagination
 {
     /**
-     * page size 
+     * page size
      */
-    pageSize: number,
-    
+    pageSize: number;
+
     /**
      * page number
      */
-    page: number
+    page: number;
 }
 
 /**
@@ -761,28 +767,28 @@ export interface IMarketCap
     /**
      * Price of BOA in usd
      */
-    price: number
+    price: number;
 
     /**
      * market cap of BOA
      */
-    market_cap: number
+    market_cap: number;
 
     /**
      * Change percentage in 24h
      */
-    change_24h?: number
+    change_24h?: number;
 
     /**
      * 24 hour volumne
      */
-    vol_24h: number
-    
+    vol_24h: number;
+
     /**
      * Last updated time
      */
-    last_updated_at: number
-    
+    last_updated_at: number;
+
 }
 
 /**
@@ -796,7 +802,7 @@ export interface IMarketChart
     usd_price: number
 
     /**
-     * Time 
+     * Time
      */
     last_updated_at: number
 }

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -11,7 +11,7 @@
 
  *******************************************************************************/
 
-import { Height, TxType } from 'boa-sdk-ts';
+import { Height, OutputType } from 'boa-sdk-ts';
 
 /**
  * The interface of the Validator
@@ -457,6 +457,11 @@ export interface ITxOverview
 export interface ITxOverviewOutputElement
 {
     /**
+     * Output type
+     */
+    type: number;
+
+    /**
      * Address, Public key
      */
     address: string;
@@ -591,7 +596,7 @@ export class ConvertTypes
     static tx_types: Array<string> = ["payment", "freeze"];
     static display_tx_type: Array<string> = ["inbound", "outbound", "freeze", "payload"];
 
-    public static DisplayTxTypeToString (type: TxType): string
+    public static DisplayTxTypeToString (type: OutputType): string
     {
         if (type < ConvertTypes.display_tx_type.length)
             return ConvertTypes.display_tx_type[type];
@@ -599,7 +604,7 @@ export class ConvertTypes
             return "";
     }
 
-    public static TxTypeToString (type: TxType): string
+    public static TxTypeToString (type: OutputType): string
     {
         if (type < ConvertTypes.tx_types.length)
             return ConvertTypes.tx_types[type];
@@ -708,7 +713,7 @@ export interface ITransaction
     /**
     * Block height
     */
-    height: string;
+    height: string,
 
    /**
     * Hash of the transaction

--- a/tests/Boascan.test.ts
+++ b/tests/Boascan.test.ts
@@ -13,7 +13,7 @@
 
 import {
     BitField, Block, BlockHeader, Enrollment, Height, Hash, Signature, SodiumHelper,
-    Transaction, TxType, TxInput, TxOutput, DataPayload, PublicKey, JSBI
+    Transaction, OutputType, TxInput, TxOutput, DataPayload, PublicKey, JSBI
 } from 'boa-sdk-ts';
 import {
     sample_data,
@@ -95,26 +95,26 @@ describe('Test of Stoa API Server', () => {
         let response = await client.get(uri.toString());
         let expected = [
             {
-                height: '1',
-                hash: '0x1b272e34c3df561450a52cf9e2eab4b1dbff4d710cba755ad76e1b2a906645e0f2b6650e62369f3f56b04a51c82fb36d33c5ef88b59949d37a81ca614902ff8e',
-                merkle_root: '0xc8f96bf274187b0b6fb73c5b609a3fff28bd1fe9e6b712aaa3d9f92351100d7ca718a6c85f5f020cdeb13753179432e710576627399a3235ae472e7fe56b27e6',
-                signature: '0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
-                validators: '[252]',
-                tx_count: '8',
-                enrollment_count: '0',
-                time_stamp: 1609459800
+                "height": "1",
+                "hash": "0x04348b962dac4423cd9ae48b4932ee1607fb1101a690d2583bbad909e8c3f22b12a6d65d1e1494d38681afc7bea61c3d81251800b8adbf1d31f52889df6d7e09",
+                "merkle_root": "0xa82a2d19ae115b521f0d65690e78f66260f5886da76508b72eee62a45cb8cfb5a7b8e300e0042faeb7b28fffc050cceb6c00ef4a326d992ef182969b1857f3d0",
+                "signature": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                "validators": "[252]",
+                "tx_count": "8",
+                "enrollment_count": "0",
+                "time_stamp": 1609459800
             },
             {
-                height: '0',
-                hash: '0x217f5b3f53a52c396c3418c0245c2435a90c53978564efac448e1162ec8647dde9e5c13263390f73f5d5b74e059b79b5286cf292f3121e6f1654ff452f9296f5',
-                merkle_root: '0x8ac592615f23ee726577eb8c305c67558fd08f14120e0f23c2969a3b1d37089009159bd42c1d7af53d601b53ccbbad0ebaa54f36f4bc13d473790921ae3dc7fa',
-                signature: '0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
-                validators: '[0]',
-                tx_count: '2',
-                enrollment_count: '6',
-                time_stamp: 1609459200
+                "height": "0",
+                "hash": "0xba54155d042d03a722dc9234f7de5b304e9efbc896091e28fb3b19b908ee782653b5e6ef44566e19c728ff0eebf65ede6cc485337d5a473b819e86eeb2f7baf8",
+                "merkle_root": "0x4cadc4d240a26ebf8a01ae1c53a4793fec40c92d36d9f8755311420c9594a9fbb827fb974b75774723acbd13b4d0589e957bf8f14da24633be6ae299446ddca7",
+                "signature": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                "validators": "[0]",
+                "tx_count": "2",
+                "enrollment_count": "6",
+                "time_stamp": 1609459200
             }
-        ]
+        ];
         assert.deepStrictEqual(response.data, expected);
     });
     it('Test of the path /latest-transactions', async () => {
@@ -127,96 +127,86 @@ describe('Test of Stoa API Server', () => {
         let response = await client.get(uri.toString());
         let expected = [
             {
-                height: '1',
-                tx_hash: '0xa4ce8dd85f51340bdae780db580e21acacfc94eec3305d83275ff2ea2d5583d75b8c400e1807952e04f243c4ef80d821e2537a59f20e12857c910bc2e4028bf7',
-                type: 0,
-                amount: '610000000000000',
-                tx_fee: '0',
-                tx_size: '1166',
-                time_stamp: 1609459800
+                "height": "1",
+                "tx_hash": "0xdd75be9a8b2778deb99734dfb17f70c3635afff654342cc1c306ba0fc69eb72494c9e3c4543eaa6974757204ff19a521989b6ab4c6d41de535b8e634faf66183",
+                "amount": "610000000000000",
+                "tx_fee": "0",
+                "tx_size": "1190",
+                "time_stamp": 1609459800
             },
             {
-                height: '1',
-                tx_hash: '0x63f299f3af18e0f333f2dbfe4a13377fbc7d11e3fb9ba0b899b4acd7219ad4c47b56481fc59979b933b33240b36aa4c090bf0440bd18e7a2e6d5405caa885794',
-                type: 0,
-                amount: '610000000000000',
-                tx_fee: '0',
-                tx_size: '1166',
-                time_stamp: 1609459800
+                "height": "1",
+                "tx_hash": "0x7989e23b6797d654499784cf70a97990b399948c7ed66663f6df31ea279c9200f770e39e72be7670b4daef64f6468b78891c29dad30c4c0a02d0b874ace16a23",
+                "amount": "610000000000000",
+                "tx_fee": "0",
+                "tx_size": "1190",
+                "time_stamp": 1609459800
             },
             {
-                height: '1',
-                tx_hash: '0xdcc5ba48d932f9681028f6aad42ac77ec2363a2279c0441aebbf419b32c81a445f2d4ffe5d1e72f86e7c3750b5ef56e1054ca84d8578ddaa88659b7bd829404e',
-                type: 0,
-                amount: '610000000000000',
-                tx_fee: '0',
-                tx_size: '1166',
-                time_stamp: 1609459800
+                "height": "1",
+                "tx_hash": "0xd9ccb48a1d1009c4cca92ce3658fd622ccb8892fb455d4b332826263a47beb8165be34ece8c885d90fcf0f678f391584a602302a8115744c1026bd55c8f9aadb",
+                "amount": "610000000000000",
+                "tx_fee": "0",
+                "tx_size": "1190",
+                "time_stamp": 1609459800
             },
             {
-                height: '1',
-                tx_hash: '0x9823f761a9f55d222861aa6702ad79cf76869552038dfe8ec601c34b3e8c600320febba7aaa44028681e6e039b18508c2d1daf999ef606d11d69f6494bd0ce88',
-                type: 0,
-                amount: '610000000000000',
-                tx_fee: '0',
-                tx_size: '1166',
-                time_stamp: 1609459800
+                "height": "1",
+                "tx_hash": "0x44707116a8fd9422048ab3164d9daa8577059fb98ae50c8ae20d64f0d126a02b244d08348d2ef1600f107687eb9d6792bc725773576fed16c60ea21d483636e1",
+                "amount": "610000000000000",
+                "tx_fee": "0",
+                "tx_size": "1190",
+                "time_stamp": 1609459800
             },
             {
-                height: '1',
-                tx_hash: '0x21f88b970256eb38f347322b07fcfdfb03eb5ba10bda3a2c2d2eac3feeaf8f073d66e3802922385a883fa2fa1dc3e1e5535ef0024eb69f839d8af23c2fa0e7af',
-                type: 0,
-                amount: '610000000000000',
-                tx_fee: '0',
-                tx_size: '1166',
-                time_stamp: 1609459800
+                "height": "1",
+                "tx_hash": "0xab31502552c985ac93c598274f11398f0543d41a66e8ae4371a1f026fd5db74dba68dc28cb90e34311facf73efde7857f3e484205224e71ff1dde63ad1c3cf5a",
+                "amount": "610000000000000",
+                "tx_fee": "0",
+                "tx_size": "1190",
+                "time_stamp": 1609459800
             },
             {
-                height: '1',
-                tx_hash: '0x3d04887353ad6eed2b61f0be74972d078eb432c5d37555b7e87aefb15a04815e4b1bea6b78c566936cbfebf5b4a8d412804881570f87555e423c1b99919c609d',
-                type: 0,
-                amount: '610000000000000',
-                tx_fee: '0',
-                tx_size: '1166',
-                time_stamp: 1609459800
+                "height": "1",
+                "tx_hash": "0x067d37b7f625baccc66186f0426fa7eb61b1657e6bf520b7bfeab0b4759a282c7604a4eac5509ba78e2a71224983237da2c75657a38a22c5f42419fd3ba2eb2b",
+                "amount": "610000000000000",
+                "tx_fee": "0",
+                "tx_size": "1190",
+                "time_stamp": 1609459800
             },
             {
-                height: '1',
-                tx_hash: '0xbc5d1308b9e2c0e32c6b6fbbbd8f955393fa190a81307d37d82e6bd4608621f8227da1c071b35edf42608c734a694946822c2d0dc6d7c8e2b697beb58888b9aa',
-                type: 0,
-                amount: '610000000000000',
-                tx_fee: '0',
-                tx_size: '1166',
-                time_stamp: 1609459800
+                "height": "1",
+                "tx_hash": "0x0054d7d59d02f6c0d29c66d719324f62146f235bf840cfc2d7a9231cb60cddf85c1f3ab70cbf6bf8d9013f744f8c3998e0e39ba953420e98b42bfd5d014ba102",
+                "amount": "610000000000000",
+                "tx_fee": "0",
+                "tx_size": "1190",
+                "time_stamp": 1609459800
             },
             {
-                height: '1',
-                tx_hash: '0xabf0830cc549d3a1be744a8b484b69236b27e8bd4f7950b1edb8fb5bd9eff31fc58bc5a645ab3a81fbd48fddb38e4677539924036de415e1a96b9a440ed4fa3d',
-                type: 0,
-                amount: '610000000000000',
-                tx_fee: '0',
-                tx_size: '1166',
-                time_stamp: 1609459800
+                "height": "1",
+                "tx_hash": "0x59595807eb5da775fe50fe0636f22aef76b0e8b33edf8a5ef8999127b350908d4fa6b0865c10b948b2cc802efa536ca344927a3f190c321972bb943c56838f29",
+                "amount": "610000000000000",
+                "tx_fee": "0",
+                "tx_size": "1190",
+                "time_stamp": 1609459800
             },
             {
-                height: '0',
-                tx_hash: '0xd7f9204afdc2d41b28a33504d21b3c5384758d851c573dde44da26d7a0c7de06fde6127ec740fbfdfafbed4fb13cff24144054b8ae2ab34582110f0f752316aa',
-                type: 1,
-                amount: '120000000000000',
-                tx_fee: '0',
-                tx_size: '255',
-                time_stamp: 1609459200
+                "height": "0",
+                "tx_hash": "0xff66ffde4ed3b91c5bce28907dd68f7ecabe776c1dc7d797e5f69fc349d28342348c778cd42c49ef2c29199f374289d44f5b4d2d149f0b8081a1077eca30f7ce",
+                "amount": "120000000000000",
+                "tx_fee": "0",
+                "tx_size": "260",
+                "time_stamp": 1609459200
             },
             {
-                height: '0',
-                tx_hash: '0xd4b2011f46b7de32e6a3f51eae35c97440b7adf427df7725d19575b8a9a8256552939656f8b5d4087b9bcbbe9219504e31f91a85fb1709683cbefc3962639ecd',
-                type: 0,
-                amount: '4880000000000000',
-                tx_fee: '0',
-                tx_size: '337',
-                time_stamp: 1609459200
+                "height": "0",
+                "tx_hash": "0x9384e68e59382a256d2598251758d3c44f6b48f9a6aa405272e7b5f536dc0f2d3b3fd76b9352ddbf199a4862b05e4300a484ebd3e591abd1df596854debb4d5e",
+                "amount": "4880000000000000",
+                "tx_fee": "0",
+                "tx_size": "344",
+                "time_stamp": 1609459200
             }
-        ]
+        ];
         assert.deepStrictEqual(response.data, expected);
     });
     it('Test of the path /block-summary with block height', async () => {
@@ -227,21 +217,21 @@ describe('Test of Stoa API Server', () => {
 
         let response = await client.get(uri.toString());
         let expected = {
-            height: '1',
-            total_transactions: 8,
-            hash: '0x1b272e34c3df561450a52cf9e2eab4b1dbff4d710cba755ad76e1b2a906645e0f2b6650e62369f3f56b04a51c82fb36d33c5ef88b59949d37a81ca614902ff8e',
-            prev_hash: '0x217f5b3f53a52c396c3418c0245c2435a90c53978564efac448e1162ec8647dde9e5c13263390f73f5d5b74e059b79b5286cf292f3121e6f1654ff452f9296f5',
-            merkle_root: '0xc8f96bf274187b0b6fb73c5b609a3fff28bd1fe9e6b712aaa3d9f92351100d7ca718a6c85f5f020cdeb13753179432e710576627399a3235ae472e7fe56b27e6',
-            signature: '0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
-            random_seed: '0x691775809b9498f45a2c5ef8b8d552e318ebaf0b1b2fb15dcc39e0ec962ae9812d7edffa5f053590a895c9ff72c1b0838ce8f5c709579d4529f9f4caf0fab13d',
-            time: 1609459800,
-            version: 'v0.x.x',
-            total_sent: 4880000000000000,
-            total_recieved: 4880000000000000,
-            total_reward: 0,
-            total_fee: 0,
-            total_size: 9328
-        }
+            "height": "1",
+            "total_transactions": 8,
+            "hash": "0x04348b962dac4423cd9ae48b4932ee1607fb1101a690d2583bbad909e8c3f22b12a6d65d1e1494d38681afc7bea61c3d81251800b8adbf1d31f52889df6d7e09",
+            "prev_hash": "0xba54155d042d03a722dc9234f7de5b304e9efbc896091e28fb3b19b908ee782653b5e6ef44566e19c728ff0eebf65ede6cc485337d5a473b819e86eeb2f7baf8",
+            "merkle_root": "0xa82a2d19ae115b521f0d65690e78f66260f5886da76508b72eee62a45cb8cfb5a7b8e300e0042faeb7b28fffc050cceb6c00ef4a326d992ef182969b1857f3d0",
+            "signature": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+            "random_seed": "0x691775809b9498f45a2c5ef8b8d552e318ebaf0b1b2fb15dcc39e0ec962ae9812d7edffa5f053590a895c9ff72c1b0838ce8f5c709579d4529f9f4caf0fab13d",
+            "time": 1609459800,
+            "version": "v0.x.x",
+            "total_sent": 4880000000000000,
+            "total_recieved": 4880000000000000,
+            "total_reward": 0,
+            "total_fee": 0,
+            "total_size": 9520
+        };
         assert.deepStrictEqual(response.data, expected);
     });
     it('Test of the path /block-enrollments with block height', async () => {
@@ -253,109 +243,109 @@ describe('Test of Stoa API Server', () => {
             .addSearch("page_size", "10");
         let response = await client.get(uri.toString());
         let expected = {
-            enrollmentElementList: [
+            "enrollmentElementList": [
                 {
-                    height: '0',
-                    utxo: '0xd68cfa6d0457b404d74a0367ace0bd3784110fb55d94692e0859f3b5a15b33f990f33e3b4e4b4030945ee0303fabf7b2702f48a31ffdc3d1d6985e3e3dfcc8d7',
-                    enroll_sig: '0x0cab27862571d2d2e33d6480e1eab4c82195a508b72672d609610d01f23b0beedc8b89135fe3f5df9e2815b9bdb763c41b8b2dab5911e313acc82470c2147422',
-                    commitment: '0x0a8201f9f5096e1ce8e8de4147694940a57a188b78293a55144fc8777a774f2349b3a910fb1fb208514fb16deaf49eb05882cdb6796a81f913c6daac3eb74328',
-                    cycle_length: 20
+                    "height": "0",
+                    "utxo": "0xf8751862d61a28fb878cd4b583ceaf39a59a5f2ff1fa78a169e56811c33b5c3eed80f83074cfb98ab5095ed563ebc6a96320ef59080628c4961f586dbf2e7d2f",
+                    "enroll_sig": "0x0cab27862571d2d2e33d6480e1eab4c82195a508b72672d609610d01f23b0beedc8b89135fe3f5df9e2815b9bdb763c41b8b2dab5911e313acc82470c2147422",
+                    "commitment": "0x0a8201f9f5096e1ce8e8de4147694940a57a188b78293a55144fc8777a774f2349b3a910fb1fb208514fb16deaf49eb05882cdb6796a81f913c6daac3eb74328",
+                    "cycle_length": 20
                 },
                 {
-                    height: '0',
-                    utxo: '0x7f6e35961dbaae3cad2efa0582a6ff2c992973bdd987c41c6d4f4b0e1289158c98b2858b4731c36744ebf92edcb05b3f68838432479aaf1373d123e60ad3448b',
-                    enroll_sig: '0x0ed498b867c33d316b468d817ba8238aec68541abd912cecc499f8e780a8cdaf2692d0b8b04133a34716169a4b1d33d77c3e585357d8a2a2c48a772275255c01',
-                    commitment: '0xd0348a88f9b7456228e4df5689a57438766f4774d760776ec450605c82348c461db84587c2c9b01c67c8ed17f297ee4008424ad3e0e5039179719d7e9df297c1',
-                    cycle_length: 20
+                    "height": "0",
+                    "utxo": "0x896240cd0ef51fdfdff645bb146737f889b70a7d72f9ebb842f9a0c4705de884209c451ccdc15aace878d12dac85f0b5522bf2642204937c5e44944741a1928f",
+                    "enroll_sig": "0x0ed498b867c33d316b468d817ba8238aec68541abd912cecc499f8e780a8cdaf2692d0b8b04133a34716169a4b1d33d77c3e585357d8a2a2c48a772275255c01",
+                    "commitment": "0xd0348a88f9b7456228e4df5689a57438766f4774d760776ec450605c82348c461db84587c2c9b01c67c8ed17f297ee4008424ad3e0e5039179719d7e9df297c1",
+                    "cycle_length": 20
                 },
                 {
-                    height: '0',
-                    utxo: '0xfbb850538245991a7156dc1713535717c530f851554c91de4b21091e88647cc0ee8c296da6fc40b283c048e3ed82cc46abe82cbd5061ba0ea579e1054ab51fcc',
-                    enroll_sig: '0x09474f489579c930dbac46f638f3202ac24407f1fa419c1d95be38ab474da29d7e3d4753b6b4ccdb35c2864be4195e83b7b8433ca1d27a57fb9f48a631001304',
-                    commitment: '0xaf43c67d9dd0f53de3eaede63cdcda8643422d62205df0b5af65706ec28b372adb785ce681d559d7a7137a4494ccbab4658ce11ec75a8ec84be5b73590bffceb',
-                    cycle_length: 20
+                    "height": "0",
+                    "utxo": "0xcbb19dfc2c28ea46ffbf962ca4bcb1a11ab6ccc8d83c9357a1d931915b0b8257cbe131e9bda51bed9668972079cf9f0d9ba0fefa01cbdd94aa05a90eb210d4bb",
+                    "enroll_sig": "0x09474f489579c930dbac46f638f3202ac24407f1fa419c1d95be38ab474da29d7e3d4753b6b4ccdb35c2864be4195e83b7b8433ca1d27a57fb9f48a631001304",
+                    "commitment": "0xaf43c67d9dd0f53de3eaede63cdcda8643422d62205df0b5af65706ec28b372adb785ce681d559d7a7137a4494ccbab4658ce11ec75a8ec84be5b73590bffceb",
+                    "cycle_length": 20
                 },
                 {
-                    height: '0',
-                    utxo: '0x765025088610ec9e6ee82c6373306bfe3c15731234195b9c762859ee3becea85d85de44ca5fef6660bdea5add694e12658ea4060c0ac5c76757829147afcc582',
-                    enroll_sig: '0x0e4566eca30feb9ad47a65e7ff7e7ce1a7555ccedcf61e1143c2e5fddbec6866fd787c4518b78ab9ed73a3760741d557ac2aca631fc2796be86fcf391d3a6634',
-                    commitment: '0xa24b7e6843220d3454523ceb7f9b43f037e56a01d2bee82958b080dc6350ebac2da12b561cbd96c6fb3f5ae5a3c8df0ac2c559ae1c45b11d42fdf866558112bc',
-                    cycle_length: 20
+                    "height": "0",
+                    "utxo": "0xd08bc4c4a5f3341369f6c628e1cb9f3339ad1376b642f8bd95603a2fad6be0db81fa4fa58dadb5dc8f3bc7a020ad1fe8d2d6643238ea2508a37ee58b0df9e9f8",
+                    "enroll_sig": "0x0e4566eca30feb9ad47a65e7ff7e7ce1a7555ccedcf61e1143c2e5fddbec6866fd787c4518b78ab9ed73a3760741d557ac2aca631fc2796be86fcf391d3a6634",
+                    "commitment": "0xa24b7e6843220d3454523ceb7f9b43f037e56a01d2bee82958b080dc6350ebac2da12b561cbd96c6fb3f5ae5a3c8df0ac2c559ae1c45b11d42fdf866558112bc",
+                    "cycle_length": 20
                 },
                 {
-                    height: '0',
-                    utxo: '0xe9786bcd4188dbc27f3bcd9f3097355ad056d7518e8ea5a908adaba7229625a195d2073c512849e856ac7f8f7e0ee463e2e2be6373f3fa3f645640d2e1141151',
-                    enroll_sig: '0x052ee1d975c49f19fd26b077740dcac399f174f40b5df1aba5f09ebea11faacfd79a36ace4d3097869dc009b8939fc83bdf940c8822c6931d5c09326aa746b31',
-                    commitment: '0xa0502960ddbe816729f60aeaa480c7924fb020d864deec6a9db778b8e56dd2ff8e987be748ff6ca0a43597ecb575da5d532696e376dc70bb4567b5b1fa512cb4',
-                    cycle_length: 20
+                    "height": "0",
+                    "utxo": "0x6c87312f75478d515c5dc2bc8beb3ac5686aacbdedc8219baaf9cb62e41b1b31f00233321b3c42f9966ee47916123191f49caf0dc761d3a7fcd69198aa63f2aa",
+                    "enroll_sig": "0x052ee1d975c49f19fd26b077740dcac399f174f40b5df1aba5f09ebea11faacfd79a36ace4d3097869dc009b8939fc83bdf940c8822c6931d5c09326aa746b31",
+                    "commitment": "0xa0502960ddbe816729f60aeaa480c7924fb020d864deec6a9db778b8e56dd2ff8e987be748ff6ca0a43597ecb575da5d532696e376dc70bb4567b5b1fa512cb4",
+                    "cycle_length": 20
                 },
                 {
-                    height: '0',
-                    utxo: '0xa551c7d3076f43857913fa1a7de694df9c1ea5606bc084caa4c7cd7868a74c9f80c303ce64324becfadf8e092781a6b5ea9c76ec81bc5f5fa18fd523b333a1a2',
-                    enroll_sig: '0x0e0070e5951ef5be897cb593c4c57ce28b7529463f7e5644b1314ab7cc69fd625c71e74382a24b7e644d32b0306fe3cf14ecd7de5635c70aa592f4721aa74fe2',
-                    commitment: '0xdd1b9c62d4c62246ea124e5422d5a2e23d3ca9accb0eba0e46cd46708a4e7b417f46df34dc2e3cba9a57b1dc35a66dfc2d5ef239ebeaaa00299232bc7e3b7bfa',
-                    cycle_length: 20
+                    "height": "0",
+                    "utxo": "0xda34f8f20fc231d4c3fe7f0190d5980c748dc82cc213ee7eb60d5c3f21c156b2a8b2113cfb48b3a02c049245e8682ff1da55b59b35abdd3832418675ccf2e29f",
+                    "enroll_sig": "0x0e0070e5951ef5be897cb593c4c57ce28b7529463f7e5644b1314ab7cc69fd625c71e74382a24b7e644d32b0306fe3cf14ecd7de5635c70aa592f4721aa74fe2",
+                    "commitment": "0xdd1b9c62d4c62246ea124e5422d5a2e23d3ca9accb0eba0e46cd46708a4e7b417f46df34dc2e3cba9a57b1dc35a66dfc2d5ef239ebeaaa00299232bc7e3b7bfa",
+                    "cycle_length": 20
                 }
             ],
-            total_data: 6
-        }
+            "total_data": 6
+        };
         assert.deepStrictEqual(response.data, expected);
     });
     it('Test of the path /block-enrollments with block hash', async () => {
         let uri = URI(host)
             .port(port)
             .directory("block-enrollments")
-            .addSearch("hash", "0x217f5b3f53a52c396c3418c0245c2435a90c53978564efac448e1162ec8647dde9e5c13263390f73f5d5b74e059b79b5286cf292f3121e6f1654ff452f9296f5")
+            .addSearch("hash", "0xba54155d042d03a722dc9234f7de5b304e9efbc896091e28fb3b19b908ee782653b5e6ef44566e19c728ff0eebf65ede6cc485337d5a473b819e86eeb2f7baf8")
             .addSearch("page", "1")
             .addSearch("page_size", "10");
         let response = await client.get(uri.toString());
         let expected = {
-            enrollmentElementList: [
+            "enrollmentElementList": [
                 {
-                    height: '0',
-                    utxo: '0xd68cfa6d0457b404d74a0367ace0bd3784110fb55d94692e0859f3b5a15b33f990f33e3b4e4b4030945ee0303fabf7b2702f48a31ffdc3d1d6985e3e3dfcc8d7',
-                    enroll_sig: '0x0cab27862571d2d2e33d6480e1eab4c82195a508b72672d609610d01f23b0beedc8b89135fe3f5df9e2815b9bdb763c41b8b2dab5911e313acc82470c2147422',
-                    commitment: '0x0a8201f9f5096e1ce8e8de4147694940a57a188b78293a55144fc8777a774f2349b3a910fb1fb208514fb16deaf49eb05882cdb6796a81f913c6daac3eb74328',
-                    cycle_length: 20
+                    "height": "0",
+                    "utxo": "0xf8751862d61a28fb878cd4b583ceaf39a59a5f2ff1fa78a169e56811c33b5c3eed80f83074cfb98ab5095ed563ebc6a96320ef59080628c4961f586dbf2e7d2f",
+                    "enroll_sig": "0x0cab27862571d2d2e33d6480e1eab4c82195a508b72672d609610d01f23b0beedc8b89135fe3f5df9e2815b9bdb763c41b8b2dab5911e313acc82470c2147422",
+                    "commitment": "0x0a8201f9f5096e1ce8e8de4147694940a57a188b78293a55144fc8777a774f2349b3a910fb1fb208514fb16deaf49eb05882cdb6796a81f913c6daac3eb74328",
+                    "cycle_length": 20
                 },
                 {
-                    height: '0',
-                    utxo: '0x7f6e35961dbaae3cad2efa0582a6ff2c992973bdd987c41c6d4f4b0e1289158c98b2858b4731c36744ebf92edcb05b3f68838432479aaf1373d123e60ad3448b',
-                    enroll_sig: '0x0ed498b867c33d316b468d817ba8238aec68541abd912cecc499f8e780a8cdaf2692d0b8b04133a34716169a4b1d33d77c3e585357d8a2a2c48a772275255c01',
-                    commitment: '0xd0348a88f9b7456228e4df5689a57438766f4774d760776ec450605c82348c461db84587c2c9b01c67c8ed17f297ee4008424ad3e0e5039179719d7e9df297c1',
-                    cycle_length: 20
+                    "height": "0",
+                    "utxo": "0x896240cd0ef51fdfdff645bb146737f889b70a7d72f9ebb842f9a0c4705de884209c451ccdc15aace878d12dac85f0b5522bf2642204937c5e44944741a1928f",
+                    "enroll_sig": "0x0ed498b867c33d316b468d817ba8238aec68541abd912cecc499f8e780a8cdaf2692d0b8b04133a34716169a4b1d33d77c3e585357d8a2a2c48a772275255c01",
+                    "commitment": "0xd0348a88f9b7456228e4df5689a57438766f4774d760776ec450605c82348c461db84587c2c9b01c67c8ed17f297ee4008424ad3e0e5039179719d7e9df297c1",
+                    "cycle_length": 20
                 },
                 {
-                    height: '0',
-                    utxo: '0xfbb850538245991a7156dc1713535717c530f851554c91de4b21091e88647cc0ee8c296da6fc40b283c048e3ed82cc46abe82cbd5061ba0ea579e1054ab51fcc',
-                    enroll_sig: '0x09474f489579c930dbac46f638f3202ac24407f1fa419c1d95be38ab474da29d7e3d4753b6b4ccdb35c2864be4195e83b7b8433ca1d27a57fb9f48a631001304',
-                    commitment: '0xaf43c67d9dd0f53de3eaede63cdcda8643422d62205df0b5af65706ec28b372adb785ce681d559d7a7137a4494ccbab4658ce11ec75a8ec84be5b73590bffceb',
-                    cycle_length: 20
+                    "height": "0",
+                    "utxo": "0xcbb19dfc2c28ea46ffbf962ca4bcb1a11ab6ccc8d83c9357a1d931915b0b8257cbe131e9bda51bed9668972079cf9f0d9ba0fefa01cbdd94aa05a90eb210d4bb",
+                    "enroll_sig": "0x09474f489579c930dbac46f638f3202ac24407f1fa419c1d95be38ab474da29d7e3d4753b6b4ccdb35c2864be4195e83b7b8433ca1d27a57fb9f48a631001304",
+                    "commitment": "0xaf43c67d9dd0f53de3eaede63cdcda8643422d62205df0b5af65706ec28b372adb785ce681d559d7a7137a4494ccbab4658ce11ec75a8ec84be5b73590bffceb",
+                    "cycle_length": 20
                 },
                 {
-                    height: '0',
-                    utxo: '0x765025088610ec9e6ee82c6373306bfe3c15731234195b9c762859ee3becea85d85de44ca5fef6660bdea5add694e12658ea4060c0ac5c76757829147afcc582',
-                    enroll_sig: '0x0e4566eca30feb9ad47a65e7ff7e7ce1a7555ccedcf61e1143c2e5fddbec6866fd787c4518b78ab9ed73a3760741d557ac2aca631fc2796be86fcf391d3a6634',
-                    commitment: '0xa24b7e6843220d3454523ceb7f9b43f037e56a01d2bee82958b080dc6350ebac2da12b561cbd96c6fb3f5ae5a3c8df0ac2c559ae1c45b11d42fdf866558112bc',
-                    cycle_length: 20
+                    "height": "0",
+                    "utxo": "0xd08bc4c4a5f3341369f6c628e1cb9f3339ad1376b642f8bd95603a2fad6be0db81fa4fa58dadb5dc8f3bc7a020ad1fe8d2d6643238ea2508a37ee58b0df9e9f8",
+                    "enroll_sig": "0x0e4566eca30feb9ad47a65e7ff7e7ce1a7555ccedcf61e1143c2e5fddbec6866fd787c4518b78ab9ed73a3760741d557ac2aca631fc2796be86fcf391d3a6634",
+                    "commitment": "0xa24b7e6843220d3454523ceb7f9b43f037e56a01d2bee82958b080dc6350ebac2da12b561cbd96c6fb3f5ae5a3c8df0ac2c559ae1c45b11d42fdf866558112bc",
+                    "cycle_length": 20
                 },
                 {
-                    height: '0',
-                    utxo: '0xe9786bcd4188dbc27f3bcd9f3097355ad056d7518e8ea5a908adaba7229625a195d2073c512849e856ac7f8f7e0ee463e2e2be6373f3fa3f645640d2e1141151',
-                    enroll_sig: '0x052ee1d975c49f19fd26b077740dcac399f174f40b5df1aba5f09ebea11faacfd79a36ace4d3097869dc009b8939fc83bdf940c8822c6931d5c09326aa746b31',
-                    commitment: '0xa0502960ddbe816729f60aeaa480c7924fb020d864deec6a9db778b8e56dd2ff8e987be748ff6ca0a43597ecb575da5d532696e376dc70bb4567b5b1fa512cb4',
-                    cycle_length: 20
+                    "height": "0",
+                    "utxo": "0x6c87312f75478d515c5dc2bc8beb3ac5686aacbdedc8219baaf9cb62e41b1b31f00233321b3c42f9966ee47916123191f49caf0dc761d3a7fcd69198aa63f2aa",
+                    "enroll_sig": "0x052ee1d975c49f19fd26b077740dcac399f174f40b5df1aba5f09ebea11faacfd79a36ace4d3097869dc009b8939fc83bdf940c8822c6931d5c09326aa746b31",
+                    "commitment": "0xa0502960ddbe816729f60aeaa480c7924fb020d864deec6a9db778b8e56dd2ff8e987be748ff6ca0a43597ecb575da5d532696e376dc70bb4567b5b1fa512cb4",
+                    "cycle_length": 20
                 },
                 {
-                    height: '0',
-                    utxo: '0xa551c7d3076f43857913fa1a7de694df9c1ea5606bc084caa4c7cd7868a74c9f80c303ce64324becfadf8e092781a6b5ea9c76ec81bc5f5fa18fd523b333a1a2',
-                    enroll_sig: '0x0e0070e5951ef5be897cb593c4c57ce28b7529463f7e5644b1314ab7cc69fd625c71e74382a24b7e644d32b0306fe3cf14ecd7de5635c70aa592f4721aa74fe2',
-                    commitment: '0xdd1b9c62d4c62246ea124e5422d5a2e23d3ca9accb0eba0e46cd46708a4e7b417f46df34dc2e3cba9a57b1dc35a66dfc2d5ef239ebeaaa00299232bc7e3b7bfa',
-                    cycle_length: 20
+                    "height": "0",
+                    "utxo": "0xda34f8f20fc231d4c3fe7f0190d5980c748dc82cc213ee7eb60d5c3f21c156b2a8b2113cfb48b3a02c049245e8682ff1da55b59b35abdd3832418675ccf2e29f",
+                    "enroll_sig": "0x0e0070e5951ef5be897cb593c4c57ce28b7529463f7e5644b1314ab7cc69fd625c71e74382a24b7e644d32b0306fe3cf14ecd7de5635c70aa592f4721aa74fe2",
+                    "commitment": "0xdd1b9c62d4c62246ea124e5422d5a2e23d3ca9accb0eba0e46cd46708a4e7b417f46df34dc2e3cba9a57b1dc35a66dfc2d5ef239ebeaaa00299232bc7e3b7bfa",
+                    "cycle_length": 20
                 }
             ],
-            total_data: 6
-        }
+            "total_data": 6
+        };
         assert.deepStrictEqual(response.data, expected);
     });
     it('Test of the path /block-transactions with block height', async () => {
@@ -367,185 +357,210 @@ describe('Test of Stoa API Server', () => {
             .addSearch("page_size", "10");
         let response = await client.get(uri.toString());
         let expected = {
-            tx: [
+            "tx": [
                 {
-                    height: '0',
-                    tx_hash: '0xd7f9204afdc2d41b28a33504d21b3c5384758d851c573dde44da26d7a0c7de06fde6127ec740fbfdfafbed4fb13cff24144054b8ae2ab34582110f0f752316aa',
-                    amount: '120000000000000',
-                    type: 1,
-                    fee: 0,
-                    size: 255,
-                    time: 1609459200,
-                    sender_address: null,
-                    receiver: [
+                    "height": "0",
+                    "tx_hash": "0xff66ffde4ed3b91c5bce28907dd68f7ecabe776c1dc7d797e5f69fc349d28342348c778cd42c49ef2c29199f374289d44f5b4d2d149f0b8081a1077eca30f7ce",
+                    "amount": "120000000000000",
+                    "fee": 0,
+                    "size": 260,
+                    "time": 1609459200,
+                    "sender_address": null,
+                    "receiver": [
                         {
-                            amount: 20000000000000,
-                            address: 'boa1xpvald2ydpxzl9aat978kv78y5g24jxy46mcnl7munf4jyhd0zjrc5x62kn'
+                            "type": 1,
+                            "amount": 20000000000000,
+                            "address": "boa1xpvald2ydpxzl9aat978kv78y5g24jxy46mcnl7munf4jyhd0zjrc5x62kn"
                         },
                         {
-                            amount: 20000000000000,
-                            address: 'boa1xzvald5dvy54j7yt2h5yzs2432h07rcn66j84t3lfdrlrwydwq78cz0nckq'
+                            "type": 1,
+                            "amount": 20000000000000,
+                            "address": "boa1xzvald5dvy54j7yt2h5yzs2432h07rcn66j84t3lfdrlrwydwq78cz0nckq"
                         },
                         {
-                            amount: 20000000000000,
-                            address: 'boa1xzvald7hxvgnzk50sy04ha7ezgyytxt5sgw323zy8dlj3ya2q40e6elltwq'
+                            "type": 1,
+                            "amount": 20000000000000,
+                            "address": "boa1xzvald7hxvgnzk50sy04ha7ezgyytxt5sgw323zy8dlj3ya2q40e6elltwq"
                         },
                         {
-                            amount: 20000000000000,
-                            address: 'boa1xrvald3zmehvpcmxqm0kn6wkaqyry7yj3cd8h975ypzlyz00sczpzhsk308'
+                            "type": 1,
+                            "amount": 20000000000000,
+                            "address": "boa1xrvald3zmehvpcmxqm0kn6wkaqyry7yj3cd8h975ypzlyz00sczpzhsk308"
                         },
                         {
-                            amount: 20000000000000,
-                            address: 'boa1xrvald4v2gy790stemq4gg37v4us7ztsxq032z9jmlxfh6xh9xfak4qglku'
+                            "type": 1,
+                            "amount": 20000000000000,
+                            "address": "boa1xrvald4v2gy790stemq4gg37v4us7ztsxq032z9jmlxfh6xh9xfak4qglku"
                         },
                         {
-                            amount: 20000000000000,
-                            address: 'boa1xrvald6jsqfuctlr4nr4h9c224vuah8vgv7f9rzjauwev7j8tj04qee8f0t'
+                            "type": 1,
+                            "amount": 20000000000000,
+                            "address": "boa1xrvald6jsqfuctlr4nr4h9c224vuah8vgv7f9rzjauwev7j8tj04qee8f0t"
                         }
                     ]
                 },
                 {
-                    height: '0',
-                    tx_hash: '0xd4b2011f46b7de32e6a3f51eae35c97440b7adf427df7725d19575b8a9a8256552939656f8b5d4087b9bcbbe9219504e31f91a85fb1709683cbefc3962639ecd',
-                    amount: '4880000000000000',
-                    type: 0,
-                    fee: 0,
-                    size: 337,
-                    time: 1609459200,
-                    sender_address: null,
-                    receiver: [
+                    "height": "0",
+                    "tx_hash": "0x9384e68e59382a256d2598251758d3c44f6b48f9a6aa405272e7b5f536dc0f2d3b3fd76b9352ddbf199a4862b05e4300a484ebd3e591abd1df596854debb4d5e",
+                    "amount": "4880000000000000",
+                    "fee": 0,
+                    "size": 344,
+                    "time": 1609459200,
+                    "sender_address": null,
+                    "receiver": [
                         {
-                            amount: 610000000000000,
-                            address: 'boa1xzgenes5cf8xel37fz79gzs49v56znllk7jw7qscjwl5p6a9zxk8zaygm67'
+                            "type": 0,
+                            "amount": 610000000000000,
+                            "address": "boa1xzgenes5cf8xel37fz79gzs49v56znllk7jw7qscjwl5p6a9zxk8zaygm67"
                         },
                         {
-                            amount: 610000000000000,
-                            address: 'boa1xzgenes5cf8xel37fz79gzs49v56znllk7jw7qscjwl5p6a9zxk8zaygm67'
+                            "type": 0,
+                            "amount": 610000000000000,
+                            "address": "boa1xzgenes5cf8xel37fz79gzs49v56znllk7jw7qscjwl5p6a9zxk8zaygm67"
                         },
                         {
-                            amount: 610000000000000,
-                            address: 'boa1xzgenes5cf8xel37fz79gzs49v56znllk7jw7qscjwl5p6a9zxk8zaygm67'
+                            "type": 0,
+                            "amount": 610000000000000,
+                            "address": "boa1xzgenes5cf8xel37fz79gzs49v56znllk7jw7qscjwl5p6a9zxk8zaygm67"
                         },
                         {
-                            amount: 610000000000000,
-                            address: 'boa1xzgenes5cf8xel37fz79gzs49v56znllk7jw7qscjwl5p6a9zxk8zaygm67'
+                            "type": 0,
+                            "amount": 610000000000000,
+                            "address": "boa1xzgenes5cf8xel37fz79gzs49v56znllk7jw7qscjwl5p6a9zxk8zaygm67"
                         },
                         {
-                            amount: 610000000000000,
-                            address: 'boa1xzgenes5cf8xel37fz79gzs49v56znllk7jw7qscjwl5p6a9zxk8zaygm67'
+                            "type": 0,
+                            "amount": 610000000000000,
+                            "address": "boa1xzgenes5cf8xel37fz79gzs49v56znllk7jw7qscjwl5p6a9zxk8zaygm67"
                         },
                         {
-                            amount: 610000000000000,
-                            address: 'boa1xzgenes5cf8xel37fz79gzs49v56znllk7jw7qscjwl5p6a9zxk8zaygm67'
+                            "type": 0,
+                            "amount": 610000000000000,
+                            "address": "boa1xzgenes5cf8xel37fz79gzs49v56znllk7jw7qscjwl5p6a9zxk8zaygm67"
                         },
                         {
-                            amount: 610000000000000,
-                            address: 'boa1xzgenes5cf8xel37fz79gzs49v56znllk7jw7qscjwl5p6a9zxk8zaygm67'
+                            "type": 0,
+                            "amount": 610000000000000,
+                            "address": "boa1xzgenes5cf8xel37fz79gzs49v56znllk7jw7qscjwl5p6a9zxk8zaygm67"
                         },
                         {
-                            amount: 610000000000000,
-                            address: 'boa1xzgenes5cf8xel37fz79gzs49v56znllk7jw7qscjwl5p6a9zxk8zaygm67'
+                            "type": 0,
+                            "amount": 610000000000000,
+                            "address": "boa1xzgenes5cf8xel37fz79gzs49v56znllk7jw7qscjwl5p6a9zxk8zaygm67"
                         }
                     ]
                 }
             ],
-            total_data: 2
-        }
+            "total_data": 2
+        };
         assert.deepStrictEqual(response.data, expected);
     });
+
     it('Test of the path /block-transactions with block hash', async () => {
         let uri = URI(host)
             .port(port)
             .directory("block-transactions")
-            .addSearch("hash", "0x217f5b3f53a52c396c3418c0245c2435a90c53978564efac448e1162ec8647dde9e5c13263390f73f5d5b74e059b79b5286cf292f3121e6f1654ff452f9296f5")
+            .addSearch("hash", "0xba54155d042d03a722dc9234f7de5b304e9efbc896091e28fb3b19b908ee782653b5e6ef44566e19c728ff0eebf65ede6cc485337d5a473b819e86eeb2f7baf8")
             .addSearch("page", "1")
             .addSearch("page_size", "10");
         let response = await client.get(uri.toString());
         let expected = {
-            tx: [
+            "tx": [
                 {
-                    height: '0',
-                    tx_hash: '0xd7f9204afdc2d41b28a33504d21b3c5384758d851c573dde44da26d7a0c7de06fde6127ec740fbfdfafbed4fb13cff24144054b8ae2ab34582110f0f752316aa',
-                    amount: '120000000000000',
-                    type: 1,
-                    fee: 0,
-                    size: 255,
-                    time: 1609459200,
-                    sender_address: null,
-                    receiver: [
+                    "height": "0",
+                    "tx_hash": "0xff66ffde4ed3b91c5bce28907dd68f7ecabe776c1dc7d797e5f69fc349d28342348c778cd42c49ef2c29199f374289d44f5b4d2d149f0b8081a1077eca30f7ce",
+                    "amount": "120000000000000",
+                    "fee": 0,
+                    "size": 260,
+                    "time": 1609459200,
+                    "sender_address": null,
+                    "receiver": [
                         {
-                            amount: 20000000000000,
-                            address: 'boa1xpvald2ydpxzl9aat978kv78y5g24jxy46mcnl7munf4jyhd0zjrc5x62kn'
+                            "type": 1,
+                            "amount": 20000000000000,
+                            "address": "boa1xpvald2ydpxzl9aat978kv78y5g24jxy46mcnl7munf4jyhd0zjrc5x62kn"
                         },
                         {
-                            amount: 20000000000000,
-                            address: 'boa1xzvald5dvy54j7yt2h5yzs2432h07rcn66j84t3lfdrlrwydwq78cz0nckq'
+                            "type": 1,
+                            "amount": 20000000000000,
+                            "address": "boa1xzvald5dvy54j7yt2h5yzs2432h07rcn66j84t3lfdrlrwydwq78cz0nckq"
                         },
                         {
-                            amount: 20000000000000,
-                            address: 'boa1xzvald7hxvgnzk50sy04ha7ezgyytxt5sgw323zy8dlj3ya2q40e6elltwq'
+                            "type": 1,
+                            "amount": 20000000000000,
+                            "address": "boa1xzvald7hxvgnzk50sy04ha7ezgyytxt5sgw323zy8dlj3ya2q40e6elltwq"
                         },
                         {
-                            amount: 20000000000000,
-                            address: 'boa1xrvald3zmehvpcmxqm0kn6wkaqyry7yj3cd8h975ypzlyz00sczpzhsk308'
+                            "type": 1,
+                            "amount": 20000000000000,
+                            "address": "boa1xrvald3zmehvpcmxqm0kn6wkaqyry7yj3cd8h975ypzlyz00sczpzhsk308"
                         },
                         {
-                            amount: 20000000000000,
-                            address: 'boa1xrvald4v2gy790stemq4gg37v4us7ztsxq032z9jmlxfh6xh9xfak4qglku'
+                            "type": 1,
+                            "amount": 20000000000000,
+                            "address": "boa1xrvald4v2gy790stemq4gg37v4us7ztsxq032z9jmlxfh6xh9xfak4qglku"
                         },
                         {
-                            amount: 20000000000000,
-                            address: 'boa1xrvald6jsqfuctlr4nr4h9c224vuah8vgv7f9rzjauwev7j8tj04qee8f0t'
+                            "type": 1,
+                            "amount": 20000000000000,
+                            "address": "boa1xrvald6jsqfuctlr4nr4h9c224vuah8vgv7f9rzjauwev7j8tj04qee8f0t"
                         }
                     ]
                 },
                 {
-                    height: '0',
-                    tx_hash: '0xd4b2011f46b7de32e6a3f51eae35c97440b7adf427df7725d19575b8a9a8256552939656f8b5d4087b9bcbbe9219504e31f91a85fb1709683cbefc3962639ecd',
-                    amount: '4880000000000000',
-                    type: 0,
-                    fee: 0,
-                    size: 337,
-                    time: 1609459200,
-                    sender_address: null,
-                    receiver: [
+                    "height": "0",
+                    "tx_hash": "0x9384e68e59382a256d2598251758d3c44f6b48f9a6aa405272e7b5f536dc0f2d3b3fd76b9352ddbf199a4862b05e4300a484ebd3e591abd1df596854debb4d5e",
+                    "amount": "4880000000000000",
+                    "fee": 0,
+                    "size": 344,
+                    "time": 1609459200,
+                    "sender_address": null,
+                    "receiver": [
                         {
-                            amount: 610000000000000,
-                            address: 'boa1xzgenes5cf8xel37fz79gzs49v56znllk7jw7qscjwl5p6a9zxk8zaygm67'
+                            "type": 0,
+                            "amount": 610000000000000,
+                            "address": "boa1xzgenes5cf8xel37fz79gzs49v56znllk7jw7qscjwl5p6a9zxk8zaygm67"
                         },
                         {
-                            amount: 610000000000000,
-                            address: 'boa1xzgenes5cf8xel37fz79gzs49v56znllk7jw7qscjwl5p6a9zxk8zaygm67'
+                            "type": 0,
+                            "amount": 610000000000000,
+                            "address": "boa1xzgenes5cf8xel37fz79gzs49v56znllk7jw7qscjwl5p6a9zxk8zaygm67"
                         },
                         {
-                            amount: 610000000000000,
-                            address: 'boa1xzgenes5cf8xel37fz79gzs49v56znllk7jw7qscjwl5p6a9zxk8zaygm67'
+                            "type": 0,
+                            "amount": 610000000000000,
+                            "address": "boa1xzgenes5cf8xel37fz79gzs49v56znllk7jw7qscjwl5p6a9zxk8zaygm67"
                         },
                         {
-                            amount: 610000000000000,
-                            address: 'boa1xzgenes5cf8xel37fz79gzs49v56znllk7jw7qscjwl5p6a9zxk8zaygm67'
+                            "type": 0,
+                            "amount": 610000000000000,
+                            "address": "boa1xzgenes5cf8xel37fz79gzs49v56znllk7jw7qscjwl5p6a9zxk8zaygm67"
                         },
                         {
-                            amount: 610000000000000,
-                            address: 'boa1xzgenes5cf8xel37fz79gzs49v56znllk7jw7qscjwl5p6a9zxk8zaygm67'
+                            "type": 0,
+                            "amount": 610000000000000,
+                            "address": "boa1xzgenes5cf8xel37fz79gzs49v56znllk7jw7qscjwl5p6a9zxk8zaygm67"
                         },
                         {
-                            amount: 610000000000000,
-                            address: 'boa1xzgenes5cf8xel37fz79gzs49v56znllk7jw7qscjwl5p6a9zxk8zaygm67'
+                            "type": 0,
+                            "amount": 610000000000000,
+                            "address": "boa1xzgenes5cf8xel37fz79gzs49v56znllk7jw7qscjwl5p6a9zxk8zaygm67"
                         },
                         {
-                            amount: 610000000000000,
-                            address: 'boa1xzgenes5cf8xel37fz79gzs49v56znllk7jw7qscjwl5p6a9zxk8zaygm67'
+                            "type": 0,
+                            "amount": 610000000000000,
+                            "address": "boa1xzgenes5cf8xel37fz79gzs49v56znllk7jw7qscjwl5p6a9zxk8zaygm67"
                         },
                         {
-                            amount: 610000000000000,
-                            address: 'boa1xzgenes5cf8xel37fz79gzs49v56znllk7jw7qscjwl5p6a9zxk8zaygm67'
+                            "type": 0,
+                            "amount": 610000000000000,
+                            "address": "boa1xzgenes5cf8xel37fz79gzs49v56znllk7jw7qscjwl5p6a9zxk8zaygm67"
                         }
                     ]
                 }
             ],
-            total_data: 2
-        }
+            "total_data": 2
+        };
         assert.deepStrictEqual(response.data, expected);
     });
     it('Test of the path /boa-stats', async () => {

--- a/tests/Stoa.test.ts
+++ b/tests/Stoa.test.ts
@@ -13,7 +13,7 @@
 
 import {
     BitField, Block, BlockHeader, Enrollment, Height, Hash, Signature, SodiumHelper,
-    Transaction, TxType, TxInput, TxOutput, DataPayload, PublicKey, JSBI
+    Transaction, OutputType, TxInput, TxOutput, DataPayload, PublicKey, JSBI, Sig
 } from 'boa-sdk-ts';
 import {
     sample_data,
@@ -128,7 +128,7 @@ describe ('Test of Stoa API Server', () =>
         let response = await client.get (uri.toString());
         assert.strictEqual(response.data.length, 6);
         assert.strictEqual(response.data[0].address,
-            "boa1xzvald5dvy54j7yt2h5yzs2432h07rcn66j84t3lfdrlrwydwq78cz0nckq");
+            "boa1xpvald2ydpxzl9aat978kv78y5g24jxy46mcnl7munf4jyhd0zjrc5x62kn");
         assert.strictEqual(response.data[0].preimage.height, '');
     });
 
@@ -231,10 +231,10 @@ describe ('Test of Stoa API Server', () =>
             const enroll_sig =
                 new Signature("0x0c48e78972e1b138a37e37ae27a01d5ebdea193088ddef2d9883446efe63086925e8803400d7b93d22b1eef5c475098ce08a5b47e8125cf6b04274cc4db34bfd");
             const utxo_key =
-                new Hash("0xd68cfa6d0457b404d74a0367ace0bd3784110fb55d94692e0859f3b5a15b33f990f33e3b4e4b4030945ee0303fabf7b2702f48a31ffdc3d1d6985e3e3dfcc8d7");
+                new Hash("0xf8751862d61a28fb878cd4b583ceaf39a59a5f2ff1fa78a169e56811c33b5c3eed80f83074cfb98ab5095ed563ebc6a96320ef59080628c4961f586dbf2e7d2f");
             const commitment =
                 new Hash("0xe0c04a5bd47ffc5b065b7d397e251016310c43dc77220bf803b73f1183da00b0e67602b1f95cb18a0059aa1cdf2f9adafe979998364b38cd5c15d92b9b8fd815");
-            const enrollment = new Enrollment(utxo_key, commitment, 20, enroll_sig);
+            const enrollment = new Enrollment(utxo_key, commitment, 20, Sig.fromSignature(enroll_sig));
             const header = new BlockHeader(
                 new Hash(Buffer.alloc(Hash.Width)), new Height("19"), new Hash(Buffer.alloc(Hash.Width)), new BitField([]),
                 new Signature(Buffer.alloc(Signature.Width)), [ enrollment ], new Hash(Buffer.alloc(Hash.Width)), [], 0);
@@ -333,11 +333,11 @@ describe ('Test of Stoa API Server', () =>
         let response = await client.get (uri.toString())
         assert.strictEqual(response.data.height, '1');
         assert.strictEqual(response.data.hash,
-            '0x1b272e34c3df561450a52cf9e2eab4b1dbff4d710cba755ad76e1b2a906645e' +
-            '0f2b6650e62369f3f56b04a51c82fb36d33c5ef88b59949d37a81ca614902ff8e');
+            '0x04348b962dac4423cd9ae48b4932ee1607fb1101a690d2583bbad909e8c3f22' +
+            'b12a6d65d1e1494d38681afc7bea61c3d81251800b8adbf1d31f52889df6d7e09');
         assert.strictEqual(response.data.merkle_root,
-            '0xc8f96bf274187b0b6fb73c5b609a3fff28bd1fe9e6b712aaa3d9f92351100d7' +
-            'ca718a6c85f5f020cdeb13753179432e710576627399a3235ae472e7fe56b27e6');
+            '0xa82a2d19ae115b521f0d65690e78f66260f5886da76508b72eee62a45cb8cfb' +
+            '5a7b8e300e0042faeb7b28fffc050cceb6c00ef4a326d992ef182969b1857f3d0');
         assert.strictEqual(response.data.time_stamp, 1609459800);
 
         uri = URI(host)
@@ -348,11 +348,11 @@ describe ('Test of Stoa API Server', () =>
         response = await client.get (uri.toString())
         assert.strictEqual(response.data.height, '0');
         assert.strictEqual(response.data.hash,
-            '0x217f5b3f53a52c396c3418c0245c2435a90c53978564efac448e1162ec8647d' +
-            'de9e5c13263390f73f5d5b74e059b79b5286cf292f3121e6f1654ff452f9296f5');
+            '0xba54155d042d03a722dc9234f7de5b304e9efbc896091e28fb3b19b908ee782' +
+            '653b5e6ef44566e19c728ff0eebf65ede6cc485337d5a473b819e86eeb2f7baf8');
         assert.strictEqual(response.data.merkle_root,
-            '0x8ac592615f23ee726577eb8c305c67558fd08f14120e0f23c2969a3b1d37089' +
-            '009159bd42c1d7af53d601b53ccbbad0ebaa54f36f4bc13d473790921ae3dc7fa');
+            '0x4cadc4d240a26ebf8a01ae1c53a4793fec40c92d36d9f8755311420c9594a9f' +
+            'bb827fb974b75774723acbd13b4d0589e957bf8f14da24633be6ae299446ddca7');
         assert.strictEqual(response.data.time_stamp, 1609459200);
     });
 
@@ -378,8 +378,8 @@ describe ('Test of Stoa API Server', () =>
         let response = await client.get (uri.toString())
         assert.strictEqual(response.data.length, 2);
         assert.strictEqual(response.data[0].tx_hash,
-            '0x66b6a0e5f58514ccdc0164598bd0b476e0b93294f9eb5b938e006028ebccda7' +
-            '78a36e7f141679c0b101bb6f74befc9a4b09d2d9203bf041409aaa206989bed4e');
+            '0xfbe8c9c8544ed673672607552274aa1f1255375f8bf5f20bb1b7f6fe037a90f' +
+            'fbb84c70d0fd089afe5e6db9f68c5f6456b92f802fbb7a91a1b24353d2c625638');
         assert.strictEqual(response.data[0].address, 'boa1xqcmmns5swnm03zay5wjplgupe65uw4w0dafzsdsqtwq6gv3h3lcz24a8ch');
         assert.strictEqual(response.data[0].amount, '1663400000');
         assert.strictEqual(response.data[0].fee, '0');
@@ -391,27 +391,27 @@ describe ('Test of Stoa API Server', () =>
         let uri = URI(host)
             .port(port)
             .directory("/transaction/status")
-            .filename("0x66b6a0e5f58514ccdc0164598bd0b476e0b93294f9eb5b938e006028ebccda778a36e7f141679c0b101bb6f74befc9a4b09d2d9203bf041409aaa206989bed4e");
+            .filename("0xfbe8c9c8544ed673672607552274aa1f1255375f8bf5f20bb1b7f6fe037a90ffbb84c70d0fd089afe5e6db9f68c5f6456b92f802fbb7a91a1b24353d2c625638");
 
         let response_pending = await client.get(uri.toString());
         let expected_pending = {
             status: 'pending',
-            tx_hash: '0x66b6a0e5f58514ccdc0164598bd0b476e0b93294f9eb5b938e006028ebccda778a36e7f141679c0b101bb6f74befc9a4b09d2d9203bf041409aaa206989bed4e'
+            tx_hash: '0xfbe8c9c8544ed673672607552274aa1f1255375f8bf5f20bb1b7f6fe037a90ffbb84c70d0fd089afe5e6db9f68c5f6456b92f802fbb7a91a1b24353d2c625638'
         }
         assert.deepStrictEqual(response_pending.data, expected_pending);
 
         uri = URI(host)
             .port(port)
             .directory("/transaction/status")
-            .filename("0xa4ce8dd85f51340bdae780db580e21acacfc94eec3305d83275ff2ea2d5583d75b8c400e1807952e04f243c4ef80d821e2537a59f20e12857c910bc2e4028bf7");
+            .filename("0xdd75be9a8b2778deb99734dfb17f70c3635afff654342cc1c306ba0fc69eb72494c9e3c4543eaa6974757204ff19a521989b6ab4c6d41de535b8e634faf66183");
 
         let response_confirmed = await client.get(uri.toString());
         let expected_confirmed = {
             status: "confirmed",
-            tx_hash: "0xa4ce8dd85f51340bdae780db580e21acacfc94eec3305d83275ff2ea2d5583d75b8c400e1807952e04f243c4ef80d821e2537a59f20e12857c910bc2e4028bf7",
+            tx_hash: "0xdd75be9a8b2778deb99734dfb17f70c3635afff654342cc1c306ba0fc69eb72494c9e3c4543eaa6974757204ff19a521989b6ab4c6d41de535b8e634faf66183",
             block: {
                 height: 1,
-                hash: "0x1b272e34c3df561450a52cf9e2eab4b1dbff4d710cba755ad76e1b2a906645e0f2b6650e62369f3f56b04a51c82fb36d33c5ef88b59949d37a81ca614902ff8e"
+                hash: "0x04348b962dac4423cd9ae48b4932ee1607fb1101a690d2583bbad909e8c3f22b12a6d65d1e1494d38681afc7bea61c3d81251800b8adbf1d31f52889df6d7e09"
             }
         };
         assert.deepStrictEqual(response_confirmed.data, expected_confirmed);
@@ -422,22 +422,22 @@ describe ('Test of Stoa API Server', () =>
         let uri = URI(host)
             .port(port)
             .directory("/transaction/pending")
-            .filename("0x66b6a0e5f58514ccdc0164598bd0b476e0b93294f9eb5b938e006028ebccda778a36e7f141679c0b101bb6f74befc9a4b09d2d9203bf041409aaa206989bed4e");
+            .filename("0xfbe8c9c8544ed673672607552274aa1f1255375f8bf5f20bb1b7f6fe037a90ffbb84c70d0fd089afe5e6db9f68c5f6456b92f802fbb7a91a1b24353d2c625638");
 
         let response = await client.get (uri.toString());
         let expected = {
-            "type": 0,
             "inputs": [
                 {
-                    "utxo": "0x0b640f95cec0159edc603291d9e519cf7ab3b141e4be9ae34770a89eb3937ed9a7ad9b601be47683c0b491ca21a67c6d43aca5d603b7489378fb6dafe19391b5",
+                    "utxo": "0xf180e8aede3ea3f6db7872b2af4225f186abc4835e2f1108ea6ee1c56a8edb79c6460de4968696ec1f9a7fe5ab0008d33781a0031d79409825f2ea45df6f7fbd",
                     "unlock": {
-                        "bytes": "lqAIaXCIgcpqhrWHGDyYB7EdArgM9Xc+K9msM5g0pQGj5t7/J1pEEKKHAppCDLQ7lBUHrCjKE9qBNKGrvQ4bAw=="
+                        "bytes": "eZid7mkGwHQGiXW9PybWvZ/mwHRp/mxmDx8I32rrYgKXGWDiGjVM0a/DO4NC2I/2rV4YzR1XEMr8RH5XmaVqKA=="
                     },
                     "unlock_age": 0
                 }
             ],
             "outputs": [
                 {
+                    "type": 0,
                     "value": "1663400000",
                     "lock": {
                         "type": 0,
@@ -445,6 +445,7 @@ describe ('Test of Stoa API Server', () =>
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24398336600000",
                     "lock": {
                         "type": 0,
@@ -465,22 +466,22 @@ describe ('Test of Stoa API Server', () =>
         let uri = URI(host)
             .port(port)
             .directory("/transaction")
-            .filename("0xa4ce8dd85f51340bdae780db580e21acacfc94eec3305d83275ff2ea2d5583d75b8c400e1807952e04f243c4ef80d821e2537a59f20e12857c910bc2e4028bf7");
+            .filename("0xdd75be9a8b2778deb99734dfb17f70c3635afff654342cc1c306ba0fc69eb72494c9e3c4543eaa6974757204ff19a521989b6ab4c6d41de535b8e634faf66183");
 
         let response = await client.get (uri.toString());
         let expected = {
-            "type": 0,
             "inputs": [
                 {
-                    "utxo": "0x6313b9c616f9eac76b11c50885ff32076f49eaca3c58f30eca846a365bc006e5afa0521787d0f984306c1cc8d48a918a8885ea2d4d3449538445f7b25411dcd4",
+                    "utxo": "0x57d4bdc5e60ac4b25f7a6502b15b66394ce4d45b48694518e09d382b9fbc9905be211e45973102609621773daac68357fe0dc0a6092a28920d33ef3194c9aed5",
                     "unlock": {
-                        "bytes": "QQDjCceIQtRE9ku/5AEXdHeZQP2KIyAKrxFGPogE5gZ+2bW3qMZUGtX1EhDGXebQmK34LylsRrc9W+CwnYQbbQ=="
+                        "bytes": "yuH5/OkqydVRZNQJSu4GJIOQxGVKCUSDzFJTVYXp5A2+oenm8a9vTdftxTgKxlXJsbLdHw4CLUGKGKY+SA8xaA=="
                     },
                     "unlock_age": 0
                 }
             ],
             "outputs": [
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -488,6 +489,7 @@ describe ('Test of Stoa API Server', () =>
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -495,6 +497,7 @@ describe ('Test of Stoa API Server', () =>
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -502,6 +505,7 @@ describe ('Test of Stoa API Server', () =>
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -509,6 +513,7 @@ describe ('Test of Stoa API Server', () =>
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -516,6 +521,7 @@ describe ('Test of Stoa API Server', () =>
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -523,6 +529,7 @@ describe ('Test of Stoa API Server', () =>
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -530,6 +537,7 @@ describe ('Test of Stoa API Server', () =>
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -537,6 +545,7 @@ describe ('Test of Stoa API Server', () =>
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -544,6 +553,7 @@ describe ('Test of Stoa API Server', () =>
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -551,6 +561,7 @@ describe ('Test of Stoa API Server', () =>
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -558,6 +569,7 @@ describe ('Test of Stoa API Server', () =>
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -565,6 +577,7 @@ describe ('Test of Stoa API Server', () =>
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -572,6 +585,7 @@ describe ('Test of Stoa API Server', () =>
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -579,6 +593,7 @@ describe ('Test of Stoa API Server', () =>
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -586,6 +601,7 @@ describe ('Test of Stoa API Server', () =>
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -593,6 +609,7 @@ describe ('Test of Stoa API Server', () =>
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -600,6 +617,7 @@ describe ('Test of Stoa API Server', () =>
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -607,6 +625,7 @@ describe ('Test of Stoa API Server', () =>
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -614,6 +633,7 @@ describe ('Test of Stoa API Server', () =>
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -621,6 +641,7 @@ describe ('Test of Stoa API Server', () =>
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -628,6 +649,7 @@ describe ('Test of Stoa API Server', () =>
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -635,6 +657,7 @@ describe ('Test of Stoa API Server', () =>
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -642,6 +665,7 @@ describe ('Test of Stoa API Server', () =>
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -649,6 +673,7 @@ describe ('Test of Stoa API Server', () =>
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -736,7 +761,7 @@ describe ('Test of the path /utxo', () =>
         let response = await client.get (uri.toString());
         let expected = [
             {
-                utxo: '0x0b640f95cec0159edc603291d9e519cf7ab3b141e4be9ae34770a89eb3937ed9a7ad9b601be47683c0b491ca21a67c6d43aca5d603b7489378fb6dafe19391b5',
+                utxo: '0xf180e8aede3ea3f6db7872b2af4225f186abc4835e2f1108ea6ee1c56a8edb79c6460de4968696ec1f9a7fe5ab0008d33781a0031d79409825f2ea45df6f7fbd',
                 type: 0,
                 unlock_height: '2',
                 amount: '24400000000000',
@@ -797,13 +822,14 @@ describe ('Test of the path /utxo for freezing', () =>
     let coinMarketService: CoinMarketService;
 
     let blocks: Array<Block> = [];
-    blocks.push(Block.reviver("", sample_data[0]));
-    blocks.push(Block.reviver("", sample_data[1]));
 
     before ('Wait for the package libsodium to finish loading', async () =>
     {
         SodiumHelper.assign(new BOASodium());
         await SodiumHelper.init();
+
+        blocks.push(Block.reviver("", sample_data[0]));
+        blocks.push(Block.reviver("", sample_data[1]));
     });
 
     before('Start a fake Agora', () => {
@@ -860,13 +886,12 @@ describe ('Test of the path /utxo for freezing', () =>
         //  Refund amount is      10,000 BOA
         //  Freezing amount is 2,430,000 BOA
         let tx1 = new Transaction(
-            TxType.Freeze,
             [
                 new TxInput(new Hash(response.data[0].utxo))
             ],
             [
-                new TxOutput(JSBI.BigInt(  "100000000000"), new PublicKey("boa1xparc00qvv984ck00trwmfxuvqmmlwsxwzf3al0tsq5k2rw6aw427ct37mj")),
-                new TxOutput(JSBI.BigInt("24300000000000"), new PublicKey("boa1xparc00qvv984ck00trwmfxuvqmmlwsxwzf3al0tsq5k2rw6aw427ct37mj"))
+                new TxOutput(OutputType.Payment, JSBI.BigInt(  "100000000000"), new PublicKey("boa1xparc00qvv984ck00trwmfxuvqmmlwsxwzf3al0tsq5k2rw6aw427ct37mj")),
+                new TxOutput(OutputType.Freeze, JSBI.BigInt("24300000000000"), new PublicKey("boa1xparc00qvv984ck00trwmfxuvqmmlwsxwzf3al0tsq5k2rw6aw427ct37mj"))
             ],
             DataPayload.init
         );
@@ -882,13 +907,12 @@ describe ('Test of the path /utxo for freezing', () =>
         //  Refund amount is      40,000 BOA
         //  Freezing amount is 2,400,000 BOA
         let tx2 = new Transaction(
-            TxType.Freeze,
             [
                 new TxInput(new Hash(response.data[0].utxo))
             ],
             [
-                new TxOutput(JSBI.BigInt(  "400000000000"), new PublicKey("boa1xrard006yhapr2dzttap6yg3l0rv5yf94hdnmmfj5zkwhhyw80sj785segs")),
-                new TxOutput(JSBI.BigInt("24000000000000"), new PublicKey("boa1xrard006yhapr2dzttap6yg3l0rv5yf94hdnmmfj5zkwhhyw80sj785segs"))
+                new TxOutput(OutputType.Payment, JSBI.BigInt(  "400000000000"), new PublicKey("boa1xrard006yhapr2dzttap6yg3l0rv5yf94hdnmmfj5zkwhhyw80sj785segs")),
+                new TxOutput(OutputType.Freeze, JSBI.BigInt("24000000000000"), new PublicKey("boa1xrard006yhapr2dzttap6yg3l0rv5yf94hdnmmfj5zkwhhyw80sj785segs"))
             ],
             DataPayload.init
         );
@@ -924,11 +948,11 @@ describe ('Test of the path /utxo for freezing', () =>
         assert.strictEqual(utxo_array.length, 2);
 
         let freeze_utxo = utxo_array.find(m => (m.amount === "24300000000000"));
-        assert.strictEqual(freeze_utxo.type, TxType.Freeze);
+        assert.strictEqual(freeze_utxo.type, OutputType.Freeze);
 
         // It was not frozen because the amount of the refund was less than 40,000 BOA.
         let refund_utxo = utxo_array.find(m => (m.amount === "100000000000"));
-        assert.strictEqual(refund_utxo.type, TxType.Payment);
+        assert.strictEqual(refund_utxo.type, OutputType.Payment);
     });
 
     it ('Check the UTXO included in the freeze transaction, when refund amount greater or equal then 40,000 BOA', async () =>
@@ -943,11 +967,11 @@ describe ('Test of the path /utxo for freezing', () =>
         assert.strictEqual(utxo_array.length, 2);
 
         let freeze_utxo = utxo_array.find(m => (m.amount === "24000000000000"));
-        assert.strictEqual(freeze_utxo.type, TxType.Freeze);
+        assert.strictEqual(freeze_utxo.type, OutputType.Freeze);
 
         // It was frozen because the amount of the refund was larger than 40,000 BOA.
         let refund_utxo = utxo_array.find(m => (m.amount === "400000000000"));
-        assert.strictEqual(refund_utxo.type, TxType.Freeze);
+        assert.strictEqual(refund_utxo.type, OutputType.Payment);
     });
 });
 
@@ -1013,9 +1037,9 @@ describe ('Test of the path /merkle_path', () =>
 
         let expected =
             [
-                "0x63f299f3af18e0f333f2dbfe4a13377fbc7d11e3fb9ba0b899b4acd7219ad4c47b56481fc59979b933b33240b36aa4c090bf0440bd18e7a2e6d5405caa885794",
-                "0x1525eddbf962c0b4212701494de724c2e4643387e4b146d4e1731be27b87b2a995b393c5ca9ddacf621dfd4f149194f96cff25e35dbcf2f6c15d732652328c3f",
-                "0xd094b29fedcca586aa70fbdfc40fadf3f68e6244c8565edbd193f057c9639c489aff949b5175883e6868166d156600b56c62fe209089c66b70b5863a598ec85a",
+                "0x7989e23b6797d654499784cf70a97990b399948c7ed66663f6df31ea279c9200f770e39e72be7670b4daef64f6468b78891c29dad30c4c0a02d0b874ace16a23",
+                "0xbf807606597e0042db589a4e7ee9d01b9f79bc2132f0adc46b9548d51a61964a38b9e21bc9ff20e39793edd9c5c64067f451e30f2366d3c1a95bbffd61829a0c",
+                "0xf7358d0981428c3db379561c7446159c73465308dc2c815520cc875cbfe8c82a3f318e69631efde59fb9559f29df9f6ff237922eb369d76c6f0c812a6c81e8c2",
             ];
 
         assert.deepStrictEqual(response.data, expected);
@@ -1026,13 +1050,13 @@ describe ('Test of the path /merkle_path', () =>
         const agora_addr: URL = new URL('http://localhost:2826');
         let agora_client = new AgoraClient(agora_addr);
         let merkle_path: Array<Hash> = await agora_client.getMerklePath(new Height("1"),
-            new Hash("0xa4ce8dd85f51340bdae780db580e21acacfc94eec3305d83275ff2ea2d5583d75b8c400e1807952e04f243c4ef80d821e2537a59f20e12857c910bc2e4028bf7"))
+            new Hash("0xdd75be9a8b2778deb99734dfb17f70c3635afff654342cc1c306ba0fc69eb72494c9e3c4543eaa6974757204ff19a521989b6ab4c6d41de535b8e634faf66183"))
 
         let expected =
             [
-                new Hash("0x63f299f3af18e0f333f2dbfe4a13377fbc7d11e3fb9ba0b899b4acd7219ad4c47b56481fc59979b933b33240b36aa4c090bf0440bd18e7a2e6d5405caa885794"),
-                new Hash("0x1525eddbf962c0b4212701494de724c2e4643387e4b146d4e1731be27b87b2a995b393c5ca9ddacf621dfd4f149194f96cff25e35dbcf2f6c15d732652328c3f"),
-                new Hash("0xd094b29fedcca586aa70fbdfc40fadf3f68e6244c8565edbd193f057c9639c489aff949b5175883e6868166d156600b56c62fe209089c66b70b5863a598ec85a"),
+                new Hash("0x7989e23b6797d654499784cf70a97990b399948c7ed66663f6df31ea279c9200f770e39e72be7670b4daef64f6468b78891c29dad30c4c0a02d0b874ace16a23"),
+                new Hash("0xbf807606597e0042db589a4e7ee9d01b9f79bc2132f0adc46b9548d51a61964a38b9e21bc9ff20e39793edd9c5c64067f451e30f2366d3c1a95bbffd61829a0c"),
+                new Hash("0xf7358d0981428c3db379561c7446159c73465308dc2c815520cc875cbfe8c82a3f318e69631efde59fb9559f29df9f6ff237922eb369d76c6f0c812a6c81e8c2"),
             ];
 
         assert.deepStrictEqual(merkle_path, expected);
@@ -1043,7 +1067,7 @@ describe ('Test of the path /merkle_path', () =>
         let uri = URI(host)
             .port(port)
             .directory("spv")
-            .filename("0xa4ce8dd85f51340bdae780db580e21acacfc94eec3305d83275ff2ea2d5583d75b8c400e1807952e04f243c4ef80d821e2537a59f20e12857c910bc2e4028bf7");
+            .filename("0xdd75be9a8b2778deb99734dfb17f70c3635afff654342cc1c306ba0fc69eb72494c9e3c4543eaa6974757204ff19a521989b6ab4c6d41de535b8e634faf66183");
 
         let response = await client.get(uri.toString());
 
@@ -1060,7 +1084,7 @@ describe ('Test of the path /merkle_path', () =>
         let uri = URI(host)
             .port(port)
             .directory("spv")
-            .filename("0x63f299f3af18e0f333f2dbfe4a13377fbc7d11e3fb9ba0b899b4acd7219ad4c47b56481fc59979b933b33240b36aa4c090bf0440bd18e7a2e6d5405caa885794 ");
+            .filename("0x7989e23b6797d654499784cf70a97990b399948c7ed66663f6df31ea279c9200f770e39e72be7670b4daef64f6468b78891c29dad30c4c0a02d0b874ace16a23 ");
 
         let response = await client.get(uri.toString());
 

--- a/tests/Storage.test.ts
+++ b/tests/Storage.test.ts
@@ -57,8 +57,8 @@ describe ('Test ledger storage and inquiry function.', () =>
         assert.strictEqual(rows.length, 1);
         assert.strictEqual(rows[0].height, height_value);
         assert.strictEqual(new Hash(rows[0].merkle_root, Endian.Little).toString(),
-            '0xc8f96bf274187b0b6fb73c5b609a3fff28bd1fe9e6b712aaa3d9f92351100d7' +
-            'ca718a6c85f5f020cdeb13753179432e710576627399a3235ae472e7fe56b27e6');
+            '0xa82a2d19ae115b521f0d65690e78f66260f5886da76508b72eee62a45cb8cfb' +
+            '5a7b8e300e0042faeb7b28fffc050cceb6c00ef4a326d992ef182969b1857f3d0');
         assert.strictEqual(new Hash(rows[0].random_seed, Endian.Little).toString(),
             '0x691775809b9498f45a2c5ef8b8d552e318ebaf0b1b2fb15dcc39e0ec962ae98' +
             '12d7edffa5f053590a895c9ff72c1b0838ce8f5c709579d4529f9f4caf0fab13d');
@@ -70,23 +70,23 @@ describe ('Test ledger storage and inquiry function.', () =>
         let rows3 = await ledger_storage.getTransactions(new Height("0"));
         assert.strictEqual(rows3.length, 2);
         assert.strictEqual(new Hash(rows3[0].tx_hash, Endian.Little).toString(),
-            '0xd7f9204afdc2d41b28a33504d21b3c5384758d851c573dde44da26d7a0c7de0' +
-            '6fde6127ec740fbfdfafbed4fb13cff24144054b8ae2ab34582110f0f752316aa');
+            '0xff66ffde4ed3b91c5bce28907dd68f7ecabe776c1dc7d797e5f69fc349d2834' +
+            '2348c778cd42c49ef2c29199f374289d44f5b4d2d149f0b8081a1077eca30f7ce');
 
         let rows4 = await ledger_storage.getTxInputs(new Height("1"), 0);
         assert.strictEqual(rows4.length, 1);
         assert.strictEqual(new Hash(rows4[0].utxo, Endian.Little).toString(),
-            '0x6313b9c616f9eac76b11c50885ff32076f49eaca3c58f30eca846a365bc006e' +
-            '5afa0521787d0f984306c1cc8d48a918a8885ea2d4d3449538445f7b25411dcd4');
+            '0x57d4bdc5e60ac4b25f7a6502b15b66394ce4d45b48694518e09d382b9fbc990' +
+            '5be211e45973102609621773daac68357fe0dc0a6092a28920d33ef3194c9aed5');
 
         let rows5 = await ledger_storage.getTxOutputs(new Height("0"), 1);
         assert.strictEqual(rows5.length, 8);
         assert.strictEqual(new Hash(rows5[0].utxo_key, Endian.Little).toString(),
-            '0x6313b9c616f9eac76b11c50885ff32076f49eaca3c58f30eca846a365bc006e' +
-            '5afa0521787d0f984306c1cc8d48a918a8885ea2d4d3449538445f7b25411dcd4');
+            '0x57d4bdc5e60ac4b25f7a6502b15b66394ce4d45b48694518e09d382b9fbc990' +
+            '5be211e45973102609621773daac68357fe0dc0a6092a28920d33ef3194c9aed5');
         assert.strictEqual(new Hash(rows5[0].tx_hash, Endian.Little).toString(),
-            '0xd4b2011f46b7de32e6a3f51eae35c97440b7adf427df7725d19575b8a9a8256' +
-            '552939656f8b5d4087b9bcbbe9219504e31f91a85fb1709683cbefc3962639ecd');
+            '0x9384e68e59382a256d2598251758d3c44f6b48f9a6aa405272e7b5f536dc0f2' +
+            'd3b3fd76b9352ddbf199a4862b05e4300a484ebd3e591abd1df596854debb4d5e');
         assert.strictEqual(rows5[0].address, 'boa1xzgenes5cf8xel37fz79gzs49v56znllk7jw7qscjwl5p6a9zxk8zaygm67');
     });
 
@@ -98,17 +98,17 @@ describe ('Test ledger storage and inquiry function.', () =>
         assert.strictEqual(rows.length, 6);
         assert.strictEqual(rows[0].block_height, height_value);
         assert.strictEqual(new Hash(rows[0].utxo_key, Endian.Little).toString(),
-            '0xd68cfa6d0457b404d74a0367ace0bd3784110fb55d94692e0859f3b5a15b33f' +
-            '990f33e3b4e4b4030945ee0303fabf7b2702f48a31ffdc3d1d6985e3e3dfcc8d7');
+            '0xf8751862d61a28fb878cd4b583ceaf39a59a5f2ff1fa78a169e56811c33b5c3' +
+            'eed80f83074cfb98ab5095ed563ebc6a96320ef59080628c4961f586dbf2e7d2f');
 
         rows = await ledger_storage.getValidators(height);
         assert.strictEqual(rows.length, 6);
         assert.strictEqual(rows[0].enrolled_at, height_value);
         assert.strictEqual(new Hash(rows[0].utxo_key, Endian.Little).toString(),
-            '0x765025088610ec9e6ee82c6373306bfe3c15731234195b9c762859ee3becea8' +
-            '5d85de44ca5fef6660bdea5add694e12658ea4060c0ac5c76757829147afcc582');
+            '0x6c87312f75478d515c5dc2bc8beb3ac5686aacbdedc8219baaf9cb62e41b1b3' +
+            '1f00233321b3c42f9966ee47916123191f49caf0dc761d3a7fcd69198aa63f2aa');
         assert.strictEqual(rows[0].address,
-            'boa1xzvald5dvy54j7yt2h5yzs2432h07rcn66j84t3lfdrlrwydwq78cz0nckq');
+            'boa1xpvald2ydpxzl9aat978kv78y5g24jxy46mcnl7munf4jyhd0zjrc5x62kn');
     });
 
     it ('Test for validator', async () =>
@@ -127,8 +127,8 @@ describe ('Test ledger storage and inquiry function.', () =>
         assert.strictEqual(rows.length, 1);
         assert.strictEqual(rows[0].address, address);
         assert.strictEqual(new Hash(rows[0].stake, Endian.Little).toString(),
-            '0xd68cfa6d0457b404d74a0367ace0bd3784110fb55d94692e0859f3b5a15b33f' +
-            '990f33e3b4e4b4030945ee0303fabf7b2702f48a31ffdc3d1d6985e3e3dfcc8d7');
+            '0xf8751862d61a28fb878cd4b583ceaf39a59a5f2ff1fa78a169e56811c33b5c3' +
+            'eed80f83074cfb98ab5095ed563ebc6a96320ef59080628c4961f586dbf2e7d2f');
 
         rows = await ledger_storage.getValidatorsAPI(null, null);
         assert.strictEqual(rows.length, 6);
@@ -144,11 +144,11 @@ describe ('Test ledger storage and inquiry function.', () =>
         assert.strictEqual(rows[0].block_height, height_value);
         assert.strictEqual(rows[0].merkle_index, 0);
         assert.strictEqual(new Hash(rows[0].merkle_hash, Endian.Little).toString(),
-            '0xd7f9204afdc2d41b28a33504d21b3c5384758d851c573dde44da26d7a0c7de0' +
-            '6fde6127ec740fbfdfafbed4fb13cff24144054b8ae2ab34582110f0f752316aa');
+            '0xff66ffde4ed3b91c5bce28907dd68f7ecabe776c1dc7d797e5f69fc349d2834' +
+            '2348c778cd42c49ef2c29199f374289d44f5b4d2d149f0b8081a1077eca30f7ce');
         assert.strictEqual(new Hash(rows[1].merkle_hash, Endian.Little).toString(),
-            '0xd4b2011f46b7de32e6a3f51eae35c97440b7adf427df7725d19575b8a9a8256' +
-            '552939656f8b5d4087b9bcbbe9219504e31f91a85fb1709683cbefc3962639ecd');
+            '0x9384e68e59382a256d2598251758d3c44f6b48f9a6aa405272e7b5f536dc0f2' +
+            'd3b3fd76b9352ddbf199a4862b05e4300a484ebd3e591abd1df596854debb4d5e');
     });
 
     it ('Test for LedgerStorage.getWalletBlocksHeaderInfo()', async () =>
@@ -158,22 +158,22 @@ describe ('Test ledger storage and inquiry function.', () =>
         assert.strictEqual(rows[0].height, 1);
         assert.strictEqual(rows[0].time_stamp, 1609459800);
         assert.strictEqual(new Hash(rows[0].merkle_root, Endian.Little).toString(),
-            '0xc8f96bf274187b0b6fb73c5b609a3fff28bd1fe9e6b712aaa3d9f92351100d7' +
-            'ca718a6c85f5f020cdeb13753179432e710576627399a3235ae472e7fe56b27e6');
+            '0xa82a2d19ae115b521f0d65690e78f66260f5886da76508b72eee62a45cb8cfb' +
+            '5a7b8e300e0042faeb7b28fffc050cceb6c00ef4a326d992ef182969b1857f3d0');
         assert.strictEqual(new Hash(rows[0].hash, Endian.Little).toString(),
-            '0x1b272e34c3df561450a52cf9e2eab4b1dbff4d710cba755ad76e1b2a906645e' +
-            '0f2b6650e62369f3f56b04a51c82fb36d33c5ef88b59949d37a81ca614902ff8e');
+            '0x04348b962dac4423cd9ae48b4932ee1607fb1101a690d2583bbad909e8c3f22' +
+            'b12a6d65d1e1494d38681afc7bea61c3d81251800b8adbf1d31f52889df6d7e09');
 
         rows = await ledger_storage.getWalletBlocksHeaderInfo(new Height("0"));
         assert.strictEqual(rows.length, 1);
         assert.strictEqual(rows[0].height, 0);
         assert.strictEqual(rows[0].time_stamp, 1609459200);
         assert.strictEqual(new Hash(rows[0].merkle_root, Endian.Little).toString(),
-            '0x8ac592615f23ee726577eb8c305c67558fd08f14120e0f23c2969a3b1d37089' +
-            '009159bd42c1d7af53d601b53ccbbad0ebaa54f36f4bc13d473790921ae3dc7fa');
+            '0x4cadc4d240a26ebf8a01ae1c53a4793fec40c92d36d9f8755311420c9594a9f' +
+            'bb827fb974b75774723acbd13b4d0589e957bf8f14da24633be6ae299446ddca7');
         assert.strictEqual(new Hash(rows[0].hash, Endian.Little).toString(),
-            '0x217f5b3f53a52c396c3418c0245c2435a90c53978564efac448e1162ec8647d' +
-            'de9e5c13263390f73f5d5b74e059b79b5286cf292f3121e6f1654ff452f9296f5');
+            '0xba54155d042d03a722dc9234f7de5b304e9efbc896091e28fb3b19b908ee782' +
+            '653b5e6ef44566e19c728ff0eebf65ede6cc485337d5a473b819e86eeb2f7baf8');
     });
 
     it ('Test for saving of a block with transaction data payload', async () =>
@@ -194,8 +194,8 @@ describe ('Test ledger storage and inquiry function.', () =>
         assert.strictEqual(rows[0].unlock_height, 2);
         assert.strictEqual(BigInt(rows[0].amount), BigInt('24400000000000'));
         assert.strictEqual(new Hash(rows[0].utxo, Endian.Little).toString(),
-            '0xa4b3128ffca978702fe2ec1e769be0b5d9c560152576251ddb2529433f006cc' +
-            '7cbe1b59d719c058503c23d5f833bb41ee4efce9b25abe8e3b6bbc22e1606acd2');
+            '0x4c70c322620c40dc9a0954c82a20df9088ee3560783b1489be73713beb0841e' +
+            '96921ce9275ae44d01b3c9d6cc6787f81da332082f4291132217200c53b23ad05');
     });
 
     it ('Test for UTXO in melting', async () => {
@@ -206,20 +206,20 @@ describe ('Test ledger storage and inquiry function.', () =>
         assert.strictEqual(rows[0].unlock_height, 2018);
         assert.strictEqual(BigInt(rows[0].amount), BigInt('4000000000000'));
         assert.strictEqual(new Hash(rows[0].utxo, Endian.Little).toString(),
-            '0x500ec77bd332f5e92107a764fbdbd8145251aa0e45875399cd7887c14314016' +
-            '6f1689e39f329e7065862f49cf1fd7864d393cdd4e2b00585821321fc167ea65d');
+            '0x229e36211d70510608b8b6cc1796a9dd47fbf2c54627a960e7894292e9ef78c' +
+            'e895807bca132e0e91823553ac13ea36b4bd37ec29cf285098346b967b497571d');
     });
 
     it ('Test for getting block height and merkle root with transaction hash', async () => {
         let tx_hash = new Hash(
-            '0x3d04887353ad6eed2b61f0be74972d078eb432c5d37555b7e87aefb15a04815' +
-            'e4b1bea6b78c566936cbfebf5b4a8d412804881570f87555e423c1b99919c609d');
+            '0x067d37b7f625baccc66186f0426fa7eb61b1657e6bf520b7bfeab0b4759a282' +
+            'c7604a4eac5509ba78e2a71224983237da2c75657a38a22c5f42419fd3ba2eb2b');
         let rows = await ledger_storage.getBlockHeaderByTxHash(tx_hash);
         assert.strictEqual(rows.length, 1);
         assert.strictEqual(rows[0].height, 1);
         assert.strictEqual(new Hash(rows[0].merkle_root, Endian.Little).toString(),
-            '0xc8f96bf274187b0b6fb73c5b609a3fff28bd1fe9e6b712aaa3d9f92351100d7' +
-            'ca718a6c85f5f020cdeb13753179432e710576627399a3235ae472e7fe56b27e6');
+            '0xa82a2d19ae115b521f0d65690e78f66260f5886da76508b72eee62a45cb8cfb' +
+            '5a7b8e300e0042faeb7b28fffc050cceb6c00ef4a326d992ef182969b1857f3d0');
     });
 });
 

--- a/tests/Utils.ts
+++ b/tests/Utils.ts
@@ -50,7 +50,7 @@ export const market_cap_sample_data = (()=>{
        let record = [];
         for (let elem of marketcap_sample_data_raw)
             record.push(JSON.parse(elem));
-       return record;     
+       return record;
 })();
 
 export const market_cap_history_sample_data = (() => {
@@ -82,14 +82,14 @@ export const recovery_sample_data =
 
 export const sample_preImageInfo =
     {
-        "utxo": "0xd68cfa6d0457b404d74a0367ace0bd3784110fb55d94692e0859f3b5a15b33f990f33e3b4e4b4030945ee0303fabf7b2702f48a31ffdc3d1d6985e3e3dfcc8d7",
+        "utxo": "0xf8751862d61a28fb878cd4b583ceaf39a59a5f2ff1fa78a169e56811c33b5c3eed80f83074cfb98ab5095ed563ebc6a96320ef59080628c4961f586dbf2e7d2f",
         "hash": "0x790ab7c8f8ddbf012561e70c944c1835fd1a873ca55c973c828164906f8b35b924df7bddcafade688ad92cfb4414b2cf69a02d115dc214bbd00d82167f645e7e",
         "height": "6"
     };
 
 export const sample_reEnroll_preImageInfo =
     {
-        "utxo": "0xd68cfa6d0457b404d74a0367ace0bd3784110fb55d94692e0859f3b5a15b33f990f33e3b4e4b4030945ee0303fabf7b2702f48a31ffdc3d1d6985e3e3dfcc8d7",
+        "utxo": "0xf8751862d61a28fb878cd4b583ceaf39a59a5f2ff1fa78a169e56811c33b5c3eed80f83074cfb98ab5095ed563ebc6a96320ef59080628c4961f586dbf2e7d2f",
         "hash": "0xe51e1cc8dfdcdcd02586c9648c6977504eade2dffc8f3289e7ae7e501c2879f99af6a199ccad499be02a66d409ca4ab51b35f1c3a06a82464ce4efcfeb3ade33",
         "height": "12"
     };

--- a/tests/WalletAPI.test.ts
+++ b/tests/WalletAPI.test.ts
@@ -102,8 +102,8 @@ describe ('Test of Stoa API for the wallet', () =>
         assert.strictEqual(response.data[0].peer_count, 1);
         assert.strictEqual(response.data[0].height, "9");
         assert.strictEqual(response.data[0].tx_hash,
-            "0x8f445c1ad33af5be09ead25795e97d74a0b25d6da7b1f918bfe0b67edf351bc" +
-            "543804a68c34e89c84a451bf99e97ae5bf4c5b5c266bb1041f2be74415f2030a8");
+            "0x137dfda16ebdcc93de30a171bd3de2cc08f8e124dc55858507b4d4ed696952d" +
+            "711b09ed83b31e0583ebddd7a3a73cc30d09d1fb656e62245e2dd56c585d1f61b");
         assert.strictEqual(response.data[0].tx_type, "payment");
         assert.strictEqual(response.data[0].amount, "610000000000000");
         assert.strictEqual(response.data[0].unlock_height, "10");
@@ -114,42 +114,43 @@ describe ('Test of Stoa API for the wallet', () =>
         let uri = URI(host)
             .port(port)
             .directory("/wallet/transaction/overview")
-            .filename("0xbd83d11bfbc2d77281d1435774990e587c871cc53564f527bb07865b31c3cb3cf5c3e235843ad7b967f7f17db5b691d3cc307983d470dd07d3347d3230cf7689")
+            .filename("0x7a1f8c370a4e31f9f3cc1559c9f1c91cd1bf2efa39156bd88ee10848380f86b27a4ed029ce30550838a6e53eec156afb7b127a1ba872ecf6acea7ac1317f3386")
 
         let response = await client.get (uri.toString());
         let expected = {
-            status: 'Confirmed',
-            height: '9',
-            time: 1609464600,
-            tx_hash: '0xbd83d11bfbc2d77281d1435774990e587c871cc53564f527bb07865b31c3cb3cf5c3e235843ad7b967f7f17db5b691d3cc307983d470dd07d3347d3230cf7689',
-            tx_type: 'payment',
-            tx_size: 182,
-            unlock_height: '10',
-            lock_height: '0',
-            unlock_time: 1609465200,
-            payload: '',
-            senders: [
+            "status": "Confirmed",
+            "height": "9",
+            "time": 1609464600,
+            "tx_hash": "0x7a1f8c370a4e31f9f3cc1559c9f1c91cd1bf2efa39156bd88ee10848380f86b27a4ed029ce30550838a6e53eec156afb7b127a1ba872ecf6acea7ac1317f3386",
+            "tx_type": "payment",
+            "tx_size": 182,
+            "unlock_height": "10",
+            "lock_height": "0",
+            "unlock_time": 1609465200,
+            "payload": "",
+            "senders": [
                 {
-                    address: 'boa1xrk00cupup5vxwpz09kl9rau78cwag28us4vuctr6zdxvwfzaht9v6tms8q',
-                    amount: 610000000000000,
-                    utxo: '0xf524c2acd5c95eebc1578dedd3f35e32cfeb6fd7181ceee4839b70745fd8eaa12442762c5d688bb9e15a2c666bccf6bc7ec8456a62daff1ebf4945a76402b6cb',
-                    signature: '0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
-                    index: 0,
-                    unlock_age: 0,
-                    bytes: '0x2cd0ae84394f7e38f94317f75f61d82830bd71e785733d9fba113b833278d00fd39520d0cc0f36df242cec682bf0b2fe7d9b274db160ebad8bc7e6f1fdeecee7'
+                    "address": "boa1xrk00cupup5vxwpz09kl9rau78cwag28us4vuctr6zdxvwfzaht9v6tms8q",
+                    "amount": 610000000000000,
+                    "utxo": "0x9fd93f7b6acf3a277569084fabc3b6a8e983087c03e75aed7327c45d0a853a18b142daf607990882fc6388856557219c2bce42fb208f9f7e2cbeb845b482dc50",
+                    "signature": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                    "index": 0,
+                    "unlock_age": 0,
+                    "bytes": "0xd5dece00b501854a8bae3509e5e314569576c5a082ae8c514db6bc96d5788f0951cece0cef0ab05d53fbc247d4732707d8f5d0e3eca65d92e5d8e86e36b1f8e0"
                 }
             ],
-            receivers: [
+            "receivers": [
                 {
-                    address: 'boa1xza007gllhzdawnr727hds36guc0frnjsqscgf4k08zqesapcg3uujh9g93',
-                    lock_type: 0,
-                    amount: 610000000000000,
-                    utxo: '0x718c57bc74ef0ded4311e7013e146834c58b20c5525919947c37482be7778b95bb7e57faacde1fc5638f6f41d30b8a790a1effffd8385e112ee1e539c41e6ecf',
-                    index: 0,
-                    bytes: '0x5f21dbacbd82f3f86006b1237f1bfc4b24b857d5e8bd8616a20d1feb09be640c9d096839324b36f8dd5457f4bef618261fe62c8e15a411495cca216a3bc94397'
+                    "type": 0,
+                    "address": "boa1xza007gllhzdawnr727hds36guc0frnjsqscgf4k08zqesapcg3uujh9g93",
+                    "lock_type": 0,
+                    "amount": 610000000000000,
+                    "utxo": "0xfa4ca8aa9fbd8d00847b53dc48878d427bef4e5b9c655dce45e35df502829e33a672b47f6bbf506f0a01c920052106f551f46c19b4390c09c2c90ea4d96f69dc",
+                    "index": 0,
+                    "bytes": "0x5f21dbacbd82f3f86006b1237f1bfc4b24b857d5e8bd8616a20d1feb09be640c9d096839324b36f8dd5457f4bef618261fe62c8e15a411495cca216a3bc94397"
                 }
             ],
-            fee: '0'
+            "fee": "0"
         }
         assert.deepStrictEqual(response.data, expected);
     });
@@ -192,8 +193,8 @@ describe ('Test of Stoa API for the wallet', () =>
         assert.strictEqual(response.data[0].tx_type, "payment");
         assert.strictEqual(response.data[0].amount, "-610000000000000");
         assert.strictEqual(response.data[0].tx_hash,
-            "0xe27d4ae7480c8bf32c3df230be00c662d6b04032aa9a53dc8df870cb5774f4b" +
-            "e6c1f583ba1d3a02ac55b59e200161e30dd140089b0136c90f44371cb9190b28f");
+            "0xc9e537de55f0f353baf53d09f1524bf43778911c7aa0a4adc51ef263c4e7ea4" +
+            "2eaca79f518a32f0669a4898edb5a43dcd7cb89882b6c1bb1ef074810a357ef61");
     });
 
     it ('Test of the path /wallet/transactions/history - Filtering - Date', async () =>
@@ -219,8 +220,8 @@ describe ('Test of Stoa API for the wallet', () =>
         assert.strictEqual(response.data[0].tx_type, "payment");
         assert.strictEqual(response.data[0].amount, "610000000000000");
         assert.strictEqual(response.data[0].tx_hash,
-            "0x0a2c0b2845e22d3a88cb18b0fd387fe10772416b85ba809b210fdfa1790ac57" +
-            "9cf64cf2c451935b6b4b5a80edb31b681bf20337f0d20a7b743ed748dd96169f0");
+            "0x90f84f032e95084e243993891e4e40d708845e7d4de197d48c0ddd6e8a66378" +
+            "b8ed6745741dcd88b828509d52ed8e7bdc9c564b90414198e2a5a9ac93446d7b8");
     });
 
     it ('Test of the path /wallet/transactions/history - Filtering - Peer', async () =>
@@ -245,8 +246,8 @@ describe ('Test of Stoa API for the wallet', () =>
         assert.strictEqual(response.data[0].tx_type, "payment");
         assert.strictEqual(response.data[0].amount, "610000000000000");
         assert.strictEqual(response.data[0].tx_hash,
-            "0x0a2c0b2845e22d3a88cb18b0fd387fe10772416b85ba809b210fdfa1790ac57" +
-            "9cf64cf2c451935b6b4b5a80edb31b681bf20337f0d20a7b743ed748dd96169f0");
+            "0x90f84f032e95084e243993891e4e40d708845e7d4de197d48c0ddd6e8a66378" +
+            "b8ed6745741dcd88b828509d52ed8e7bdc9c564b90414198e2a5a9ac93446d7b8");
     });
 });
 
@@ -315,46 +316,48 @@ describe ('Test of Stoa API for the wallet with `sample_data`', () => {
         let uri = URI(host)
             .port(port)
             .directory("/wallet/transaction/overview")
-            .filename("0x66b6a0e5f58514ccdc0164598bd0b476e0b93294f9eb5b938e006028ebccda778a36e7f141679c0b101bb6f74befc9a4b09d2d9203bf041409aaa206989bed4e")
+            .filename("0xfbe8c9c8544ed673672607552274aa1f1255375f8bf5f20bb1b7f6fe037a90ffbb84c70d0fd089afe5e6db9f68c5f6456b92f802fbb7a91a1b24353d2c625638")
 
         let response = await client.get(uri.toString());
         let expected = {
             "status": "Confirmed",
             "height": "2",
-            "lock_height": "0",
             "time": 1609460400,
-            "tx_hash": "0x66b6a0e5f58514ccdc0164598bd0b476e0b93294f9eb5b938e006028ebccda778a36e7f141679c0b101bb6f74befc9a4b09d2d9203bf041409aaa206989bed4e",
+            "tx_hash": "0xfbe8c9c8544ed673672607552274aa1f1255375f8bf5f20bb1b7f6fe037a90ffbb84c70d0fd089afe5e6db9f68c5f6456b92f802fbb7a91a1b24353d2c625638",
             "tx_type": "payment",
-            "tx_size": 1247,
+            "tx_size": 1248,
             "unlock_height": "3",
+            "lock_height": "0",
             "unlock_time": 1609461000,
             "payload": "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0+P0BBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWltcXV5fYGFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6e3x9fn+AgYKDhIWGh4iJiouMjY6PkJGSk5SVlpeYmZqbnJ2en6ChoqOkpaanqKmqq6ytrq+wsbKztLW2t7i5uru8vb6/wMHCw8TFxsfIycrLzM3Oz9DR0tPU1dbX2Nna29zd3t/g4eLj5OXm5+jp6uvs7e7v8PHy8/T19vf4+fr7/P3+/wABAgMEBQYHCAkKCwwNDg8QERITFBUWFxgZGhscHR4fICEiIyQlJicoKSorLC0uLzAxMjM0NTY3ODk6Ozw9Pj9AQUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVpbXF1eX2BhYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5ent8fX5/gIGCg4SFhoeIiYqLjI2Oj5CRkpOUlZaXmJmam5ydnp+goaKjpKWmp6ipqqusra6vsLGys7S1tre4ubq7vL2+v8DBwsPExcbHyMnKy8zNzs/Q0dLT1NXW19jZ2tvc3d7f4OHi4+Tl5ufo6err7O3u7/Dx8vP09fb3+Pn6+/z9/v8AAQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyAhIiMkJSYnKCkqKywtLi8wMTIzNDU2Nzg5Ojs8PT4/QEFCQ0RFRkdISUpLTE1OT1BRUlNUVVZXWFlaW1xdXl9gYWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXp7fH1+f4CBgoOEhYaHiImKi4yNjo+QkZKTlJWWl5iZmpucnZ6foKGio6SlpqeoqaqrrK2ur7CxsrO0tba3uLm6u7y9vr/AwcLDxMXGx8jJysvMzc7P0NHS09TV1tfY2drb3N3e3+Dh4uPk5ebn6Onq6+zt7u/w8fLz9PX29/j5+vv8/f7/AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0+P0BBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWltcXV5fYGFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6e3x9fn+AgYKDhIWGh4iJiouMjY6PkJGSk5SVlpeYmZqbnJ2en6ChoqOkpaanqKmqq6ytrq+wsbKztLW2t7i5uru8vb6/wMHCw8TFxsfIycrLzM3Oz9DR0tPU1dbX2Nna29zd3t/g4eLj5OXm5+jp6uvs7e7v8PHy8/T19vf4+fr7/P3+/w==",
             "senders": [
                 {
                     "address": "boa1xparc00qvv984ck00trwmfxuvqmmlwsxwzf3al0tsq5k2rw6aw427ct37mj",
                     "amount": 24400000000000,
-                    "utxo": "0x0b640f95cec0159edc603291d9e519cf7ab3b141e4be9ae34770a89eb3937ed9a7ad9b601be47683c0b491ca21a67c6d43aca5d603b7489378fb6dafe19391b5",
+                    "utxo": "0xf180e8aede3ea3f6db7872b2af4225f186abc4835e2f1108ea6ee1c56a8edb79c6460de4968696ec1f9a7fe5ab0008d33781a0031d79409825f2ea45df6f7fbd",
                     "signature": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
                     "index": 0,
                     "unlock_age": 0,
-                    "bytes": "0x96a00869708881ca6a86b587183c9807b11d02b80cf5773e2bd9ac339834a501a3e6deff275a4410a287029a420cb43b941507ac28ca13da8134a1abbd0e1b03"
+                    "bytes": "0x79989dee6906c074068975bd3f26d6bd9fe6c07469fe6c660f1f08df6aeb6202971960e21a354cd1afc33b8342d88ff6ad5e18cd1d5710cafc447e5799a56a28"
                 }
             ],
             "receivers": [
                 {
+                    "type": 0,
                     "address": "boa1xqcmmns5swnm03zay5wjplgupe65uw4w0dafzsdsqtwq6gv3h3lcz24a8ch",
-                    "amount": 1663400000,
-                    "utxo": "0x28c8b71b0e783a80c3d6fa828aa40e350abe5c69b582bf301d21ce4d02caf35a6caed282203cef3ed20db91d5a725e4fa9b201d1f8832610c97491b1ca1f53ca",
-                    "index": 0,
                     "lock_type": 0,
+                    "amount": 1663400000,
+                    "utxo": "0xb1262f48009e97c3f3041b52552986f0b260aad9c03d82ea6d027e0a85caa58a52aebcd8f623cf21e1652619feb047e911a4992dc58d2b1a58fe6bf2ee4ee679",
+                    "index": 0,
                     "bytes": "0x178f01a58740ab687b82c61fea00ed740de5bac97ada2599300bfbb1e5b244e945c9b78412864341f96f537a993cf011a15a2affc95f944fdc937aa8ce303f2c"
                 },
                 {
+                    "type": 0,
                     "address": "boa1xrlj00v7wyf9vf0cm2thd58tquqxpj9xtdrh2hhfyrmag4cdkmej5nystea",
-                    "amount": 24398336600000,
-                    "utxo": "0x1e6cc3e8c4f6cc543651a0ba55de7691cf7c0551bb3045f3f89eaa583c6ecc4073099158cd109ce5fea1e7ddc115a3d8a83d6012a0c23b7a1eb54483d8ebbadd",
-                    "index": 1,
                     "lock_type": 0,
+                    "amount": 24398336600000,
+                    "utxo": "0xdc6e74b9b32a706e7bf389d59dd88d1adfde4161e1854cc5663aa1b15fc6cc99ff9fa6c1779d0e58c51f101bad2d0d3246ffd0917ff12d194daa4486a1f52dee",
+                    "index": 1,
                     "bytes": "0xe3dd9e0f4d5b39dfd3a0c656a12179f627da5298c2d9f668099db5dc33e6a9f8dfbbb5f7d9a974a2e2eb27e34ce33582948902c73aca315adc1c2e4025595b0f"
                 }
             ],

--- a/tests/data/Block.0.sample1.json
+++ b/tests/data/Block.0.sample1.json
@@ -2,42 +2,42 @@
     "header": {
         "prev_block": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
         "height": "0",
-        "merkle_root": "0x8ac592615f23ee726577eb8c305c67558fd08f14120e0f23c2969a3b1d37089009159bd42c1d7af53d601b53ccbbad0ebaa54f36f4bc13d473790921ae3dc7fa",
+        "merkle_root": "0x4cadc4d240a26ebf8a01ae1c53a4793fec40c92d36d9f8755311420c9594a9fbb827fb974b75774723acbd13b4d0589e957bf8f14da24633be6ae299446ddca7",
         "validators": "[0]",
         "signature": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
         "enrollments": [
             {
-                "utxo_key": "0xd68cfa6d0457b404d74a0367ace0bd3784110fb55d94692e0859f3b5a15b33f990f33e3b4e4b4030945ee0303fabf7b2702f48a31ffdc3d1d6985e3e3dfcc8d7",
+                "utxo_key": "0xf8751862d61a28fb878cd4b583ceaf39a59a5f2ff1fa78a169e56811c33b5c3eed80f83074cfb98ab5095ed563ebc6a96320ef59080628c4961f586dbf2e7d2f",
                 "commitment": "0x0a8201f9f5096e1ce8e8de4147694940a57a188b78293a55144fc8777a774f2349b3a910fb1fb208514fb16deaf49eb05882cdb6796a81f913c6daac3eb74328",
                 "cycle_length": 20,
                 "enroll_sig": "0x0cab27862571d2d2e33d6480e1eab4c82195a508b72672d609610d01f23b0beedc8b89135fe3f5df9e2815b9bdb763c41b8b2dab5911e313acc82470c2147422"
             },
             {
-                "utxo_key": "0x7f6e35961dbaae3cad2efa0582a6ff2c992973bdd987c41c6d4f4b0e1289158c98b2858b4731c36744ebf92edcb05b3f68838432479aaf1373d123e60ad3448b",
+                "utxo_key": "0x896240cd0ef51fdfdff645bb146737f889b70a7d72f9ebb842f9a0c4705de884209c451ccdc15aace878d12dac85f0b5522bf2642204937c5e44944741a1928f",
                 "commitment": "0xd0348a88f9b7456228e4df5689a57438766f4774d760776ec450605c82348c461db84587c2c9b01c67c8ed17f297ee4008424ad3e0e5039179719d7e9df297c1",
                 "cycle_length": 20,
                 "enroll_sig": "0x0ed498b867c33d316b468d817ba8238aec68541abd912cecc499f8e780a8cdaf2692d0b8b04133a34716169a4b1d33d77c3e585357d8a2a2c48a772275255c01"
             },
             {
-                "utxo_key": "0xfbb850538245991a7156dc1713535717c530f851554c91de4b21091e88647cc0ee8c296da6fc40b283c048e3ed82cc46abe82cbd5061ba0ea579e1054ab51fcc",
+                "utxo_key": "0xcbb19dfc2c28ea46ffbf962ca4bcb1a11ab6ccc8d83c9357a1d931915b0b8257cbe131e9bda51bed9668972079cf9f0d9ba0fefa01cbdd94aa05a90eb210d4bb",
                 "commitment": "0xaf43c67d9dd0f53de3eaede63cdcda8643422d62205df0b5af65706ec28b372adb785ce681d559d7a7137a4494ccbab4658ce11ec75a8ec84be5b73590bffceb",
                 "cycle_length": 20,
                 "enroll_sig": "0x09474f489579c930dbac46f638f3202ac24407f1fa419c1d95be38ab474da29d7e3d4753b6b4ccdb35c2864be4195e83b7b8433ca1d27a57fb9f48a631001304"
             },
             {
-                "utxo_key": "0x765025088610ec9e6ee82c6373306bfe3c15731234195b9c762859ee3becea85d85de44ca5fef6660bdea5add694e12658ea4060c0ac5c76757829147afcc582",
+                "utxo_key": "0xd08bc4c4a5f3341369f6c628e1cb9f3339ad1376b642f8bd95603a2fad6be0db81fa4fa58dadb5dc8f3bc7a020ad1fe8d2d6643238ea2508a37ee58b0df9e9f8",
                 "commitment": "0xa24b7e6843220d3454523ceb7f9b43f037e56a01d2bee82958b080dc6350ebac2da12b561cbd96c6fb3f5ae5a3c8df0ac2c559ae1c45b11d42fdf866558112bc",
                 "cycle_length": 20,
                 "enroll_sig": "0x0e4566eca30feb9ad47a65e7ff7e7ce1a7555ccedcf61e1143c2e5fddbec6866fd787c4518b78ab9ed73a3760741d557ac2aca631fc2796be86fcf391d3a6634"
             },
             {
-                "utxo_key": "0xe9786bcd4188dbc27f3bcd9f3097355ad056d7518e8ea5a908adaba7229625a195d2073c512849e856ac7f8f7e0ee463e2e2be6373f3fa3f645640d2e1141151",
+                "utxo_key": "0x6c87312f75478d515c5dc2bc8beb3ac5686aacbdedc8219baaf9cb62e41b1b31f00233321b3c42f9966ee47916123191f49caf0dc761d3a7fcd69198aa63f2aa",
                 "commitment": "0xa0502960ddbe816729f60aeaa480c7924fb020d864deec6a9db778b8e56dd2ff8e987be748ff6ca0a43597ecb575da5d532696e376dc70bb4567b5b1fa512cb4",
                 "cycle_length": 20,
                 "enroll_sig": "0x052ee1d975c49f19fd26b077740dcac399f174f40b5df1aba5f09ebea11faacfd79a36ace4d3097869dc009b8939fc83bdf940c8822c6931d5c09326aa746b31"
             },
             {
-                "utxo_key": "0xa551c7d3076f43857913fa1a7de694df9c1ea5606bc084caa4c7cd7868a74c9f80c303ce64324becfadf8e092781a6b5ea9c76ec81bc5f5fa18fd523b333a1a2",
+                "utxo_key": "0xda34f8f20fc231d4c3fe7f0190d5980c748dc82cc213ee7eb60d5c3f21c156b2a8b2113cfb48b3a02c049245e8682ff1da55b59b35abdd3832418675ccf2e29f",
                 "commitment": "0xdd1b9c62d4c62246ea124e5422d5a2e23d3ca9accb0eba0e46cd46708a4e7b417f46df34dc2e3cba9a57b1dc35a66dfc2d5ef239ebeaaa00299232bc7e3b7bfa",
                 "cycle_length": 20,
                 "enroll_sig": "0x0e0070e5951ef5be897cb593c4c57ce28b7529463f7e5644b1314ab7cc69fd625c71e74382a24b7e644d32b0306fe3cf14ecd7de5635c70aa592f4721aa74fe2"
@@ -49,10 +49,10 @@
     },
     "txs": [
         {
-            "type": 1,
             "inputs": [],
             "outputs": [
                 {
+                    "type": 1,
                     "value": "20000000000000",
                     "lock": {
                         "type": 0,
@@ -60,6 +60,7 @@
                     }
                 },
                 {
+                    "type": 1,
                     "value": "20000000000000",
                     "lock": {
                         "type": 0,
@@ -67,6 +68,7 @@
                     }
                 },
                 {
+                    "type": 1,
                     "value": "20000000000000",
                     "lock": {
                         "type": 0,
@@ -74,6 +76,7 @@
                     }
                 },
                 {
+                    "type": 1,
                     "value": "20000000000000",
                     "lock": {
                         "type": 0,
@@ -81,6 +84,7 @@
                     }
                 },
                 {
+                    "type": 1,
                     "value": "20000000000000",
                     "lock": {
                         "type": 0,
@@ -88,6 +92,7 @@
                     }
                 },
                 {
+                    "type": 1,
                     "value": "20000000000000",
                     "lock": {
                         "type": 0,
@@ -101,10 +106,10 @@
             "lock_height": "0"
         },
         {
-            "type": 0,
             "inputs": [],
             "outputs": [
                 {
+                    "type": 0,
                     "value": "610000000000000",
                     "lock": {
                         "type": 0,
@@ -112,6 +117,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "610000000000000",
                     "lock": {
                         "type": 0,
@@ -119,6 +125,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "610000000000000",
                     "lock": {
                         "type": 0,
@@ -126,6 +133,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "610000000000000",
                     "lock": {
                         "type": 0,
@@ -133,6 +141,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "610000000000000",
                     "lock": {
                         "type": 0,
@@ -140,6 +149,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "610000000000000",
                     "lock": {
                         "type": 0,
@@ -147,6 +157,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "610000000000000",
                     "lock": {
                         "type": 0,
@@ -154,6 +165,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "610000000000000",
                     "lock": {
                         "type": 0,
@@ -168,9 +180,8 @@
         }
     ],
     "merkle_tree": [
-        "0xd7f9204afdc2d41b28a33504d21b3c5384758d851c573dde44da26d7a0c7de06fde6127ec740fbfdfafbed4fb13cff24144054b8ae2ab34582110f0f752316aa",
-        "0xd4b2011f46b7de32e6a3f51eae35c97440b7adf427df7725d19575b8a9a8256552939656f8b5d4087b9bcbbe9219504e31f91a85fb1709683cbefc3962639ecd",
-        "0x8ac592615f23ee726577eb8c305c67558fd08f14120e0f23c2969a3b1d37089009159bd42c1d7af53d601b53ccbbad0ebaa54f36f4bc13d473790921ae3dc7fa"
+        "0xff66ffde4ed3b91c5bce28907dd68f7ecabe776c1dc7d797e5f69fc349d28342348c778cd42c49ef2c29199f374289d44f5b4d2d149f0b8081a1077eca30f7ce",
+        "0x9384e68e59382a256d2598251758d3c44f6b48f9a6aa405272e7b5f536dc0f2d3b3fd76b9352ddbf199a4862b05e4300a484ebd3e591abd1df596854debb4d5e",
+        "0x4cadc4d240a26ebf8a01ae1c53a4793fec40c92d36d9f8755311420c9594a9fbb827fb974b75774723acbd13b4d0589e957bf8f14da24633be6ae299446ddca7"
     ]
 }
-

--- a/tests/data/Block.1.sample1.json
+++ b/tests/data/Block.1.sample1.json
@@ -1,8 +1,8 @@
 {
     "header": {
-        "prev_block": "0x217f5b3f53a52c396c3418c0245c2435a90c53978564efac448e1162ec8647dde9e5c13263390f73f5d5b74e059b79b5286cf292f3121e6f1654ff452f9296f5",
+        "prev_block": "0xba54155d042d03a722dc9234f7de5b304e9efbc896091e28fb3b19b908ee782653b5e6ef44566e19c728ff0eebf65ede6cc485337d5a473b819e86eeb2f7baf8",
         "height": "1",
-        "merkle_root": "0xc8f96bf274187b0b6fb73c5b609a3fff28bd1fe9e6b712aaa3d9f92351100d7ca718a6c85f5f020cdeb13753179432e710576627399a3235ae472e7fe56b27e6",
+        "merkle_root": "0xa82a2d19ae115b521f0d65690e78f66260f5886da76508b72eee62a45cb8cfb5a7b8e300e0042faeb7b28fffc050cceb6c00ef4a326d992ef182969b1857f3d0",
         "validators": "[252]",
         "signature": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
         "enrollments": [],
@@ -12,18 +12,18 @@
     },
     "txs": [
         {
-            "type": 0,
             "inputs": [
                 {
-                    "utxo": "0x6313b9c616f9eac76b11c50885ff32076f49eaca3c58f30eca846a365bc006e5afa0521787d0f984306c1cc8d48a918a8885ea2d4d3449538445f7b25411dcd4",
+                    "utxo": "0x57d4bdc5e60ac4b25f7a6502b15b66394ce4d45b48694518e09d382b9fbc9905be211e45973102609621773daac68357fe0dc0a6092a28920d33ef3194c9aed5",
                     "unlock": {
-                        "bytes": "QQDjCceIQtRE9ku/5AEXdHeZQP2KIyAKrxFGPogE5gZ+2bW3qMZUGtX1EhDGXebQmK34LylsRrc9W+CwnYQbbQ=="
+                        "bytes": "yuH5/OkqydVRZNQJSu4GJIOQxGVKCUSDzFJTVYXp5A2+oenm8a9vTdftxTgKxlXJsbLdHw4CLUGKGKY+SA8xaA=="
                     },
                     "unlock_age": 0
                 }
             ],
             "outputs": [
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -31,6 +31,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -38,6 +39,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -45,6 +47,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -52,6 +55,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -59,6 +63,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -66,6 +71,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -73,6 +79,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -80,6 +87,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -87,6 +95,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -94,6 +103,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -101,6 +111,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -108,6 +119,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -115,6 +127,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -122,6 +135,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -129,6 +143,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -136,6 +151,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -143,6 +159,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -150,6 +167,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -157,6 +175,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -164,6 +183,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -171,6 +191,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -178,6 +199,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -185,6 +207,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -192,6 +215,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -205,18 +229,18 @@
             "lock_height": "0"
         },
         {
-            "type": 0,
             "inputs": [
                 {
-                    "utxo": "0x6313b9c616f9eac76b11c50885ff32076f49eaca3c58f30eca846a365bc006e5afa0521787d0f984306c1cc8d48a918a8885ea2d4d3449538445f7b25411dcd4",
+                    "utxo": "0x57d4bdc5e60ac4b25f7a6502b15b66394ce4d45b48694518e09d382b9fbc9905be211e45973102609621773daac68357fe0dc0a6092a28920d33ef3194c9aed5",
                     "unlock": {
-                        "bytes": "3hYTtgdIkogXKJOOHHeKHr45ruWrHT3hJ34dh9G3igQqSKZebbhWIpAF2RAmZqrEIRhbuvLpTp+4Y0oYLxlxkA=="
+                        "bytes": "038ZroOBEdorcAdz333ZBYNDZvhSf4OOZIYVM/nwgARJEstIp+XNOG8uaU9+EHJueMh9nGBzfvYs5b/ikIwGeQ=="
                     },
                     "unlock_age": 0
                 }
             ],
             "outputs": [
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -224,6 +248,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -231,6 +256,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -238,6 +264,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -245,6 +272,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -252,6 +280,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -259,6 +288,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -266,6 +296,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -273,6 +304,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -280,6 +312,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -287,6 +320,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -294,6 +328,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -301,6 +336,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -308,6 +344,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -315,6 +352,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -322,6 +360,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -329,6 +368,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -336,6 +376,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -343,6 +384,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -350,6 +392,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -357,6 +400,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -364,6 +408,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -371,6 +416,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -378,6 +424,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -385,6 +432,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -398,18 +446,18 @@
             "lock_height": "0"
         },
         {
-            "type": 0,
             "inputs": [
                 {
-                    "utxo": "0x6313b9c616f9eac76b11c50885ff32076f49eaca3c58f30eca846a365bc006e5afa0521787d0f984306c1cc8d48a918a8885ea2d4d3449538445f7b25411dcd4",
+                    "utxo": "0x57d4bdc5e60ac4b25f7a6502b15b66394ce4d45b48694518e09d382b9fbc9905be211e45973102609621773daac68357fe0dc0a6092a28920d33ef3194c9aed5",
                     "unlock": {
-                        "bytes": "+ISI2q8t3LEwnlve4xDM3W9/ee9XWJgnELrk6mr4YwfetB9K9nRT3m1+7gsEF2V/mr+t0ulx0YYti1kcY+ezZw=="
+                        "bytes": "4wXqYYCZb15XfbpDeT2wEQbtNCAIASoBdRm0AP+8pgV9exY5Zc36YtAjDQ3rB8A/0l0b7RXQtxM/TwZ1MMT5aw=="
                     },
                     "unlock_age": 0
                 }
             ],
             "outputs": [
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -417,6 +465,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -424,6 +473,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -431,6 +481,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -438,6 +489,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -445,6 +497,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -452,6 +505,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -459,6 +513,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -466,6 +521,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -473,6 +529,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -480,6 +537,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -487,6 +545,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -494,6 +553,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -501,6 +561,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -508,6 +569,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -515,6 +577,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -522,6 +585,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -529,6 +593,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -536,6 +601,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -543,6 +609,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -550,6 +617,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -557,6 +625,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -564,6 +633,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -571,6 +641,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -578,6 +649,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -591,18 +663,18 @@
             "lock_height": "0"
         },
         {
-            "type": 0,
             "inputs": [
                 {
-                    "utxo": "0x6313b9c616f9eac76b11c50885ff32076f49eaca3c58f30eca846a365bc006e5afa0521787d0f984306c1cc8d48a918a8885ea2d4d3449538445f7b25411dcd4",
+                    "utxo": "0x57d4bdc5e60ac4b25f7a6502b15b66394ce4d45b48694518e09d382b9fbc9905be211e45973102609621773daac68357fe0dc0a6092a28920d33ef3194c9aed5",
                     "unlock": {
-                        "bytes": "66dSt9xcBoLOk/8vqEkZOehWLDJBwTvojG4D2mf7vgTMf0vwQCSdlfYwNjeHGtxIcM4SCvWUH5Wc1YglWRMQfg=="
+                        "bytes": "JXcDU8uNFPkVy73jlDoTjKSg8SdCLgJShhzKkTd+vwFPJ8QY8rN+WC0hXRVjbrzxJkBZbz98kV8ZfJVJ2wRjVQ=="
                     },
                     "unlock_age": 0
                 }
             ],
             "outputs": [
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -610,6 +682,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -617,6 +690,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -624,6 +698,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -631,6 +706,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -638,6 +714,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -645,6 +722,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -652,6 +730,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -659,6 +738,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -666,6 +746,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -673,6 +754,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -680,6 +762,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -687,6 +770,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -694,6 +778,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -701,6 +786,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -708,6 +794,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -715,6 +802,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -722,6 +810,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -729,6 +818,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -736,6 +826,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -743,6 +834,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -750,6 +842,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -757,6 +850,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -764,6 +858,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -771,6 +866,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -784,18 +880,18 @@
             "lock_height": "0"
         },
         {
-            "type": 0,
             "inputs": [
                 {
-                    "utxo": "0x6313b9c616f9eac76b11c50885ff32076f49eaca3c58f30eca846a365bc006e5afa0521787d0f984306c1cc8d48a918a8885ea2d4d3449538445f7b25411dcd4",
+                    "utxo": "0x57d4bdc5e60ac4b25f7a6502b15b66394ce4d45b48694518e09d382b9fbc9905be211e45973102609621773daac68357fe0dc0a6092a28920d33ef3194c9aed5",
                     "unlock": {
-                        "bytes": "XA3ARr/o6ZA/vmDyLt+KQkkJPZvCCJ5el6ef2zecIgFdE+BhF6EL4SVCk47WwZNDwY24AqxKjVclEqX/jlZMtA=="
+                        "bytes": "8Sdo3C03b7d5KlO/Qwi4cuZy7JtqRF8BqsynPyzOVAF6G+ZtAFvISjca14Ot2xEODg75nywMnHLUqyAC7wgLaw=="
                     },
                     "unlock_age": 0
                 }
             ],
             "outputs": [
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -803,6 +899,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -810,6 +907,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -817,6 +915,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -824,6 +923,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -831,6 +931,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -838,6 +939,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -845,6 +947,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -852,6 +955,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -859,6 +963,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -866,6 +971,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -873,6 +979,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -880,6 +987,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -887,6 +995,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -894,6 +1003,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -901,6 +1011,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -908,6 +1019,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -915,6 +1027,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -922,6 +1035,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -929,6 +1043,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -936,6 +1051,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -943,6 +1059,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -950,6 +1067,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -957,6 +1075,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -964,6 +1083,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -977,18 +1097,18 @@
             "lock_height": "0"
         },
         {
-            "type": 0,
             "inputs": [
                 {
-                    "utxo": "0x6313b9c616f9eac76b11c50885ff32076f49eaca3c58f30eca846a365bc006e5afa0521787d0f984306c1cc8d48a918a8885ea2d4d3449538445f7b25411dcd4",
+                    "utxo": "0x57d4bdc5e60ac4b25f7a6502b15b66394ce4d45b48694518e09d382b9fbc9905be211e45973102609621773daac68357fe0dc0a6092a28920d33ef3194c9aed5",
                     "unlock": {
-                        "bytes": "iyunYXqA/B4w/emh49kUoE5LvtTri5jfLT4iaMfn9w+6lREY00SymQaY6io5l1C0amqFMW1KnZbFS7O+H4Q0uQ=="
+                        "bytes": "yMwjrSK9gxnDJuv5Ef/OGIEsWnrf8VuIJ9NWOQD6sgBUP6kVCJJFJWpCaPkrM1yonKivw8mk2/Dg+HIm8jwzlg=="
                     },
                     "unlock_age": 0
                 }
             ],
             "outputs": [
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -996,6 +1116,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1003,6 +1124,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1010,6 +1132,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1017,6 +1140,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1024,6 +1148,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1031,6 +1156,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1038,6 +1164,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1045,6 +1172,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1052,6 +1180,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1059,6 +1188,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1066,6 +1196,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1073,6 +1204,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1080,6 +1212,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1087,6 +1220,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1094,6 +1228,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1101,6 +1236,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1108,6 +1244,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1115,6 +1252,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1122,6 +1260,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1129,6 +1268,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1136,6 +1276,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1143,6 +1284,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1150,6 +1292,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1157,6 +1300,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1170,18 +1314,18 @@
             "lock_height": "0"
         },
         {
-            "type": 0,
             "inputs": [
                 {
-                    "utxo": "0x6313b9c616f9eac76b11c50885ff32076f49eaca3c58f30eca846a365bc006e5afa0521787d0f984306c1cc8d48a918a8885ea2d4d3449538445f7b25411dcd4",
+                    "utxo": "0x57d4bdc5e60ac4b25f7a6502b15b66394ce4d45b48694518e09d382b9fbc9905be211e45973102609621773daac68357fe0dc0a6092a28920d33ef3194c9aed5",
                     "unlock": {
-                        "bytes": "m2dKmx0TTmtk7H867qNM0mlsLujJUvYboJdajCPB6ggHpOHGaM/cpnIg1DlIzpdGkRoDLLofahbm17zGHuIuvQ=="
+                        "bytes": "vfXJfKXtfYEoWeV0FTcynz+6rggwXG1IdN+TTkZ0fwPITIBmRsuyyXq+3TVFRfI72eFgCGt8QO0kMEPUdyRaWg=="
                     },
                     "unlock_age": 0
                 }
             ],
             "outputs": [
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1189,6 +1333,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1196,6 +1341,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1203,6 +1349,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1210,6 +1357,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1217,6 +1365,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1224,6 +1373,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1231,6 +1381,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1238,6 +1389,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1245,6 +1397,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1252,6 +1405,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1259,6 +1413,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1266,6 +1421,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1273,6 +1429,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1280,6 +1437,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1287,6 +1445,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1294,6 +1453,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1301,6 +1461,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1308,6 +1469,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1315,6 +1477,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1322,6 +1485,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1329,6 +1493,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1336,6 +1501,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1343,6 +1509,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1350,6 +1517,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1363,18 +1531,18 @@
             "lock_height": "0"
         },
         {
-            "type": 0,
             "inputs": [
                 {
-                    "utxo": "0x6313b9c616f9eac76b11c50885ff32076f49eaca3c58f30eca846a365bc006e5afa0521787d0f984306c1cc8d48a918a8885ea2d4d3449538445f7b25411dcd4",
+                    "utxo": "0x57d4bdc5e60ac4b25f7a6502b15b66394ce4d45b48694518e09d382b9fbc9905be211e45973102609621773daac68357fe0dc0a6092a28920d33ef3194c9aed5",
                     "unlock": {
-                        "bytes": "GhOLd5LoCtgag4lTEmB5YpDYldFF+WzbqpL/ZalzbQgjlYFwpY2XjQGxOVZsjTAbSgQXgUaDoGgVrnIcEz8qGA=="
+                        "bytes": "x4P5gISQ4plW6/gYYwbRalUam2+xxGkOraN9bzf16A9sKEVw/lNUTgXONFf3Umj8uxFUaRGX3Z2dCit5tBOk0A=="
                     },
                     "unlock_age": 0
                 }
             ],
             "outputs": [
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1382,6 +1550,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1389,6 +1558,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1396,6 +1566,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1403,6 +1574,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1410,6 +1582,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1417,6 +1590,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1424,6 +1598,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1431,6 +1606,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1438,6 +1614,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1445,6 +1622,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1452,6 +1630,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1459,6 +1638,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1466,6 +1646,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1473,6 +1654,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1480,6 +1662,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1487,6 +1670,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1494,6 +1678,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1501,6 +1686,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1508,6 +1694,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1515,6 +1702,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1522,6 +1710,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1529,6 +1718,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1536,6 +1726,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1543,6 +1734,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24400000000000",
                     "lock": {
                         "type": 0,
@@ -1557,20 +1749,20 @@
         }
     ],
     "merkle_tree": [
-        "0xa4ce8dd85f51340bdae780db580e21acacfc94eec3305d83275ff2ea2d5583d75b8c400e1807952e04f243c4ef80d821e2537a59f20e12857c910bc2e4028bf7",
-        "0x63f299f3af18e0f333f2dbfe4a13377fbc7d11e3fb9ba0b899b4acd7219ad4c47b56481fc59979b933b33240b36aa4c090bf0440bd18e7a2e6d5405caa885794",
-        "0xdcc5ba48d932f9681028f6aad42ac77ec2363a2279c0441aebbf419b32c81a445f2d4ffe5d1e72f86e7c3750b5ef56e1054ca84d8578ddaa88659b7bd829404e",
-        "0x9823f761a9f55d222861aa6702ad79cf76869552038dfe8ec601c34b3e8c600320febba7aaa44028681e6e039b18508c2d1daf999ef606d11d69f6494bd0ce88",
-        "0x21f88b970256eb38f347322b07fcfdfb03eb5ba10bda3a2c2d2eac3feeaf8f073d66e3802922385a883fa2fa1dc3e1e5535ef0024eb69f839d8af23c2fa0e7af",
-        "0x3d04887353ad6eed2b61f0be74972d078eb432c5d37555b7e87aefb15a04815e4b1bea6b78c566936cbfebf5b4a8d412804881570f87555e423c1b99919c609d",
-        "0xbc5d1308b9e2c0e32c6b6fbbbd8f955393fa190a81307d37d82e6bd4608621f8227da1c071b35edf42608c734a694946822c2d0dc6d7c8e2b697beb58888b9aa",
-        "0xabf0830cc549d3a1be744a8b484b69236b27e8bd4f7950b1edb8fb5bd9eff31fc58bc5a645ab3a81fbd48fddb38e4677539924036de415e1a96b9a440ed4fa3d",
-        "0xce1350bda7e7fb3aa1b3a79cfe9894720bfe9848f21a7e44dfdb54dd5d1a38f55f27f99efb7762a64688989c908d8a0ed21c78b7ec2787a2993bebd12c46e561",
-        "0x1525eddbf962c0b4212701494de724c2e4643387e4b146d4e1731be27b87b2a995b393c5ca9ddacf621dfd4f149194f96cff25e35dbcf2f6c15d732652328c3f",
-        "0x8c31f1d21336d302db6750828d83c9bcf14fc3951b53f5dbc84f88c7a87a5f93d357639925ac81c5a2f45f62104a8a105ab914f81af7b3f11fa86c8f768fd310",
-        "0xd327b3ee5db6eebe9b78e4ecad8142155087ea50f603baace26963ed6f8a5853469935ef353efac4321b89dde5fe16018065eb5ad8b1e4a670304d23dbe5df19",
-        "0x8ea7f5fdbe8c2382bfec67d06d812f3a305caed6f16d862041b2ca23ce5f728fb3c744ecebf33fc2d75a59ce4f14c95d45cd45c45318f7b46a085e35ff9d8f29",
-        "0xd094b29fedcca586aa70fbdfc40fadf3f68e6244c8565edbd193f057c9639c489aff949b5175883e6868166d156600b56c62fe209089c66b70b5863a598ec85a",
-        "0xc8f96bf274187b0b6fb73c5b609a3fff28bd1fe9e6b712aaa3d9f92351100d7ca718a6c85f5f020cdeb13753179432e710576627399a3235ae472e7fe56b27e6"
+        "0xdd75be9a8b2778deb99734dfb17f70c3635afff654342cc1c306ba0fc69eb72494c9e3c4543eaa6974757204ff19a521989b6ab4c6d41de535b8e634faf66183",
+        "0x7989e23b6797d654499784cf70a97990b399948c7ed66663f6df31ea279c9200f770e39e72be7670b4daef64f6468b78891c29dad30c4c0a02d0b874ace16a23",
+        "0xd9ccb48a1d1009c4cca92ce3658fd622ccb8892fb455d4b332826263a47beb8165be34ece8c885d90fcf0f678f391584a602302a8115744c1026bd55c8f9aadb",
+        "0x44707116a8fd9422048ab3164d9daa8577059fb98ae50c8ae20d64f0d126a02b244d08348d2ef1600f107687eb9d6792bc725773576fed16c60ea21d483636e1",
+        "0xab31502552c985ac93c598274f11398f0543d41a66e8ae4371a1f026fd5db74dba68dc28cb90e34311facf73efde7857f3e484205224e71ff1dde63ad1c3cf5a",
+        "0x067d37b7f625baccc66186f0426fa7eb61b1657e6bf520b7bfeab0b4759a282c7604a4eac5509ba78e2a71224983237da2c75657a38a22c5f42419fd3ba2eb2b",
+        "0x0054d7d59d02f6c0d29c66d719324f62146f235bf840cfc2d7a9231cb60cddf85c1f3ab70cbf6bf8d9013f744f8c3998e0e39ba953420e98b42bfd5d014ba102",
+        "0x59595807eb5da775fe50fe0636f22aef76b0e8b33edf8a5ef8999127b350908d4fa6b0865c10b948b2cc802efa536ca344927a3f190c321972bb943c56838f29",
+        "0x4f3c0d0da3f3ca5ea1ea3f79f72250b7ae0baa0e80ba09782a0b36b157bb210887b31e84689c38137c27a5b353763223026c6757160f6c963737c853ce42774f",
+        "0xbf807606597e0042db589a4e7ee9d01b9f79bc2132f0adc46b9548d51a61964a38b9e21bc9ff20e39793edd9c5c64067f451e30f2366d3c1a95bbffd61829a0c",
+        "0xc319c79be9a20539680fab0505c68d35044b19ea7e03edeccd6c07321fee2656928c0e3b5a5487bbbb68654015e57b4fa707f60e58aa3bb9145bad147f24c32a",
+        "0xaabb0751fdf98385a05f946acb0a8f13eea39ee3e0b11a7280872db99e627ab71ebb8c797eeda204b46e9514a622b185cfdd27634aa7e45436c1e29ac21e6909",
+        "0xf2db0964fb8d20c7740b322004fd4ef8696d26d874d75ffa66309b8c1eaad7906018569e1e8e4c0093234957709c318feb8de5956c71e916b68f89ba0da3f4ba",
+        "0xf7358d0981428c3db379561c7446159c73465308dc2c815520cc875cbfe8c82a3f318e69631efde59fb9559f29df9f6ff237922eb369d76c6f0c812a6c81e8c2",
+        "0xa82a2d19ae115b521f0d65690e78f66260f5886da76508b72eee62a45cb8cfb5a7b8e300e0042faeb7b28fffc050cceb6c00ef4a326d992ef182969b1857f3d0"
     ]
 }

--- a/tests/data/Block.2.sample1.json
+++ b/tests/data/Block.2.sample1.json
@@ -1,8 +1,8 @@
 {
     "header": {
-        "prev_block": "0x1b272e34c3df561450a52cf9e2eab4b1dbff4d710cba755ad76e1b2a906645e0f2b6650e62369f3f56b04a51c82fb36d33c5ef88b59949d37a81ca614902ff8e",
+        "prev_block": "0x04348b962dac4423cd9ae48b4932ee1607fb1101a690d2583bbad909e8c3f22b12a6d65d1e1494d38681afc7bea61c3d81251800b8adbf1d31f52889df6d7e09",
         "height": "2",
-        "merkle_root": "0x5164e81fb8cf09aaff7ffac86e3d167318fbd6de035057dbeae2d380edd3d4fd491852c426d62766ad53a26294bf1cd0efb8e9140418e343b502975c29623f91",
+        "merkle_root": "0x2c7f07ca5e9d17e6e72502d0937e48f7e5cfad8378fdc08acb7a3a6753ea5c999e505133c139d5e0f31ce9d944fc4d09450ba782f0aa767e75db98f9dc70ffc1",
         "validators": "[252]",
         "signature": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
         "enrollments": [],
@@ -12,18 +12,18 @@
     },
     "txs": [
         {
-            "type": 0,
             "inputs": [
                 {
-                    "utxo": "0x0b640f95cec0159edc603291d9e519cf7ab3b141e4be9ae34770a89eb3937ed9a7ad9b601be47683c0b491ca21a67c6d43aca5d603b7489378fb6dafe19391b5",
+                    "utxo": "0xf180e8aede3ea3f6db7872b2af4225f186abc4835e2f1108ea6ee1c56a8edb79c6460de4968696ec1f9a7fe5ab0008d33781a0031d79409825f2ea45df6f7fbd",
                     "unlock": {
-                        "bytes": "lqAIaXCIgcpqhrWHGDyYB7EdArgM9Xc+K9msM5g0pQGj5t7/J1pEEKKHAppCDLQ7lBUHrCjKE9qBNKGrvQ4bAw=="
+                        "bytes": "eZid7mkGwHQGiXW9PybWvZ/mwHRp/mxmDx8I32rrYgKXGWDiGjVM0a/DO4NC2I/2rV4YzR1XEMr8RH5XmaVqKA=="
                     },
                     "unlock_age": 0
                 }
             ],
             "outputs": [
                 {
+                    "type": 0,
                     "value": "1663400000",
                     "lock": {
                         "type": 0,
@@ -31,6 +31,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "24398336600000",
                     "lock": {
                         "type": 0,
@@ -44,18 +45,18 @@
             "lock_height": "0"
         },
         {
-            "type": 0,
             "inputs": [
                 {
-                    "utxo": "0x7f6e35961dbaae3cad2efa0582a6ff2c992973bdd987c41c6d4f4b0e1289158c98b2858b4731c36744ebf92edcb05b3f68838432479aaf1373d123e60ad3448b",
+                    "utxo": "0x896240cd0ef51fdfdff645bb146737f889b70a7d72f9ebb842f9a0c4705de884209c451ccdc15aace878d12dac85f0b5522bf2642204937c5e44944741a1928f",
                     "unlock": {
-                        "bytes": "Z0ljMy9wWCqkXQ3O7yCyICHO5jP0dJq/8nr+VLET5AoFQHW4hvf1P/JFzIXPYtOQWP/avAa3s52aWvBFKIDLKg=="
+                        "bytes": "+FBRLUJHf6RdE3insW75WsUVDqFEi4lk4NSKEW/0FQKJgt5SItIG6TF1JVzPGgpQZd9YqU6LSaGKmAVdFIsfog=="
                     },
                     "unlock_age": 0
                 }
             ],
             "outputs": [
                 {
+                    "type": 0,
                     "value": "4000000000000",
                     "lock": {
                         "type": 0,
@@ -63,6 +64,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "4000000000000",
                     "lock": {
                         "type": 0,
@@ -70,6 +72,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "4000000000000",
                     "lock": {
                         "type": 0,
@@ -77,6 +80,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "4000000000000",
                     "lock": {
                         "type": 0,
@@ -84,6 +88,7 @@
                     }
                 },
                 {
+                    "type": 0,
                     "value": "4000000000000",
                     "lock": {
                         "type": 0,
@@ -98,8 +103,8 @@
         }
     ],
     "merkle_tree": [
-        "0x66b6a0e5f58514ccdc0164598bd0b476e0b93294f9eb5b938e006028ebccda778a36e7f141679c0b101bb6f74befc9a4b09d2d9203bf041409aaa206989bed4e",
-        "0xcbbc1f9eb9db56c846b34a5861d14b6726d567ed65223601c261a618dcf183b14469a5105ed77a6a090d63e3a1996f3f41923808e867da84c432f947571fab62",
-        "0x5164e81fb8cf09aaff7ffac86e3d167318fbd6de035057dbeae2d380edd3d4fd491852c426d62766ad53a26294bf1cd0efb8e9140418e343b502975c29623f91"
+        "0xfbe8c9c8544ed673672607552274aa1f1255375f8bf5f20bb1b7f6fe037a90ffbb84c70d0fd089afe5e6db9f68c5f6456b92f802fbb7a91a1b24353d2c625638",
+        "0x6bb2d19aff6bcd102b0dc98abe1bc8d7e494cc61ccb761890160db9b589553c4b43d50dde6f8d3a0f05a8427180d4a30cea0e357a3d974c688e7def488de45b2",
+        "0x2c7f07ca5e9d17e6e72502d0937e48f7e5cfad8378fdc08acb7a3a6753ea5c999e505133c139d5e0f31ce9d944fc4d09450ba782f0aa767e75db98f9dc70ffc1"
     ]
 }

--- a/tests/data/Recovery.blocks.sample10.json
+++ b/tests/data/Recovery.blocks.sample10.json
@@ -3,42 +3,42 @@
         "header": {
             "prev_block": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
             "height": "0",
-            "merkle_root": "0x8ac592615f23ee726577eb8c305c67558fd08f14120e0f23c2969a3b1d37089009159bd42c1d7af53d601b53ccbbad0ebaa54f36f4bc13d473790921ae3dc7fa",
+            "merkle_root": "0x4cadc4d240a26ebf8a01ae1c53a4793fec40c92d36d9f8755311420c9594a9fbb827fb974b75774723acbd13b4d0589e957bf8f14da24633be6ae299446ddca7",
             "validators": "[0]",
             "signature": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
             "enrollments": [
                 {
-                    "utxo_key": "0xd68cfa6d0457b404d74a0367ace0bd3784110fb55d94692e0859f3b5a15b33f990f33e3b4e4b4030945ee0303fabf7b2702f48a31ffdc3d1d6985e3e3dfcc8d7",
+                    "utxo_key": "0xf8751862d61a28fb878cd4b583ceaf39a59a5f2ff1fa78a169e56811c33b5c3eed80f83074cfb98ab5095ed563ebc6a96320ef59080628c4961f586dbf2e7d2f",
                     "commitment": "0x0a8201f9f5096e1ce8e8de4147694940a57a188b78293a55144fc8777a774f2349b3a910fb1fb208514fb16deaf49eb05882cdb6796a81f913c6daac3eb74328",
                     "cycle_length": 20,
                     "enroll_sig": "0x0cab27862571d2d2e33d6480e1eab4c82195a508b72672d609610d01f23b0beedc8b89135fe3f5df9e2815b9bdb763c41b8b2dab5911e313acc82470c2147422"
                 },
                 {
-                    "utxo_key": "0x7f6e35961dbaae3cad2efa0582a6ff2c992973bdd987c41c6d4f4b0e1289158c98b2858b4731c36744ebf92edcb05b3f68838432479aaf1373d123e60ad3448b",
+                    "utxo_key": "0x896240cd0ef51fdfdff645bb146737f889b70a7d72f9ebb842f9a0c4705de884209c451ccdc15aace878d12dac85f0b5522bf2642204937c5e44944741a1928f",
                     "commitment": "0xd0348a88f9b7456228e4df5689a57438766f4774d760776ec450605c82348c461db84587c2c9b01c67c8ed17f297ee4008424ad3e0e5039179719d7e9df297c1",
                     "cycle_length": 20,
                     "enroll_sig": "0x0ed498b867c33d316b468d817ba8238aec68541abd912cecc499f8e780a8cdaf2692d0b8b04133a34716169a4b1d33d77c3e585357d8a2a2c48a772275255c01"
                 },
                 {
-                    "utxo_key": "0xfbb850538245991a7156dc1713535717c530f851554c91de4b21091e88647cc0ee8c296da6fc40b283c048e3ed82cc46abe82cbd5061ba0ea579e1054ab51fcc",
+                    "utxo_key": "0xcbb19dfc2c28ea46ffbf962ca4bcb1a11ab6ccc8d83c9357a1d931915b0b8257cbe131e9bda51bed9668972079cf9f0d9ba0fefa01cbdd94aa05a90eb210d4bb",
                     "commitment": "0xaf43c67d9dd0f53de3eaede63cdcda8643422d62205df0b5af65706ec28b372adb785ce681d559d7a7137a4494ccbab4658ce11ec75a8ec84be5b73590bffceb",
                     "cycle_length": 20,
                     "enroll_sig": "0x09474f489579c930dbac46f638f3202ac24407f1fa419c1d95be38ab474da29d7e3d4753b6b4ccdb35c2864be4195e83b7b8433ca1d27a57fb9f48a631001304"
                 },
                 {
-                    "utxo_key": "0x765025088610ec9e6ee82c6373306bfe3c15731234195b9c762859ee3becea85d85de44ca5fef6660bdea5add694e12658ea4060c0ac5c76757829147afcc582",
+                    "utxo_key": "0xd08bc4c4a5f3341369f6c628e1cb9f3339ad1376b642f8bd95603a2fad6be0db81fa4fa58dadb5dc8f3bc7a020ad1fe8d2d6643238ea2508a37ee58b0df9e9f8",
                     "commitment": "0xa24b7e6843220d3454523ceb7f9b43f037e56a01d2bee82958b080dc6350ebac2da12b561cbd96c6fb3f5ae5a3c8df0ac2c559ae1c45b11d42fdf866558112bc",
                     "cycle_length": 20,
                     "enroll_sig": "0x0e4566eca30feb9ad47a65e7ff7e7ce1a7555ccedcf61e1143c2e5fddbec6866fd787c4518b78ab9ed73a3760741d557ac2aca631fc2796be86fcf391d3a6634"
                 },
                 {
-                    "utxo_key": "0xe9786bcd4188dbc27f3bcd9f3097355ad056d7518e8ea5a908adaba7229625a195d2073c512849e856ac7f8f7e0ee463e2e2be6373f3fa3f645640d2e1141151",
+                    "utxo_key": "0x6c87312f75478d515c5dc2bc8beb3ac5686aacbdedc8219baaf9cb62e41b1b31f00233321b3c42f9966ee47916123191f49caf0dc761d3a7fcd69198aa63f2aa",
                     "commitment": "0xa0502960ddbe816729f60aeaa480c7924fb020d864deec6a9db778b8e56dd2ff8e987be748ff6ca0a43597ecb575da5d532696e376dc70bb4567b5b1fa512cb4",
                     "cycle_length": 20,
                     "enroll_sig": "0x052ee1d975c49f19fd26b077740dcac399f174f40b5df1aba5f09ebea11faacfd79a36ace4d3097869dc009b8939fc83bdf940c8822c6931d5c09326aa746b31"
                 },
                 {
-                    "utxo_key": "0xa551c7d3076f43857913fa1a7de694df9c1ea5606bc084caa4c7cd7868a74c9f80c303ce64324becfadf8e092781a6b5ea9c76ec81bc5f5fa18fd523b333a1a2",
+                    "utxo_key": "0xda34f8f20fc231d4c3fe7f0190d5980c748dc82cc213ee7eb60d5c3f21c156b2a8b2113cfb48b3a02c049245e8682ff1da55b59b35abdd3832418675ccf2e29f",
                     "commitment": "0xdd1b9c62d4c62246ea124e5422d5a2e23d3ca9accb0eba0e46cd46708a4e7b417f46df34dc2e3cba9a57b1dc35a66dfc2d5ef239ebeaaa00299232bc7e3b7bfa",
                     "cycle_length": 20,
                     "enroll_sig": "0x0e0070e5951ef5be897cb593c4c57ce28b7529463f7e5644b1314ab7cc69fd625c71e74382a24b7e644d32b0306fe3cf14ecd7de5635c70aa592f4721aa74fe2"
@@ -50,10 +50,10 @@
         },
         "txs": [
             {
-                "type": 1,
                 "inputs": [],
                 "outputs": [
                     {
+                        "type": 1,
                         "value": "20000000000000",
                         "lock": {
                             "type": 0,
@@ -61,6 +61,7 @@
                         }
                     },
                     {
+                        "type": 1,
                         "value": "20000000000000",
                         "lock": {
                             "type": 0,
@@ -68,6 +69,7 @@
                         }
                     },
                     {
+                        "type": 1,
                         "value": "20000000000000",
                         "lock": {
                             "type": 0,
@@ -75,6 +77,7 @@
                         }
                     },
                     {
+                        "type": 1,
                         "value": "20000000000000",
                         "lock": {
                             "type": 0,
@@ -82,6 +85,7 @@
                         }
                     },
                     {
+                        "type": 1,
                         "value": "20000000000000",
                         "lock": {
                             "type": 0,
@@ -89,6 +93,7 @@
                         }
                     },
                     {
+                        "type": 1,
                         "value": "20000000000000",
                         "lock": {
                             "type": 0,
@@ -102,10 +107,10 @@
                 "lock_height": "0"
             },
             {
-                "type": 0,
                 "inputs": [],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -113,6 +118,7 @@
                         }
                     },
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -120,6 +126,7 @@
                         }
                     },
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -127,6 +134,7 @@
                         }
                     },
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -134,6 +142,7 @@
                         }
                     },
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -141,6 +150,7 @@
                         }
                     },
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -148,6 +158,7 @@
                         }
                     },
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -155,6 +166,7 @@
                         }
                     },
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -169,16 +181,16 @@
             }
         ],
         "merkle_tree": [
-            "0xd7f9204afdc2d41b28a33504d21b3c5384758d851c573dde44da26d7a0c7de06fde6127ec740fbfdfafbed4fb13cff24144054b8ae2ab34582110f0f752316aa",
-            "0xd4b2011f46b7de32e6a3f51eae35c97440b7adf427df7725d19575b8a9a8256552939656f8b5d4087b9bcbbe9219504e31f91a85fb1709683cbefc3962639ecd",
-            "0x8ac592615f23ee726577eb8c305c67558fd08f14120e0f23c2969a3b1d37089009159bd42c1d7af53d601b53ccbbad0ebaa54f36f4bc13d473790921ae3dc7fa"
+            "0xff66ffde4ed3b91c5bce28907dd68f7ecabe776c1dc7d797e5f69fc349d28342348c778cd42c49ef2c29199f374289d44f5b4d2d149f0b8081a1077eca30f7ce",
+            "0x9384e68e59382a256d2598251758d3c44f6b48f9a6aa405272e7b5f536dc0f2d3b3fd76b9352ddbf199a4862b05e4300a484ebd3e591abd1df596854debb4d5e",
+            "0x4cadc4d240a26ebf8a01ae1c53a4793fec40c92d36d9f8755311420c9594a9fbb827fb974b75774723acbd13b4d0589e957bf8f14da24633be6ae299446ddca7"
         ]
     },
     {
         "header": {
-            "prev_block": "0x217f5b3f53a52c396c3418c0245c2435a90c53978564efac448e1162ec8647dde9e5c13263390f73f5d5b74e059b79b5286cf292f3121e6f1654ff452f9296f5",
+            "prev_block": "0xba54155d042d03a722dc9234f7de5b304e9efbc896091e28fb3b19b908ee782653b5e6ef44566e19c728ff0eebf65ede6cc485337d5a473b819e86eeb2f7baf8",
             "height": "1",
-            "merkle_root": "0xf1c8567edfa30397b58fdefb0deccf84735c72d59601114ce67c937ccd1d77c72feb3bdeabbd83f53c9628005b4c43bf1fa556fb03b41c6192ec904f1d35678f",
+            "merkle_root": "0xb6b36b43f8c3ee3b1e0b5a72336eaca544b040995a246fcd1fe9687dab1c032cfbef6dd34b9c880694c183789a338eb80bfc7471c2cea908b32c25c827deb5d1",
             "validators": "[252]",
             "signature": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
             "enrollments": [],
@@ -188,18 +200,18 @@
         },
         "txs": [
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0x6313b9c616f9eac76b11c50885ff32076f49eaca3c58f30eca846a365bc006e5afa0521787d0f984306c1cc8d48a918a8885ea2d4d3449538445f7b25411dcd4",
+                        "utxo": "0x57d4bdc5e60ac4b25f7a6502b15b66394ce4d45b48694518e09d382b9fbc9905be211e45973102609621773daac68357fe0dc0a6092a28920d33ef3194c9aed5",
                         "unlock": {
-                            "bytes": "lavrsDjzx/WzR9wzbULYyjZ77ayjw3+4zE38fa3hyA0kiSv+jRmAvkJ4aPZTQVALcS15e4OmXkWOdLIjCDQk8A=="
+                            "bytes": "Z3DLUfkrL+i6xkvlc5qBXoonC9qeZf70aS50xZDUJgcd3nY7euC5B4NWzCM3IgIy9Ls6JgOxVQFsNkwcHRsumA=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -213,18 +225,18 @@
                 "lock_height": "0"
             },
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0x6313b9c616f9eac76b11c50885ff32076f49eaca3c58f30eca846a365bc006e5afa0521787d0f984306c1cc8d48a918a8885ea2d4d3449538445f7b25411dcd4",
+                        "utxo": "0x57d4bdc5e60ac4b25f7a6502b15b66394ce4d45b48694518e09d382b9fbc9905be211e45973102609621773daac68357fe0dc0a6092a28920d33ef3194c9aed5",
                         "unlock": {
-                            "bytes": "HRjLfLSdFQxHv4cHCA/tXK8yJKMAPUDPaQiK6MSp4wkM1iWLYJBkzeZxlXZyI17tGCx7AwUpGxS3yJdDVQrNOA=="
+                            "bytes": "7VklClDTX/ceAY5VVGtOAhDrzvYsiQPrMjXZ3yNc0At6j2Vpruc0x6TYuhMMSq3rH3Zr1O3bxT3u3F/pJIm5Zg=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -238,18 +250,18 @@
                 "lock_height": "0"
             },
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0x6313b9c616f9eac76b11c50885ff32076f49eaca3c58f30eca846a365bc006e5afa0521787d0f984306c1cc8d48a918a8885ea2d4d3449538445f7b25411dcd4",
+                        "utxo": "0x57d4bdc5e60ac4b25f7a6502b15b66394ce4d45b48694518e09d382b9fbc9905be211e45973102609621773daac68357fe0dc0a6092a28920d33ef3194c9aed5",
                         "unlock": {
-                            "bytes": "fTA6bl5ebNJGMJX1sv2T0Akpy6JmzP6n0Q/0plDyrgZO8E1KmUVySWZRTILb9c3z4ZNEiFbhYP0dAE7hNAiZlg=="
+                            "bytes": "qdB7ZnWWElUtPBoGPzEBx29bNLpMpynYuRKzLprcbgkczo74rz9HodrXsZuEzfXaMWYE5bptF5iNDMBNHWIdPw=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -263,18 +275,18 @@
                 "lock_height": "0"
             },
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0x6313b9c616f9eac76b11c50885ff32076f49eaca3c58f30eca846a365bc006e5afa0521787d0f984306c1cc8d48a918a8885ea2d4d3449538445f7b25411dcd4",
+                        "utxo": "0x57d4bdc5e60ac4b25f7a6502b15b66394ce4d45b48694518e09d382b9fbc9905be211e45973102609621773daac68357fe0dc0a6092a28920d33ef3194c9aed5",
                         "unlock": {
-                            "bytes": "CewnGSlBm5GWkvNNn+Auk/ia/E/h0C5mUWx5wotMRAFaT7y7JEywCihH/NCp4vivQBJL2ul023vgaohud+eO2Q=="
+                            "bytes": "YQKYlGhsIvFwrHL3trMB18F3Rs4Cwg2bnTvacPEvZwRCDbG32S47RAhnkeLBG2NpIMXc+pISqs1quewiRh1z2w=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -288,18 +300,18 @@
                 "lock_height": "0"
             },
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0x6313b9c616f9eac76b11c50885ff32076f49eaca3c58f30eca846a365bc006e5afa0521787d0f984306c1cc8d48a918a8885ea2d4d3449538445f7b25411dcd4",
+                        "utxo": "0x57d4bdc5e60ac4b25f7a6502b15b66394ce4d45b48694518e09d382b9fbc9905be211e45973102609621773daac68357fe0dc0a6092a28920d33ef3194c9aed5",
                         "unlock": {
-                            "bytes": "1Y9TE/FUhRKDYg3MyuF/cnBgGqS4ukH2wyJuQPjHxwb5MjV/fYpB1zeKsAgIP+28Ls2mk+EZyZkPpUuHzgIndQ=="
+                            "bytes": "+0uOIocRi+pzEMaMATma2aTHJ2Rrgij1BOOhAVHWbgZkqZ1QRL2QrDPFT8SBGjAl3GdHBqYyDXKUHIph17KQfA=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -313,18 +325,18 @@
                 "lock_height": "0"
             },
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0x6313b9c616f9eac76b11c50885ff32076f49eaca3c58f30eca846a365bc006e5afa0521787d0f984306c1cc8d48a918a8885ea2d4d3449538445f7b25411dcd4",
+                        "utxo": "0x57d4bdc5e60ac4b25f7a6502b15b66394ce4d45b48694518e09d382b9fbc9905be211e45973102609621773daac68357fe0dc0a6092a28920d33ef3194c9aed5",
                         "unlock": {
-                            "bytes": "Wnet1Rk4jB8gDwxsK1GJpx+ITySslO4hJEOMeexA9w0f0goulEFmsy6vKlIgHEPUcYMZWUsPiJwlZTUi7e848g=="
+                            "bytes": "HkOnNYwxHENPdyK9pX+bydBvb4/ISTUXZPlOCfO64gwGARJ4HQJKZVQZYxZTcMg9fjn6LHC5k1YqBG6PIlyskQ=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -338,18 +350,18 @@
                 "lock_height": "0"
             },
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0x6313b9c616f9eac76b11c50885ff32076f49eaca3c58f30eca846a365bc006e5afa0521787d0f984306c1cc8d48a918a8885ea2d4d3449538445f7b25411dcd4",
+                        "utxo": "0x57d4bdc5e60ac4b25f7a6502b15b66394ce4d45b48694518e09d382b9fbc9905be211e45973102609621773daac68357fe0dc0a6092a28920d33ef3194c9aed5",
                         "unlock": {
-                            "bytes": "e60xnB3QBzx7zzXmIXYphbJ2G6ldV1Z3r2QuFP/BOQecWNOlxt1U4y10n7DTDdXvsliFqHBEyy7/lzd0Bnu6qA=="
+                            "bytes": "esxJn0J4PmpdihlVRbkHZrtAchiUtv3G41NolNODKQpTNumeK5NEoDZSoKDBm4eVEd87DixUBAEmcgC/LSxw5w=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -363,18 +375,18 @@
                 "lock_height": "0"
             },
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0x6313b9c616f9eac76b11c50885ff32076f49eaca3c58f30eca846a365bc006e5afa0521787d0f984306c1cc8d48a918a8885ea2d4d3449538445f7b25411dcd4",
+                        "utxo": "0x57d4bdc5e60ac4b25f7a6502b15b66394ce4d45b48694518e09d382b9fbc9905be211e45973102609621773daac68357fe0dc0a6092a28920d33ef3194c9aed5",
                         "unlock": {
-                            "bytes": "xWbfL2Vk57+He1rPE5sk7KMIQ3d2KRdshgta/IV5+gwXJa48qhJLFge6bkU2+ei1QEGlk2KTHPjInpVvNqPA2w=="
+                            "bytes": "32jXsOW0cOjx3dNeFOPmETTV4MySoVFJ/rNO5yP0cgVBOXoME6/iJqp6JIlgMRaodvhiAQ3cLWjrAdY3P/f44w=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -389,28 +401,28 @@
             }
         ],
         "merkle_tree": [
-            "0xb44a034fafba2b2121d55a2645e640556dd45869b3b19a94620309c4f77d949caf6c4cebc607811e0ad1ab8c31ffadc5d3b9881898a25b4df6f571cee40a6c9b",
-            "0x91912f187c384c7e4a3de2ce00fc36a3ebc77a65f623cf2ed777d8f29c414e22d7f3ce0b64adafe885349e12dfce505abfcb3f8b6ce044151ef34a5e79de182a",
-            "0xce7e68020fd5e2c202adc23ed6b280b41bfc655729289d71d0d62d4775634ae0e01a1b28243171c132b3c6eebc77961fa7b9073a5a2fc462a34f8f70f194559f",
-            "0xecc173d70c823797504e24850b50c8e162cebf5a782f6843b6361807d05ee4796a634b549370c75d5ccf0486e295e58321ddc24b24fb3c6ef107ffd8304de689",
-            "0x0a2c0b2845e22d3a88cb18b0fd387fe10772416b85ba809b210fdfa1790ac579cf64cf2c451935b6b4b5a80edb31b681bf20337f0d20a7b743ed748dd96169f0",
-            "0x155fe5e86fd95417b7c6246e7ff05f244e6887b36f2b1f843c3e8f9e2f3f8128e2ad50027e46b18f0b2c173e473fea62a7114b64e1d220020a93345682f50f08",
-            "0xf16058645c8f19c7634fbc7d002f22fe60fc3b182686d2e45577816b00c20bed3086cf99d0818a446d5314cf4885fb077165b434174c835dc717db396d1eafff",
-            "0x33ae29226c4048f7d91c053c793d59780879ece457730f8b532f5c347b2665910f134bcabcc14ccd30df47983a4399a24fd7aa8afc32f1616a7161ff8d7af7e6",
-            "0x88636c0523e803e1f43244ea39b9cc99c610f62d3ad9fb8612b7249c669d41ccca44a0a2aca05231106a2f0da292cafea91f56eb457297f62aa21ca86aa7ed22",
-            "0xb8c206c258c5a9797c73438c670b89c56db94b20afdd47f33566489fd35aa4fcc8577b9b9b16494819769c1aa953d6c8b58b8c1482a7f51029e16222c663a82d",
-            "0x1f4eb3c9632c385969d2db9e388b96abe5f00b5dc6058c80035a3ee47847e871b1c89f61fb1a193c365f0555bad959cda53fe75113db6844a8676b5e235f6879",
-            "0x2b4bead0d9554ecad57cabc0eee57f6a0d9e8c44a724e6dc4052f3ca5db70386da7cd0c949e4cd62eee50c280774cde71717f1919f0418442da8b8828732e5b0",
-            "0xe06182bb72b46511e2da6630bd6fbd55493825d73d7257f5c8351a842754934ff36926c4844d27d34c5d44087d8ae60604a81a260698d84b7269d3a4df4cc068",
-            "0x0a9a0442c380652315237e5ae9b56d4f7dca9243b6444c5f1a5c9ae55ad1e589192f13b7b9afacc58e9aa497e267c027ac995ade00c5c8253e99d75c4f332696",
-            "0xf1c8567edfa30397b58fdefb0deccf84735c72d59601114ce67c937ccd1d77c72feb3bdeabbd83f53c9628005b4c43bf1fa556fb03b41c6192ec904f1d35678f"
+            "0x0f99c28bce31ce5417d7388093ab59e78946579fd3fcc357667d3f90d75e369822a6820920a2e978634eb62186c21003cac5ca0b907f087eb52bbb944f1afcfc",
+            "0xf17b9e328c16185c1b71e721bbbbc2cc5e6b843dece4120f4c89d1be7a833ea8585fd335b4c0c252049ae0b6bfe1cfee7e97e11216db14615b998f8c88d56bd7",
+            "0x5521195a74cde140296d3b14dfd09ec1b050f328790fa986dadc26b3ed444f96d33c56c6bfb315849fc34e02848709a3069a355f559056c647a7f9a0e5eef793",
+            "0x169888b4c0ed339308971b3dde3178cf30f0889fe4c43707ec2f23fe40d207197aeb2579d55baad17cd077ce83d7b215294359b4b3df0e1ef187522a2dfae80f",
+            "0x90f84f032e95084e243993891e4e40d708845e7d4de197d48c0ddd6e8a66378b8ed6745741dcd88b828509d52ed8e7bdc9c564b90414198e2a5a9ac93446d7b8",
+            "0x0c3103b670db03058dc44df6722b544adc8b046bfc051b8eede3a8d4a1a4885f371a42ec12e379cc60bc8ff54abacd6c5d53876f76c46d3757e27638b5153c5b",
+            "0x4bdf57ccc6bae98c1b6d589af7b08cb43fbed5faf9375f5a40b74dddc93247cc4aa7eb97e5a2f7d2fedcf1cc2b08a7cb0634da886a36ef8ae7b1711aac00af9b",
+            "0xc671ad11d3b17d11f72ca0424d26cb3c5c65099a90c8c94b1e76c9525a5e0b02deead51eec09fab8c6486c405ea7c85a445ee72a5e65a36cf05472895acc2696",
+            "0x269153736797f6f4479f49a186ed5cbc6c1e589e39abccd6d67d31fdf7e7bb580ec656d7e9a6ceef5398b0c0870b19402e25ea805d2219f05e8c117c959aa289",
+            "0x697ae59594b01552de40867153df439b8c7f1ddf8aab00a3fb6be1ddfd39b3bd9e848b47e1f27997f05deb33503aaaf0a2173eb41c6a469a923f69d49db29149",
+            "0x3ac0d0759dea61273418468cb7c1a6f790a357292116893540e7cd752827442349b1705c64bd1959fadb8c9878ecd12a0532d602503e26fff36348f9295884d4",
+            "0xe17221a57e8e8e0b76973f7abcaad51484208b0b37d8b44d3fcf5c31fabbba11803eccd8fb618c6f41669a6badba1093f0def2632d8429192fc1dbc857e19e3e",
+            "0x287d9e8bfd05c2c9b504423f0257eae70059bf163f64fb7e7220ef2c0c1c355e26e3d82fe2ae2d13c307cbd123c0443cf71f766c99123865d38e29f274d6abe4",
+            "0x3971824e4994ed96876895bdfac8bffdbed97d052045ec1be4e5876e630638f0667ebd056b73be0c84903062238dd6bec63e646b7d36833961209496f9bd903a",
+            "0xb6b36b43f8c3ee3b1e0b5a72336eaca544b040995a246fcd1fe9687dab1c032cfbef6dd34b9c880694c183789a338eb80bfc7471c2cea908b32c25c827deb5d1"
         ]
     },
     {
         "header": {
-            "prev_block": "0x5fb4a1bd596e5c4b5cd3027c6e92f4ecb8178f167c749eb8938d92b2394473348fe8be7fe123978c72fbd9a1e4a23daa192d28bfaa6d9996286f5e4d3f5ae96f",
+            "prev_block": "0x21e49c8cfb4e3ddc5ae2632c24a8f263223b32ee95bf21d32a0a80ab32072e3c8bff6dfa03869a608064c5dda389b288f75a5a5a1a354d7f96c80fa3b005a797",
             "height": "2",
-            "merkle_root": "0x72b710953d77b0a6d2a41e6d077cacd4a8f307f005723d5bb7c9eeab457bfd77d121b53a72394aa652f3beb49c29ba3c4872b269b954f74f86b585eb18847d41",
+            "merkle_root": "0x46fb52039c4d42504421f16d4d7565e74c73d78181e1d1ab29cf71714f5158be1d2550ba96c4302084878ed67f9368a7b129e4930eb78bd457dde38031ff157d",
             "validators": "[252]",
             "signature": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
             "enrollments": [],
@@ -420,18 +432,18 @@
         },
         "txs": [
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0x35b5a0c6a15e4d7002e50c81117897619a42b991b387826f55082827590faf5afedd30fd1395ca4da75f51429754e770cae80b47c93f730281281ace756c8981",
+                        "utxo": "0x6e15a4a2b18a269ff8d1813adfcd5b438591f10449a0280435b50f8ffbc07437c3b88bb82801daf1e2ffc105f7b0131df1be7d5dbac18b9dfb28d0670df7818f",
                         "unlock": {
-                            "bytes": "a5xrmHGveF5Iwzs533u4VStl4xLrhTYgpBpkcnu42gHubOoTR059xXK82CQnZ73oWA8v7f6DGpOi9r6K6NeWOA=="
+                            "bytes": "MbTWacOwEdSwU5HpDPk50ljTnQoYNZBfTlTSMnZmOAMuhQ/2R/5J5QvYA1s7t+wtUw5cbwm56q0xz91DrjGWpA=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -445,18 +457,18 @@
                 "lock_height": "0"
             },
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0x2ecc983fddb3f0a0b5384996f7dfbbaafd3c59da5d085d04cf8599dd97fc1b6dd42fb3b6586ccefcb15d9bc5efde26a450275bd12d44465de132effd8a7497e4",
+                        "utxo": "0x9d7c3eeed5a41eb23cc5abed159403fd2e5d023051ec1acda3fdf44ff7313f17bcd768f45b9a520e10ba360c1b32b288743f8cc7877994d4b9f6d75c66f1c749",
                         "unlock": {
-                            "bytes": "6+bnKgzRmhxgrFdB4MVJ6MGJGyRvsuNG5rUBh5/XrgWv2q5F8HlwAFfY+K7yDzb+Me2pE64F7x/5B/Rm05yomg=="
+                            "bytes": "qU+Pj6ob5w91+byDiIKuBjjE5AYIrb+vnEJ3AL4gIgMi8XpYm9IScu6nM5/iWEXOZlpcYKMVV0+AWkD2diEdyw=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -470,18 +482,18 @@
                 "lock_height": "0"
             },
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0x01c94dad565917845e3083908b05eee9af595d80ac8f895d398754700f5884311a06e245e2019c84b04d37486f4da1d4763ffe9bc6e99256018476d72f3a5e40",
+                        "utxo": "0x3c43dd733130dd3c3136a6691a14e5e30d0a93dc9ec0112bfbb84637fdb78713468b8cae99905993569080f90a5478312d6446e2f89e15f67b10936ee002f9be",
                         "unlock": {
-                            "bytes": "glcDcWJeLraqfP3jEm/i0dvuTf2ruZvjaKQ++0/MqwYuiLr+yILdZCq+LBTARJxRwZVgGcpx+Z7pWGTryrG/Qg=="
+                            "bytes": "YYHcuRbOh492ldr1gzhJO40BtBy3aselK8rNBfNHYgRbkIv0GRczF3dwYMrvf1uoaxDK7TuE9JiIthW4V8ltoA=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -495,18 +507,18 @@
                 "lock_height": "0"
             },
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0x4d0a110390796825f023c5323ca14dd66537d198d1165e54faee6a475f89d3ab4f508b64fb2470c38fa7ad229eda2512a94d9cf622e7993da03ea9d8e772cf76",
+                        "utxo": "0x2616febbea6e01019b104f566290e055d006d26876d271fb46fc35bfba350f844f17b0fd8509077240d64f3ad373b603299750bb71bb679f8326028056f341b9",
                         "unlock": {
-                            "bytes": "TU2g1MLiitHIaAb+WWq4iE2Cka4UUrxrRX9tb4PvcQnESv8zNioqBaR0R6CwJME71QLXifKH0HQLZkcETyvmgA=="
+                            "bytes": "d0/gbUwyUv7DhOPkNc9IfoqhDpKAeZaVGZI9SPtJ2QNrUHLjTjb+ughUw8yLqZqFjwnTDL0AoeTHXgrM+zibcA=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -520,18 +532,18 @@
                 "lock_height": "0"
             },
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0x28caa35b82fd1b7294da5acb81de8869fef2308535c08eaa1892f0d7afc1b6e2a52fc371e20e78c7f500a4be77b93d4f230cf25150ad5001a53be16c3b832b20",
+                        "utxo": "0x544bf713d158c24df391ff91b1b452d79e70417adc706efd9b129ca3b181c2336eb0615733cdfeac014e6df022b7b57f48faa49fa66f8fd42fe9de0375fc2ba5",
                         "unlock": {
-                            "bytes": "2gX+Ov1KckaggT7MlSR8Iqf31a9T3NzWkm4ECv1vFg6IcV8jXCOXmjgndhg/3h+fpOCtY7i7u4I/HtcGNcbAZA=="
+                            "bytes": "xxZ6HFUfj6vB6Qx6v9ht2iTk/QdhakfR04Q4Un7ACwnct6omlmX3HWTiG1k+baU9JOgru7ixbSpNvpsz1iZ9Mg=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -545,18 +557,18 @@
                 "lock_height": "0"
             },
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0xf297b1673f791be15925be04e5e5655ae98ece7626ca8a2bf966928fab3560a63f29175c7f5fd01d60e9a627dddd2f8e5b39c99282617a6262d01509819bf2fb",
+                        "utxo": "0xdaa32dbaffc6c2ad3b78605922580a80fcb20ea74b7d19168450ffe130c24f0f83ed141c9190868de4befde92fc151ae536de68d41b14295a97062416288f2da",
                         "unlock": {
-                            "bytes": "dDbxXe2dn/uUJkkE4XQaXNP9ZA4DWZBwIN2wa8fbdwa9jvJfbzMzFzNw+hbAv8v8ID2nt2QQkZ1/3zNHMuby7w=="
+                            "bytes": "1FddW0dLAV3ZBqiZKywYo3yB3MHBL4HchXJI3MMNhArIVEnj04uXnIAEGYXHGUCEb4B0w0oEFjdkwGleejLDlQ=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -570,18 +582,18 @@
                 "lock_height": "0"
             },
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0xdf889230cc609212e261367f089a0ab003d87bdf5f190629eeae92c2ffef0e1df7734f3ed2b570ffa3085663e0cce8dff3fe6199d2226d089f2360e9d7d3e9dd",
+                        "utxo": "0x6520c9d8c04709d78ee3a0745a471997d141717a397f27570ad1de95f05efb9ec9fea75589bae674cf332be213113eab444f625d24b70e725475eb495a70059d",
                         "unlock": {
-                            "bytes": "ZVfyO7mriXm083qDyFouBARdEQM156FPvNFai0ullwwyc7EiSRJi5uWHvG8lR3diJg88csd3CKEC8CFg5YKr7w=="
+                            "bytes": "J9XQnvEcXr1v4rXuh8y69gmBAZfDww6mvYpnSk+m/w8CS5BoHqpY0nnngmQi0nXl1UF0tJiSAOn4TOv7NiD1MQ=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -595,18 +607,18 @@
                 "lock_height": "0"
             },
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0xba86db2660f3027e509c93b83ea9b8ec3bb1b330ba98bf997c5b555850beea23d28ed1688c4edfe8e98cc0b721d34f3210380a9e7978237c09f70439c5b3f110",
+                        "utxo": "0x9d82aebcfeae95f70d84e955b8484c2c58e3d58d5d3cb7ca749e4cff14de018987836316aa21bc2f2ffc7270b90ee2c7810687b6bd6e8bf8eb66212c13a69d9d",
                         "unlock": {
-                            "bytes": "PSBt7UdBChpePBMyEo8N+R+a5ZR84kDhVouII7cVRgghY24uJreGFabKgl60Tf8Rooo69srErEQHbFJZy5f5ag=="
+                            "bytes": "TMimx70dhgIutHgUoEwubhhOOKwYRiUV3I4RmpIVSQI830ll6whUO79W8obtvj5SSP9VVKwI3ZmbzJJlhrXE2w=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -621,28 +633,28 @@
             }
         ],
         "merkle_tree": [
-            "0x03212fb5c1f2e3610655c568c335011ad0d0de256e6e421941483e8ff2f1c15877dc18cf44bac30f865710d257a060fff47440a5be3057cf50416b842ece87e7",
-            "0x453a03da788d4c38a25b26ecf8784bc77c437e4e2399d8242c2cc7cfe45c9dfd99791e6804e32dddcb75a2325c82195f88564002dbab9f1b12cfb911794f853b",
-            "0xcf4bc11daf60532bd018465b8f188d312c64930de00757fec2b78c0ae33a2d746d1dab4622e3d328d0a67e12aae57adc8f6c3f21664b8bbbca21b505b1e61bd7",
-            "0x5b4fcb1ec2e0b1a74f945fe4b62d7a994bb9e2e6047ce211127ed04d7ffcb886dee9aa42ef5e8180b4e9c31d33ad648c4575d8cb779c2d4db113764428063913",
-            "0x77c81b499bd4cb86db1fc87c0fdc202e7fc480c3d22886896043f62fd615952715cfb56b53d863b466a5d07c11cf403afbabdb567e7f760b61ae8ae873d40011",
-            "0x8fccfb96a54a9959bf78e6b5fd0826b6f5381650a32be54dd931b774d02b77d224bb1823968242e01e6dc2248b0240faa22d11fbca576d568c779f4961f28bf4",
-            "0x1960af0873855e0366a3067a61ce0569f22e40ee84aac66ad23352d8335343f2116acbeed1222651084c7e418704df2259fec92fc1e1c04d00949a519d083f57",
-            "0x9416e393c9809cde542ffa7a01fa2f2b3a5d7c27e22abf8bfc03e0357f00df3d74130cf31e464a674a736c930297959533c27227f996bf83bcf8b8718bdb6b95",
-            "0xa171d7396c276f75333c72007c0ad5316ef6c71333ec7fbfe15f0621364f296492bc0418c773056e83d65b07be2396a5e3d83058b638cbef897452d555aa6c8e",
-            "0x1f91e65d98fa66ec5f9d923b8d3fa4d804501fd80be311ee3cffc2e79f4483520d7d87c7b0a16532ebcf2312f43d0a17872a237ad32cd10a702b925b94cd3e27",
-            "0x68cb0f096a7b7a82b6022ab4b4c0f9007c332b19c2f2bb2026ec03191349b29aaba7a561889867fb58830f73b1b1383788c56831b96b0926e87f918791586914",
-            "0x47e2eab7cde71623acecbe47283934c9692e80b8bf7117de2eeef249b0784e2a49d37d60d7aeaf8dfddbf085ae68599e2db3e455b13c61c7e99702597140be19",
-            "0xb28b11be91714a197458271efa91687219107e6b68355210782688c7840f1ed23d9f71e0b503f5599d0415d19eebcafdde026b2d8774e8584fbba3600fc6fd3e",
-            "0x30ba1a8a2df64351747983db5f77ee18ffcdc87b82f930a587430831eab9250d3b8863c3afb43a78430ecec36853d6dbac05236960c1b1f04c77fbe8611e7075",
-            "0x72b710953d77b0a6d2a41e6d077cacd4a8f307f005723d5bb7c9eeab457bfd77d121b53a72394aa652f3beb49c29ba3c4872b269b954f74f86b585eb18847d41"
+            "0xf271bb4fd4daa6d06ad25754c038af08bee5ed41c206454b5f40b22d7c54806e55a727aa1c0a555c36518985633ab4856ce8f57188f85c041f8e96425e405f6b",
+            "0xfc063784d76b050596777cc2dd1e5f555eefbf6a0c52f4aa1ecaf69a9660398bfb324b3d2a635e83220b8684fe47dae3e48e4eae6f62d7914eb7ac8922de30dd",
+            "0xdff767997141253f9b4237152466d19e1a96b0427e0bea8c8c3ed89e0a6fd9c6e04f2a43007918c94a97789b1c6aea9bcdd4beb743ed824e2a6fcffb74c4e6d9",
+            "0x6f21b4b0c8da4f152752e833a907af1bfd1daa465b5b35d3a9476c307dee7979006323735c37773b2820a8ef1a1f7cc45baa025f5a7c6de69b1a47296b214f89",
+            "0x8a4d25774725654c661e74ccfd6d7134fe6015324c4a6ade5aba062d3735236eba3927ed977ba53e7917ec001033bd4ae8cfb303667d3bfbd4dc1e0fd80530dd",
+            "0xcbcaf989349068337391056c31849a111de17c4d493c5f46f0a94f4cdc1ae2c2005bf30e36ef97313e4b6a92f5e8301b6b6e21e2bd28a75131121ef09c85da92",
+            "0x0887e4339e7f63db81de7c85630833d0c351660e0ce92a25a7be700c4ab966b440419098211ac8ac407f9dd46a942a8eeb29dac00495e3686851fcfb8df0815e",
+            "0xff320eace9f8043990ee26fe545521b37214af4e50551d22927abf5474d8a4dcf21b679357afa76fef070ea39cc7f7c629ad64976cccbbf6749d5399799c793d",
+            "0x5c9fe0fb6dbe4e431970c4fa7cc10b50d960c538a0a8e488ae41190388f6079b08baf40241bfa3597f25e74128ad0095bebab76b7b5e13abd7cbff8360f99472",
+            "0x86aede9474895c19fffd0bfb26e3c3b5f3a03248fa6cb49f4edda93fa795e710eb48fb4cf769c952daeeaef5a3027a15dba1c66f33751a2f0afd2f5dfecb7279",
+            "0x3a077388a0b0a27588d798a494b113d22b5ac37abae262666836c4d1c8f5ea7b8696d99713b7203fd1523a213a7a084cb704835ab315527417412f3d04d7dbd8",
+            "0xef793afb874dc04855c05f0fdd6869c2a40f058c4b005ce3d44ed311bf0fb34968beab09562be3c0ba46fc3a315390653b1d637a927b577069b37756729bedae",
+            "0x2eab8dbbdb92e9e4e731210454cfda6982d514f24cd0a081ad4364604c3574819cea1b2dc2911a2518a82c17c3faf3c4a49664911aceb2f4245e023d298bc954",
+            "0x535a4077e6ef6e9e727d91cb98e3ac1165c70b7b5dffa327a2d1a1cdcdb90abbca8564e4298b3470cfd19e5b123ae3c42b41e8a09481112abfc9383b5e852f31",
+            "0x46fb52039c4d42504421f16d4d7565e74c73d78181e1d1ab29cf71714f5158be1d2550ba96c4302084878ed67f9368a7b129e4930eb78bd457dde38031ff157d"
         ]
     },
     {
         "header": {
-            "prev_block": "0x40f9e6f19e2664ec7dec2391a31de58f3046fb9e4bb555ebb719e5e8598d5d245cfd77847ea15e0069ad7f053b2f9e3631d277b3b26300ba31af4ddfd756fe2e",
+            "prev_block": "0xc2c886b74285edd7a3da55a12e902940bd361052bf3ac232fd2539b7dc72e6e704bd178f195982724d56daee5cab89401458d7b4e767210a794d01807b2ae60e",
             "height": "3",
-            "merkle_root": "0x4a969b43083ef44d64237cc66070582e9a1beac7ecf4ebe5400c5f75e2ca0176e4a5a5ae128cc5f72d28f223c9821fe953028dc666fd0765180e05b8190dad85",
+            "merkle_root": "0x009cde64833a9c190d338fdd2d3f1f843d9c786c34d82290570b4f04f30a9174d58689f9289d35740610eb94cf8bd89b09a044fb48e4197c08f316b572878935",
             "validators": "[252]",
             "signature": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
             "enrollments": [],
@@ -652,18 +664,18 @@
         },
         "txs": [
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0x9192b80acfe2f42a14ac0c360b7f9fdb1229fe1a467f6ccf42ebabf36d5f5bd006046e710094d3bb632df6f27cbaf05b404f6460488129c64a91e95dea8cd9e6",
+                        "utxo": "0xd08da4d80adcc83e487fe9bc46f34a666c1daab840723d43f88222aef7b61f624632cd0ed299c8172260992f5ec769669cc4a4bed973e2d7585eda1bea5ee474",
                         "unlock": {
-                            "bytes": "p3A3aT3CNLti7WEqGOJC9x2pcsDiOI49l0NV5lznegwb+SMN45QviwC/7kTpDnlJsqjWfPdMJcm3n4StjJ4haw=="
+                            "bytes": "Z1iBWcRWyKvZgA+S8iJHBML9fEkF/VjNwIRRJz1y2ged10HYLpopulb26hoI2hiRhnf7MAq05fGXg+JnBIRVdQ=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -677,18 +689,18 @@
                 "lock_height": "0"
             },
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0x79ca7b56f2ea4bdeec6824ce685e1a42840f29bfd630d8b0d0fbd1e1b934fec8652b1618d7e54c363747d959e5774a500427e9f6206c4b2ea5782c2b619e5bcd",
+                        "utxo": "0xe72f4605a0acf6ea61c6c491e424e3bea45146ff8cdaccc5937ed7316886ce7bd723381cdab3826a7103ebfcc5f37a0092f0d2521a7ce5b95090e4a923cff143",
                         "unlock": {
-                            "bytes": "3O33e5qteTsF3DcA29AS3+crHbvsA+8XLVZeqfdQYAwlPX1ZnUp7517jsUSk+iFdzbXa1QwvgibSUZELArAI5w=="
+                            "bytes": "3hqv7hRSzb4NRchKQIBW0tdPmqUKQ8+JCYqHi78tcAekOGojVnmN+GXZVTScG70DmeOJx/xt9ncaTErO9DCSZw=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -702,18 +714,18 @@
                 "lock_height": "0"
             },
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0xb889c21c6c8ac3bfc36c3b3583a7f1df3ae9162c7b5cf8e0d554b536bcd57d65351e9ff5f60d4b3fb8e9f5ce453102dde80f72e46b8efd6df2d0e31346c62c68",
+                        "utxo": "0xa80e7a1f148008c0dfe5e25fb3401b7e957646f0ae86a6621d3194abba712a2def47d23cba5340c9ad0e84f00cc4785b915f3b2ce9c0704a670d6f02bd605303",
                         "unlock": {
-                            "bytes": "TJxFM9TJYjO5QVlw5I/rfmVA9A31T/iX+IW/ILWOwQyg0KPwmmAzOUVo57QOGGbtb9n/hyF80uPNswFLzCAaug=="
+                            "bytes": "1wOaONTNAL3Ix8s9otCVm+mdCLDkCJpboIO9QFERhAORAZVrEHY1JQnuOpOB+gmFQdhGDdcEnhqJCskRNc2ikQ=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -727,18 +739,18 @@
                 "lock_height": "0"
             },
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0x8c9ffadb338413f47fa6fcd774a786935eaa5c6a7af787e3634a419c083dee043862883f5ce7c2e5b3b4069d825732eb7b8fd68aac3de812e30fc48dc9ff7692",
+                        "utxo": "0x352bcc14b7811ec1e79730f920bd79c5d0c01d07bb00ff2c19ca1266f57fccb117f6fb9737c3d243b858fe6a528082de5cd7192486878449fe3a7fad0a7f4d3c",
                         "unlock": {
-                            "bytes": "O2YVLnP1EKzpBb7WvfYq4QnibVH8bj3BM45uUKs71gySj2YAEE9WgNXprV3se2i4mwAO+2DJc8e2GeAXZ27/vA=="
+                            "bytes": "mFPrbVzqSLE/eo/z+SGa0kzvJrEZyU+WXyBwRJXpEAxfWdt5Lru8yBw7BUTYPsPHUi5Qj5RBRXh9As4KsNjNog=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -752,18 +764,18 @@
                 "lock_height": "0"
             },
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0xa75dad6ea130ddad66c4670f1198be5dc40c2bd7d54387c05ef362dc257a137571cbebc60a1d688c4a8ec516bca7c0d9214441529036217356496b14ac0dd946",
+                        "utxo": "0x35066061001a9d2dae1c01f92df3fec9f774713ee31b0345febb30eaec4dd5353221061ba9e68ce98a2c4389567fc49296a0a9c97576799ffe228c7c1afc2e3e",
                         "unlock": {
-                            "bytes": "5H7hwNsc31/Zly3T6kok94PSXPVOuVr3zK8JPvdq3ANMDS6ctkMms8Wemk8U2tZ/om/quAKXSoRSzxky3okLlg=="
+                            "bytes": "USxBvT57kCqGv7dYEmzhy64ulbj6b10O6u4KZZ4KcwHi/xG0pjv68MXp3RITnH/zCv5w/wRRHOEqweNSzOD5ug=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -777,18 +789,18 @@
                 "lock_height": "0"
             },
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0x892afa7d726ee9cf1cf29e830187ce7ce7861e8193c0e41606a4ae501a393b0cdbae24c27b0389a62ff74e6285061835c6c33c6f02ceff21424960738823a74c",
+                        "utxo": "0x93e2fd3f24aa81f2beae4d3f9f2cfdb8bcba32d0c5694e9c5dc60fab0bad026ca335b918a794e5191c784e6eccebbd4c0ba4c6a4b34a0e2ac6bd8af48df29a06",
                         "unlock": {
-                            "bytes": "4J7ADJtsbUJlJO3L8RdNYOkLOLlZa9bOoX7XNvpZDwdDN/KGV6j+r+SlXCzortzD4hjcvBOXMOdvlQrfiT7NFQ=="
+                            "bytes": "PLQ2Epiyf8swAx5oBq/eWUImY37OKBcg2OKMPLieBwX2iNWXiS9ZwOcULWS+iGuvA3rF7Su32hOhkCbAxSEb2w=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -802,18 +814,18 @@
                 "lock_height": "0"
             },
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0x609cd639c9f65dcf4bc7094e514b4e193b56d6931c42da6b80d335c1352c68e0f01fcce2bf38314088578bd7b38d4512c0ad95317a05c59e5859e76fdc4342ac",
+                        "utxo": "0x12b8a2a28516e77a7e1e653120a3ba4747810de67e93a20ac16f8a1c23347a1b152423559f321f3944f3940781e5f7a2a121c629a25bf554a2e9d3f867ed24d7",
                         "unlock": {
-                            "bytes": "3wHHm2lbcGGajgWJs9L1uNrZm8ZacDpVevDVg/HArA1ecOtKnI8e2ymzS1WV9FYew5VT1I2nCuMQ3Q1EYJUkSw=="
+                            "bytes": "hHFaHJ48kpvOrfCZyO+QmXHLs1xeyq5PlUY4EPvECwnjG0dIKAJ9mwtpc4fZgautxKYaaYaFXd1It7QiGi6+Xg=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -827,18 +839,18 @@
                 "lock_height": "0"
             },
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0x0e9737611c47274319421400a0a674c5d18696c3462cf0dced6822086918d0883f4d312876839287b580afeb52b737d9009898d986c918cafd14c33bc1c6412f",
+                        "utxo": "0xc1b0be3cb1af257d0c7233f958223c0e9325532ac51cd9c1467ccb746b7e960b37bfaa4de94bf437341abfd025c0661cc61afff8baaf4285fe412c69ba2f6258",
                         "unlock": {
-                            "bytes": "QWOGJpoqTkne2AAf1MwFErqCGCCaMMBcdj7U3FoDYA44sun0VwryqaH4Yq7stX1eyp6TzxQMoui6sXxpgD3xEA=="
+                            "bytes": "mQr1yMzTbR+ULrl3az3QIdnrt/Sfluu1UwtM503oZgJZkWvMGdKiCSeHcxMlkRfKvPAuFA92VPNJ0IduxRqMmQ=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -853,28 +865,28 @@
             }
         ],
         "merkle_tree": [
-            "0x19042d393bb098c197949eb012ba847c0e97189455d42253781b64a3dc1064e8f109668e967ba1f09a341776c99b8d5d018039aeb29a6e9cde9fe8471b932c6c",
-            "0x444b8fe1dc72ea8d2a5c034efabaf3526e5f3917808b304a1bec0ba04d664e7ca813cb136c22142bc7052298327f101c477fb82048304d9ec6bfc50658fd56fd",
-            "0xc476c5d5746bd566766f2f45065bb3722dd0a116489e0146c3e6b6f50d08de6d0ed292ac6110f2adf97deb6a0b5f0999082dd0a0d9c5b5dee02fc828fd413cc2",
-            "0x4c565d565c82ab4b61d2729fa83e02e3e2f995aab2b2a999052a4eb8132db90213384a3a05e98682b1f4f10a5e34a01e56a7eea3bced2fff3c789570339f824b",
-            "0xc7ce2ea11c5277baa1433307a1d00cd4168eab6bbe9d5b0406f10fd63f3176d5163758aaa3165b91a225139a1975f47b7f454b1c0c32fdd8c4430c3d090f570b",
-            "0x4852803a2dba081078d63b620fabd50215567a6a76caed278e126a600e0adf11d5acf5e26930e69b9f123c945c60e87b76b9fd2324c5215c22d392606c71aafa",
-            "0xed148a4ee9d3f71f318e0603d9d5ea1f1a8b281d643505bbdd1611a3e4110f28e8ea0f8b280f252702b53a300ffd11d03829f307a698cddbaed7d9d234e5a03e",
-            "0x8f789f620bdeb52bac5dfb031de00ecad39d342c93febf878ec6a0cf9c181b9967c256491662891d532efc49904b8ad6e3f8c66074ab2a8e2f7edf5447753b04",
-            "0xa08cc865963c8f53931509985f9b77574e79613f8ee5698072402ca9f9e2711929c5ac3ef96e80a07ff5a7387d3b4b3d315f567d2f095d12b3dc617313eb3c93",
-            "0xfb627a2ac633d2ac40966989e950e7107cfb1e38792cedbc1c23282b8c6887cdbf16ff7316ab9aa3b0b3e8cae6b2f402d9e88d2683e42f96049078d520645e75",
-            "0xf4fe0c27f09bda4e7134d6026f4d511a32982e3bc87283d705925fa5231a8020e7d20def1ff56bf92e3306a16973f2d92690de4e67fc335f08749a054fb6ed4a",
-            "0xbc07bfcfd330190f2a2d56b3165e5c2c25823cb3b0ed7cbe0b62cbb9bf573d0a58a8abddc87291f7c9c138ccd5c1c990b81f53adb998a99b7aa013ad7e6d1e5e",
-            "0x7120f434de1c9e40850be8c3896516104fab5585b4fd73952e8f870fba6e72041ac56a001ffa2497b5fe3d76fe9829334a7bbe53314da12487af2a7a68ac4c5d",
-            "0x69c87da8d3546b1eee7d5e892519bf4cafc5b8e24947ae6d42a4f034e2fbf7ff71f41a75aeb0b559e904f4dce0ff8b49536898bfb4842f10a2a9dabf628e6072",
-            "0x4a969b43083ef44d64237cc66070582e9a1beac7ecf4ebe5400c5f75e2ca0176e4a5a5ae128cc5f72d28f223c9821fe953028dc666fd0765180e05b8190dad85"
+            "0xc1792412bef8865cfca893b987ea6fde882a06870436663c2f479e7926f46d3465fbfec336948136ae1e7cfdcafd0bfc10fe7e0b1779aa80b0d1f672d9bfcb75",
+            "0x2277f0f971e5c85a13fba299f05d3112335eb9357812e18bcb9e691a60f258d2eb431474ce54171dd625bba6de09f1390347e00d1c85428d47fb22865675a357",
+            "0x284f89c07a918c89130389ff5960462b37bbc6e526aaf563851b29368f6553d2f0179b9d4cbc07602794cbc7f15eb4b0c2e9eb7b8cd5dc6547f1574e9cf93c36",
+            "0x772f2be8d5ea4365d1e2b8f1c1c538180b6a2f3511de8e2bd88b30792ca5314e809c8de8f60c8afccadff59a57fb56d830b02756eb249166d8891381716d6225",
+            "0xb6b612916849fe986f0e3a6ee6ad81168804f62308413c519f952126d210c7a77f64208d37665f0bb2e68cdd98b0181608c2fae71a3f024f373251ce40b36ec5",
+            "0x21758a098db5e08a1daeb2c862a135552a2127b9435795aebe31ee6f343535452028a0139b7e86e7bc10215c4d5e5172e0bb125893bad151f35d8b64c9141b27",
+            "0x7d85aa3c3f739b6d4bc5571ee5ae167283ee9f22acd8b739e7deb0e65b2f9152051b78ca1e22598d4344e87a385ac209bc0f6587105aa74bfbb08a84fba81863",
+            "0xcd25e829da71798c86a58efb6cdcbfa784cca31c346b5cb7891ea7206a2ff0a180c93d7056544ee19e1a89f4a5856f63bc00acff05b8b38d141548ec3d0e932e",
+            "0xf03fb3e53a01cad993c80aa9d9c658e4583b36d06a2f57b25934d1081ed118c0462ce26c84f85bdf87576ba9b3f1190436e866f29da2ab96d547e3684d65f51c",
+            "0xee6cfb6273d26e46195af8032ad19ffa4cdabe8652329ace8c5df089670f69d02a8502ce5501f193d9cb44e0f2a8988bd5ef3dedacc13b188c4da2337767a56f",
+            "0xb7874235aceff320cf372a085aebcdbe1500206e394946f51d513e68f9fde6adf567af46a2d731736cf12ea0301fd88f323bc49258c0dec4f7a3b18b9abf9e35",
+            "0x400fbaf6747624cd4cd42aae161a16e561ded71056be7b58247f27e13bf3a7c1c834ec50dda24c8a654ff8887d6b235c7db5f70e583c1d5585f1d91ed756a379",
+            "0x1745ebf63b2955a6a3523140b636021d51b64ae4c2310121cf540b75d7206cc2743e207314de3f6c943f114624209dcaacce85307e81ce9670b59cf42371dfd7",
+            "0xf49beb258dcbe1b6adf178b9e74bad4dd04cd1f9d49fe68685638754733a283a9d98f49c77f664e717f238584fa3c42c17f21d3a26bd6c9e93381465fd7d234c",
+            "0x009cde64833a9c190d338fdd2d3f1f843d9c786c34d82290570b4f04f30a9174d58689f9289d35740610eb94cf8bd89b09a044fb48e4197c08f316b572878935"
         ]
     },
     {
         "header": {
-            "prev_block": "0x81ad16eb5a279a2db939b17b97240c39bcbeccad6618020606f2e0d5924b402c346102242071b9ff740de83b78abc2a58f96ba02186f875c84e3e4934b134aa1",
+            "prev_block": "0x9d47b35e22c1e43dfe7ba1cb09f71c985c3b14da04e8617e8086587ba024b0d444c33229d47135bfd9a38d5d6aef343825d31e456acd0a470f3bea9e4f5f16f1",
             "height": "4",
-            "merkle_root": "0xc9e08c176879d73053cfb881cda48cc55b7ee9504cf187bd7f1db4000c97b25da79ea8570121a0486bc864c191c666eb18cc1b54f000eb9dc207b2fcf0c5a499",
+            "merkle_root": "0x17fb1275e75c7a353a76f933a0f4407bd8d4f1f889499f0f456966d710bce3d4395aa1cbbb5d8250a0c4421e12f20440e6f1d0dc2394a177be88ce06286e228d",
             "validators": "[252]",
             "signature": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
             "enrollments": [],
@@ -884,18 +896,18 @@
         },
         "txs": [
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0x182e24e599dca5bb055d120eb0f663bd8413d4afe3217ec7d728f40695345ae1839b38ca3d285d0436c950f3571ef59f5d3aaf11116407dc23edea590ff020ee",
+                        "utxo": "0x14a47a5bf3d4c4313b6d90af89cf73b6d2879f03345623c11fd709989e51731aa11197b5f92115194e7f1f79ecfae61ea83501d14bf3bf4f6d712dd32b6e95d0",
                         "unlock": {
-                            "bytes": "fOTHpJWJ+RyG9aK7P+Bn6oS0rwsl3kfhz12v4phPiQCKiT2k/jr/xK2tstV2Yew9Y6tmO+XOol++ZnQ2oyo46Q=="
+                            "bytes": "dBYQLTo6UVF3GiZGJfLXAyb+xHpA3wBH++qS1bzPIA4Bt8Hz/B3KfLmOG/ugsPpE65EZy1WLUKjSDZpzDC/RSQ=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -909,18 +921,18 @@
                 "lock_height": "0"
             },
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0x5844a1b49d2061e603c4d7311cd0f93dbbf383a0352e83a7554659f9fb28beeba5dc85adbe7cb2fbbf8f6a92112b7a57afa653e4b65316973095a03657c28051",
+                        "utxo": "0xca53f4eccff25f4a6bf586b4e37085dbfbe6d02a05c17173588bae6a66cb3a10e2ebb9fb4223f37f1b65d478d1e597c560a532fb0effc9a488827f9e8e795831",
                         "unlock": {
-                            "bytes": "n1Ri/uDZBVBlAvew6Cpv/7evX51RxzGapSyS5uTiEQxF0DdtUjIErDQBGaROIBVvT9DSC7YnY3u7kbIQp8QJwg=="
+                            "bytes": "gu70t4chUNVfoV0IrpVngm07vhctGAotPE+uuf60aAoVhLJqgOE5HnNXLobUu7sPjARNyEflQJIdEJDtIYOsng=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -934,18 +946,18 @@
                 "lock_height": "0"
             },
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0xc71dbaedc17c3affb2294692b3447e733b90b4156773c37dacdc42fffa6c98042d0b0d504f499e27b4c313a7493b6dbbb686088200f54c4f8f9880ecf0da1ec0",
+                        "utxo": "0xc770684c17ed65877a942e60644dcd2bd4469f6898e0361184db5f05795313b41fe3b6ecb331336f715f328b604a824584210e95aa28f0cf4ecba1678fa8027e",
                         "unlock": {
-                            "bytes": "nOwNRkyuRckqNdAE0J8jUByfPathhlTZD82v0a4IHgPHzz+Fs9ZKWiroapE+6Rj9TQzqh4tUFzvBw97ujjFDqw=="
+                            "bytes": "CLJCYbyqNW1tlmZRd9UxgysYdyhuWeNrZTyfuLaG7g/l2tsP/avgWRQye2hBh1LewUKdfGXZDtZTTkHSZxeMcg=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -959,18 +971,18 @@
                 "lock_height": "0"
             },
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0xb3116985b3330af98986987439decceed63c99e97bd03dfee3046bc95bdfd360477b3777e21a3d2900c45eca16a198307319b556e461c72f87a5e55d8c383ef1",
+                        "utxo": "0x26745786615f86065a3327ead851821d43da9a1ebe33a75ab583fbce66e1beb417c2f922e6013f86f5de6fbe0285d2b9920be8d4f1402c28332de2e72e1d8e5a",
                         "unlock": {
-                            "bytes": "AjZGuSJBbAzGWlvkGEef4ulnpJIOiO2jnpYnvzmySADQswI/XdTmOxcActbmNvE85BWceNl93rFNHNbwOqD2Xg=="
+                            "bytes": "7HS0d98i2WPlkUwh0lRwSoQYSVae1MTzymSe0frauAoZ0KxzyQMDvk5EDG9COzKYFB26bcGB4iz/bNGHIzGd7A=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -984,18 +996,18 @@
                 "lock_height": "0"
             },
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0x7a358eb78cbb1911e18444620d210acbc3ae08d891cfe8940a3df0e5527facfd30fe58d7f878c8b723fa9a01e75c7d40a1e36b245b81b93f61831c666bf59272",
+                        "utxo": "0xf55a3d8c3a3709c51a243854b2e1b4d95d0ecf0d3037cc81d98c9931926cce87535b590b1d309e7ee39ebee90e66eeeca7d213c7882ff8756478f4d5f7adcfa1",
                         "unlock": {
-                            "bytes": "HF8AFAJTkWKZ65ql4j3gDtLLsMlV3yAmBvMFjHLb7gHpiSlZtbJdGNePJMfdMJQfYOC25oztTZbirLwaT5eWAw=="
+                            "bytes": "W7QKJc7Y2L3SGZPyN80H8lFATH/UcEm1yi5TvpGFzwak2wVDkKf0yYZx9qruHkdaRzQ8gIiCxjNyJx0Q4qv5GQ=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -1009,18 +1021,18 @@
                 "lock_height": "0"
             },
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0x465a7bf41d691ea8ce4cea45e3a6cc906e9e50556952b09c6a2bd83860f0d616cf34d9cb27c8ff3f3c70f77ed37a92f72232d7a1d9e3725e4bf1e9f01d51fceb",
+                        "utxo": "0x614cf2ea0874889e4cdcc304f7ad9674fe49cd0f21a8040d623f9dca9fbd3375d64192621fcb49be757401efa84f9d1c6beb7ebe7944c55097e1865a5ca2cc9b",
                         "unlock": {
-                            "bytes": "cPM9UCmBSLVexabFwHjexM3AUT8BB6qW1XC8IYrwnQ3W+mLS39O0MXvCDNpciBzk1AG/+LRmkpxFEjRaYRrZ9g=="
+                            "bytes": "muJEZaWseo2F3eezO/WM0ezCF7ywpL/xD+Mo65YGLQaHR5NtUYt7IsYM52gPKZ3dCK9xpvTsByIUv8syMncaig=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -1034,18 +1046,18 @@
                 "lock_height": "0"
             },
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0xee5be83a6bf747c3d38242add39ed81382ec3484f3792efcab90352e97e9f9ab22d7b450be815bbfd0322e493ed98d23eef3b3ac93819c5168bb5d657b7b03ea",
+                        "utxo": "0x047f99e01a21bf561a1883ee47d107b2ea4c4f710f07b3fe4bb82ef6633a796fe2f141ce96beae4159efdbc4d20f0c194d54b1e5d93fa6438bc218c4747badc8",
                         "unlock": {
-                            "bytes": "TizCbH4N26UzZv1bX789rEF/cpCXZJKmPWF7IDSwhwX2zSFnPUjji4aixX7dkQ8hna/X3cO86xKwXI8aGWkF0g=="
+                            "bytes": "D+IVBZgvYKdXpWQtMU2xAxy20J2WYHcTUJybvZDSSwREfontk1gc53dmbdr3NW/WeAlSM9lX4IU5hGbaHVIWBQ=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -1059,18 +1071,18 @@
                 "lock_height": "0"
             },
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0x58293b1a768e7df2ae91967e02debe7fa0bb0bcf89180ae6787a636e3114f44c7cee9b7d5da10a7e5a975a4e31b21305882f3ffd02738b3ce78cb4cdbf91ab3d",
+                        "utxo": "0x50be030556c60ccf48c8a215757d726ed956487bf898de36cbe57c483394814b874f3714f5235afd58c4f9f3db99cc110ebe6a8bb8a28c7d00380445ceadb07f",
                         "unlock": {
-                            "bytes": "6HUa5Y9Ia5MdeVPzouOHvcbLS2c47LlHtxNgtwMkjAFfD8QPHNI/SYixvn3qY77MIHQ0ZAQJ1sAU4TOZCVFG9A=="
+                            "bytes": "RWQ7Q6+IFFGhzAwoIZTCqZqMvwbHkUuu+HPl2fKaSgYNHSVihDtTIs3F/v+4apqJlC6zsjn1IdVO9UgzWgT/Kw=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -1085,28 +1097,28 @@
             }
         ],
         "merkle_tree": [
-            "0x21ba4e08ae57dea51a5f83e0c72b14790542e8f4f3202df487e7cf17be5e7b5604fc3beac4b332b8c75a255dc00ed754c7fe76884787e57f59c14bf6475d06fc",
-            "0x3bf75898e3eb838ba3a0a744ceb0aa7ca86802b4708be569e533521c319a781d7fa9da8d06695cf6742ec7d41a13fb9e5ad1195efca2bd504339c71c27420c6b",
-            "0x0f00b7e6ea88aa7539a77ceca4c987df99e26ddcd0be8dc457bd8f08ee62c8a738774981f201dea057ffae61f153df7d380dbf1cbd9b076866ff063b2efcfa5e",
-            "0x9c62df8db5713950dfddc5a99b59461f775f6057458cce2eae212671e941ed9a56b4a8c83e953621dd42d529588200887c04629c8c48be2b6f4ccf2a0835fb87",
-            "0xa289633121280fb2b7416f37e803a1f22e7c77c02cf7e63668cba00c3aa29edebfc5808a717ece3bea5c0a5ef361cfdc2bfabc5a3ea7d263e23199e830a3f071",
-            "0xe28d1f2b4d1e40a0e92cbc511055ba5ba0b8210c1c7438cdf49c0e9ebd2f330b8800c3cd930c5f60e5f7c68bdb1665006168d3325e66f4a38dbd1e9db6f8f1c6",
-            "0x14e16bd2370c75fdec64cc118617331e32221c49fb56f27f93faa76c26370ca013deba2483d220a6477d4829fae621d02729d09c446f4891104108e18fe71f88",
-            "0x872d97d0d55120c3ae525343d2d43651e36763ba4a76ec8e7f668c50d9d7921633c20d4996d226b02848e08e35f8a2b8cbecf40b5a4274bd5712b56d0841119f",
-            "0x5861127f27c5b857886faa513d8a6311a1b94efa30f0c3c87844598d0321d3b5403efe415f9e62c5aba54eda70b3794d87ee39ee82e5e76cb9e13642d9ec07b4",
-            "0xba5ce4462df3ce3e724e6b343bda31e3be70b5322fa366578e89a49f35d96a6e10842244947eb22c6ef4df2a2dfdfa3692dd529434d3cf1ba920076243716823",
-            "0x94dfb4cf500dc2dbbb99d14982838d2792a3e7274de0d0a8e5ef2870842f792eab80a4c204cd4b403608dd0ae78ba3d69fc3b5d54268233e5d13ecbc64dfeb99",
-            "0xfd46c5bb719fdc20816df93b40e443235a822a9c43336f7200ebeefae48426ab5ad9672b3416ebaaf36fb20b96b3e5900adbb5a4d66f76ee9c6b5e291f0f8f7e",
-            "0x0db12df53079e17de63c51e7e57db232da63aa18191522a6e21a83e0df08cd96a78d288fb4f06a2984079582985a51aae3a195ee81994bce1fbb7e764c7833d7",
-            "0x1a4ee927bb57e3ade90319d5178a91673bd7b830ead40256eade9dc09c8dd68998dd83bd19ab1e08fa95ddd73477ffb1ee093702e484880d65a3edec7fb636ac",
-            "0xc9e08c176879d73053cfb881cda48cc55b7ee9504cf187bd7f1db4000c97b25da79ea8570121a0486bc864c191c666eb18cc1b54f000eb9dc207b2fcf0c5a499"
+            "0x63cf89225ff90bc3a9f9de85d496c1d15d07f9b05025576ec68401948a3d5079d2cae6e017a073682763c8fb7bf70f3a7c4450a84ca0c6c8033a8823f48215aa",
+            "0xa23f031e89c730ad61966051b5f7c3feebfa4d8a60904730b79bcaa3706dc4f17c573abbbeb2b68cf920658f9e39aba52cace69fca614f78c117ccf0a7650bf6",
+            "0x0cca2f010a8141175c2383586318866b0e330385dd199e737d59bbb00876e67572986ec8bcf7d5f1a14470e9e50aa1f7b9477cb63146ee4aab6e9b8a48fe0f0d",
+            "0xe791163e10aa5396d61220de90ea9838bb898593bc6d1e1e471c3258e6d52ca8ba7a8b79bb2e5e2d58fcd92c26f9ae1b90daca44b0a10b9966dcbbfcee697c54",
+            "0xe1201a56eb8bd425d587eb5d542c7b92dad712b264043bf5374584a429123cff863a5ac4ffdcda26d750c49e0da1fb50bde4609a0d2db1b390dfb961bf8e03ae",
+            "0xf3a30c083c45e7bf53fe66ce3d02e4745552eff4f0441cec84610e01e06bb1f79510d9beef6b61918bfdb2dd1ae6aee6b52000fa27a7897e4650db206a30e989",
+            "0x9bebf50a11ca2b3c221a1f77935abffe1a4895f9b1581f82ede47193d8d739b429d90d00d1849f9f03f6c8b4590ab058dc979e69d4441c60e9901757e8756caf",
+            "0x558b3861f2b813fc00234e788d31cf534cb942509ed9da32ba2e356a890f0d0632e507fd4ec064124c01c90ba34e96b9660abb22a2820edaaa2cb0a34ef79403",
+            "0x4c686fdcf6a41e43bb10215f54de8736c44eec05533effd9f961d40f482dd56875f28a413676281969a07219ed8f80834055d6b8883b5efce32bd442ef13bce5",
+            "0x1b32f693a172ab3721f5bf418833ec8cb7229ad4dbe7375280cc99c22a7c8fcc1823c048b07ada34a7eb0dfa3d201a4f245ca750c29d0db5744df32735ab4ad4",
+            "0x6784ba4bfe99576be9c193a0c1e1b0a4fe611c131c2642c1d9bf2dcb03b5f656b384645b97cecd897256532f4a58ee05e1dc4a81ddf73ec8c20af694591aec66",
+            "0xd7e1fe45674776a9aa12bca909b479857953be02407c3f421e3884936f9f3f2451f38b61be4a8f346fb330bc44a34fbc2cdd6e21008df4187e33935c29f69a75",
+            "0x988f4df3cbb324323407dc5a792d8d8f9341b8e786d5f9fa40ad9bd9bccad7ead22bb4f6703f9b0b5fc327a5cc941a9435d7322b7653eb521340af330825ddf9",
+            "0x969c92ea7a28e19883eb8212d467d61a29c2e25714a9b24d9a3d0d8b7502c3c7a0f0cbeeda49030ea6423d1f928e01e46d3780f969d35cb705410a4167b74dbe",
+            "0x17fb1275e75c7a353a76f933a0f4407bd8d4f1f889499f0f456966d710bce3d4395aa1cbbb5d8250a0c4421e12f20440e6f1d0dc2394a177be88ce06286e228d"
         ]
     },
     {
         "header": {
-            "prev_block": "0xe3e9a88bc7a85c2f8d1db9f8914ab25c2515b8ef5e01c4109dd76f72e4bccc2cf5abb5f738f5f77f5da42f4a9f45877efe9c627eaab8f586ce78fc372bcdbbe1",
+            "prev_block": "0xca0e460cc88d9f5c7b4708f44e76ab9b383d7add79eb0d90c9b2fcd8d3c26cde7f2c9d9bb7d475245ef0d3708eb98db2faaaf32774ff6f02a75102da24dc599f",
             "height": "5",
-            "merkle_root": "0xe4822886f6855a20d52d199add649885f720e45b630a2bb1b0d9887d00da404659a35315ecc56fc98dfccf431a0dda3423afc0f60c5c066ba39488b1f1c75910",
+            "merkle_root": "0x9ecc4f91e7b11e3595e0b49d64837703c1cb7cc946a0d407f5b8ed0c2074cf943aeec4afd5976f7ff195b0bd301b5f35808f8c235ec1788803556f42cc372765",
             "validators": "[252]",
             "signature": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
             "enrollments": [],
@@ -1116,18 +1128,18 @@
         },
         "txs": [
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0xdcbaa667a194306d557e855f543a978b8a2e6863eec505404038d3b510ba4e8b61bd870782c36265e6c60ebf7a5a94502f3cfd8a3030dcccf94231211e3db9b8",
+                        "utxo": "0xe13244dcb3239e5269d8bbf14dad1fcc342d94137b916c8943d549353fe30548cb821f264fa5f5d231cd94615a140e1b719d21e9a7b5ae85a5dda371f70b47a5",
                         "unlock": {
-                            "bytes": "Gb+DuAfdg94aVRvkrTQb+3Mt6pKp6yRNV0iU8/e7ZQvsAv2vNdIp6QHqrLBtjwtkkki0W9libHzQQgoz6AYcfQ=="
+                            "bytes": "zRe85rbZ/Zc3VdgRVpb0vRC35U6u2QuIHY1jmBI4ego0h6rexWUl3BzMVjMFvr7otyL0UkmST7acVlNUoD4zmQ=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -1141,18 +1153,18 @@
                 "lock_height": "0"
             },
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0x2c02b5351aa12db8e00f5c88a204e8f8d8d0dde6f6d730228708395ec3598d9d143c8f9ece535c38e88f245af71f052d665606e68554917063279ed8a3f759e0",
+                        "utxo": "0x842c057798b2a10486b3f9a9ff8749b73ce45573b6329ef870040660380ba783df33d0bbc39cec2312596145fd9174d53602f2854e4da68147a05685f849325b",
                         "unlock": {
-                            "bytes": "V79V4waN7v+Hrp1Id7p/XQeNCYRrc7CUG4FwkwjLJAdur4IcRXXNLKRjFMofyJEDoBVskRBsmNaDBwMmc+3MAg=="
+                            "bytes": "1fklVN2nQRFiPlG5FIESj9/cYdTVJ5QXyFmPVCLgeQtqcHemwu0Jg/5hPkoRuOb427yv6EpsNbuRVV6roNH4LA=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -1166,18 +1178,18 @@
                 "lock_height": "0"
             },
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0x95f09d6b2d7e1bb2fb7566f958af349725ce09ce973d50306590a35ee953a656bbd79efabc05a24c1a2b4859c597546af066d5936818cf9dfce9b3f100f1fb4b",
+                        "utxo": "0x928bd75263d6215f0b27a51d193afc8876a1a271cffd15191b60228ec3e66599f070cc122f3685d8bf70aebc333e6f29cdb313ff055853d582f21294d1a7b063",
                         "unlock": {
-                            "bytes": "oDZc1ujkHXm3aWw0sAmJcFUWmlYKUrZT22ny+ZfGvALXLgwPk8ZKcwtSIdv/gfANJO5JW3psZEExjB5pAL7kZQ=="
+                            "bytes": "agj8QTnwl3t3RXzLtzNVaKnKAj2N5Crj9CKC5yYm/Q5SoltQ7IensuKC1rTK/Ss0CO9ILRuHpp7vyQZ6g35P5g=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -1191,18 +1203,18 @@
                 "lock_height": "0"
             },
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0xbe1a69b77825ab90ac05b5f1552b542c980362fe945637c1f3acce071c2fff827fe21314e749631465d857615af5b05339ddf764dbbc382bf4d60183eaa11599",
+                        "utxo": "0x21c536105163bb44d37aebff429337a3b73465dfa8646db8cd38f13e48caadd9e209ef1eda9266c68678c417940f3267014ca0d1cc05cb3b4bd33fb54851b851",
                         "unlock": {
-                            "bytes": "ywlljSpe33dsGrwPK3kSoMsPjRAAV8BB3CiCVQRqRgIIfDoIRN2fqST3sopgay6RBhGd8SdGeJBnUG06cRNh5w=="
+                            "bytes": "+Cp7diDTSh3G3pXbC35Y2MUeD0mrBEQc0EyAi93NIw/7wbY+LIJjcFVnc5Jy3oXV8Jmkv+Jk/jpSLK0WUo4j6w=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -1216,18 +1228,18 @@
                 "lock_height": "0"
             },
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0x25e70acae35ce0b4136adf79c071ca8eea5a30650994104746ae6748eba35c1304d2303019f061545836f89aba5f56a3ff06a21340ceee55d177d503b6f613fd",
+                        "utxo": "0x77c3c6273d50de8408f75671350aaf51050bcf9022288c38812330221271727a89f6044ef8b24af4f2eff4faf20c177a032e6f67f680f227f6d014c9cec16ff6",
                         "unlock": {
-                            "bytes": "CZcA/DEy/9bP6qfwkbYwyYSkTLjYrxNIcZRdQFTR7AHNgX3oUlNldqEYEYYHDCKbbz+R00LrmYkkeSXUXr//zA=="
+                            "bytes": "mHv+b951YphYx1crn04rRgd89SykBzvYfC1V6+1ScwFW9aOr6wRx1SiRqdrR09SFDstEhVFR9Xy0YCOePTJ0vg=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -1241,18 +1253,18 @@
                 "lock_height": "0"
             },
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0xa82a8a1ee8470fc4d28536bbce7df70439548153722ff08a0dd6bd29ee179cf64d30bfbadabdcae503ac339c84bfe0c3fbe2f900496ea293e3c1c2e4f99546f1",
+                        "utxo": "0xdfd3b01a7cf2c7928fe2f23bbe99cfaa6f54f4d03e6d20280421e0fb277f0033995307af3fa25de9c39b9b35bb981417fa0662de061bf55efca1bc16a0b834e0",
                         "unlock": {
-                            "bytes": "dmafnDi2BU6rDFNYKbxpT01cSSzEv5kHJHVFwPVDXwDhPkuYqva53ytmOJUwdxAw6tNsRZ6Vt+wRyB44HBooRg=="
+                            "bytes": "F60/cyzFrwt0mw4FN5Bxu1+3iCP27UBrpRyXnyKdUgHyKss3nUs87zZcde02c6j1kLVV2kX5d8sfvkUjIbMUBA=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -1266,18 +1278,18 @@
                 "lock_height": "0"
             },
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0x105089fc7be646cdc4bf03169dff24fc9d346caf2b94cd69652e36e553dc603eec1041f83dde3b5bf7f9d39b7e29cb37ac13ccf19d023c6b6192b3e323041ff7",
+                        "utxo": "0x2fdc90428217487c412fb27841bd60f6cba82afeaf654b5b0a64a364ea649f373d719b30e8932edb822e06b4151834b68a363f94b7914b1e750a9cb305ddafcf",
                         "unlock": {
-                            "bytes": "D01HVzLPEA9PnC+P8/51fuHsmi9Q7bGR3brs5fxj1gfpxZPH5WaReflyIWvFpgMMt5j5USWGgSo+R983RCq+GA=="
+                            "bytes": "5nQxHsd2neATzNGMJbFdaTI5/ClQFE2KbRe8v68YjgQ5VVkSnhTFjXJERN0ruyByDM8YgnsgIN2IDfYPwYCRgg=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -1291,18 +1303,18 @@
                 "lock_height": "0"
             },
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0xab1550a87811ed0563e648c6acfb69ffd5993038e5cc0475203f6861876978e5d1766aef33984c93ffa7a57627f26f5555ab2e5c7f9c7b9706d03cd8f42e5470",
+                        "utxo": "0xfa0bc972ede527b33b869e7fe1693a104dc4d0027ac646a6f923f37a2a8ee13c31ef8e5a0431dfa8ba12f4e98d851bd7460ee666bf76ba14591299cc4325a0f1",
                         "unlock": {
-                            "bytes": "NI0UJm+uPXSHQlp/FDInawWztvjFr6PjV4BxgR8uXgK1xlrbKwuRwOLw+lfCflTcVR3zhck71E9lPzUr5jnh8Q=="
+                            "bytes": "J+DKMC991WVI1+ESGwtVIIYhId0hu++twoHZHjRv/As/1sFp9c/XQ8ibhSPzwqngIf28e9fS6mpQKR1dAj7zUw=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -1317,28 +1329,28 @@
             }
         ],
         "merkle_tree": [
-            "0x46b9fc123d48dc043fe9df9ec9d32702bfff597c1e4437d3a435b13c42174a220666467576e3808c3323883dee1a637bd8e32a6d680ef101cc133cbefda67fc4",
-            "0x946336ee2890c3e7d2be09bf95fda4a94cd5fa23914b657ec14a449dc11511f85822d66f227b33dc4d083878eea6bc5ff9e122a3f3ae97cfacfdd2618d1e5c60",
-            "0xec5c7f716d235118cc1f26303735567c90417dc28c142d48ccd083830aa623a38c3710e5dfc54570bea4886fd2de6a05d2896ed2fa99549cd2a464f38793f1d0",
-            "0xc20dd8a2821ce19f0ae88e42a61318075a56007e4b5a43c093909a924c0925ddbc847d03d271876518d357571e2036915b280e03a7d2f57c4a3f307ca522af68",
-            "0xf664eabb5d7c822a7556c7d38c365aa8bf24b7a532daffc2b3cb98640bc6ea599a969e9b41b195799d0e4f42269cd7979a72cb372c9ddad8bf67903395a128ef",
-            "0x618ca526e8ab25ed27230ee8db857e4b30626cf36789525abba8f36ec2129afee997945024b06f8c5190a3b0277938d9e53e8492aafef8eeb616945c8d5e872b",
-            "0x5e442c9ac58332fabb2d7a29c8c162c2743915dca5df91b43c9ca66fe4cc02148e3ecd9c8e82cf76ade89676f94df90efd5d8e0321ce7630c7ad4937df0da66e",
-            "0x81f088c850dc9ea7d01077f74e563f682e4467fe31db1422e0fa1f70eb92347877168096b42bd66ee7732738da9b9f0a7b32edae659c84b11cb9bdba8bc4ae8d",
-            "0xa92016681a77d6c959c6dfbf450f42e2c61fcf13289cb13f5cbf356bfd64580571d12f6109d6940c72275fdbf4601e872d0082f327f4a8fa56ef43452d816015",
-            "0x0f87971364b76a9e2b670a3df97ee7c0656570c73cf0e17eee500ebc143eb9ac1cf64dd2ea39821658935c9ebc940a918ba02a04ace8c600f5ba40b50c255b44",
-            "0x9fea32ee08c04805b597c01dfea1e0780de025e70bbfcc195ce53a35b947b4f4130e4cb3d58b0601dd0d0f7d2929a2b90ed8c72baa85fbc5bae33d7e1bfdcb52",
-            "0x2be87348b257fba05380512786a17d2d13072322be9d0c1acde37b4b79efdca1c02785f024aecd8958678b452e9ba6b9d36b540a0b61eb80a5b3209485319121",
-            "0x006246fa9b1424aeb4ce0d7ebe4a5d9c507f4609a315325b7e8b2669c10993d836f83c0d31a97dbcfd27dd1239dffa47dfd57f9c6df434663c561e7cf9daab5f",
-            "0x42a6194a77c03a8897bf7725dc529ffeef95ec60048f23faeb2d4e5d5e2d9f471351b996a4bae069d89b7918b2bfc7d1d8d8794c39ae3d795f1c6229f88f2a7c",
-            "0xe4822886f6855a20d52d199add649885f720e45b630a2bb1b0d9887d00da404659a35315ecc56fc98dfccf431a0dda3423afc0f60c5c066ba39488b1f1c75910"
+            "0xbdbd41c275b4d99f3ba07dd8cae34228ba8397b3c6ea2155027aa1122066e34ee8334425ac04bf94962f2d8b94a802db1ff834d8a6c7389a38163b877bd59578",
+            "0xb4488005833fa9ec7fccfec0ac66ab78c10dbdaa6f25fdd65fdf2ceca90e48c95befe1e6a00de9cbf86df2f71a4788af9edf79b3205ec4ea821e73a28375c15a",
+            "0x00a43cc343bd63bc14bc1c34056144ce2114bc6c6b7a8ea0ef455a3f07a0ebba6dc3310619dd395166c75de1c692d332004b8978542f7128044dd811f14e3c76",
+            "0x23657550d6378e5b58a392eb903483b91c9f5d3c266e333b62bf843257b593bc5739602298cda12cb160b788eed4afc840f39ee515cecc19b220545f6e8aeba7",
+            "0x2dd9f34f326b257c791a2e5e185e3147a01ab85897d0ae9dd8cf396f5787e797b40bf8570ab29274ca63ce4b33216b1e9339dbad002e66c02a852fb7fdbab6cf",
+            "0x58c8e5f27ab665b07ed17cfad19c21190d038392ef56b384a98934470c9b2c88de65bef100e0ce6b50c2b9289b0c6bf033426b7aa3f32946477e97afb78b1180",
+            "0x4d1d395d29db12694256ad5434d6c4bd7c6d49d39a73575266a79d0ca1eeff5c08c227b8ee323b42e6970354917ef03dd9cefff7d033a5be71bac91a5e27e58a",
+            "0xa90c8ba61591aa67d1c46e4d12c1222792e9ce81b8d28261813ce56cc7ec73b02e99df4b3824d5d0af88cdd30e83ca41f1957862266d959ba2461f26a970f23a",
+            "0x9084111c501791e783eccef1af3dd97418a76eab2d9bd350c4c731b5947a744efed5ef8a031958cb6d1996134639606664547514100979b3aad60d905e8ebe6f",
+            "0xacd8b34cd2b161dd94d3a3e4731668041aae4e41523f013e407beca65f9174860e3f3880f7e07360db78ae98579bb8071feadda4a000e7d244839670d3676f33",
+            "0xb3f3bb32e2552c92361f89ebbbbf0e7fc4c8e6312179f8b16a1a76c684a42f81515bb45d227618e1c08034587f1ba33a2fdf60879787b54e908935290a7a0bce",
+            "0x347b4aa5f5df986cb47d4077510b335ada6e53ddc295764d7a8422c6273002c5334c9590b7815e304596d557acda868325ec2ac171559ef064214aa2cd4c40df",
+            "0xe288d7aa729f5f98c4fb4b5e6b2bb3906722ce49e9b70fdc7b6a19cf1f8147fdf8575659ff9259f8c373a3e73d5c61ddb41bc2f4c38ee6cc0147d3f5c0bf86d4",
+            "0x3653529e5e418b379b24897605689a699ee7c9ab9224283421bff90a7633a8709fddfaf052ae62d5284f78b25ed1d829e856f6f8d0c705632cee3cb293f075e0",
+            "0x9ecc4f91e7b11e3595e0b49d64837703c1cb7cc946a0d407f5b8ed0c2074cf943aeec4afd5976f7ff195b0bd301b5f35808f8c235ec1788803556f42cc372765"
         ]
     },
     {
         "header": {
-            "prev_block": "0x57b89a0c38282f3a63c6e74ff32e7817dbf195f23453507ca967d83edd54303a87a9156489931835ff13152f5f1941c551d261324cb9de49c24ed428a9ebc310",
+            "prev_block": "0x038a0f9b11ab9167509263e33833f90113634c82a2e9c3404051d79cb2a82af7f3a3a17e8ef0510554677ec3821e334af7b65bfe13b4bd1e3fd19191cbc4758e",
             "height": "6",
-            "merkle_root": "0xbccb4b24d481a24a7bde53e70a61e2701388e4b017cae33f83a650b52329b1c278305447b7bc81f025329ca33da414b3e3b5f115ec99ee4263c419e6ad4cffdf",
+            "merkle_root": "0x5f2742233d188b0eff3a945c196525a0693cf961d462f74edda46b5391375f5b9300133e127671e898ac570aeae543a5b8a0a124d0a132e7fe6675b42c3d737c",
             "validators": "[252]",
             "signature": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
             "enrollments": [],
@@ -1348,18 +1360,18 @@
         },
         "txs": [
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0x6a258e67708332205c1dfc709e43638d442923874c720e740ee78a1a5defe9b1e2cd02295bb6aedbf5511fc1a239e9fed774e96c29f52532dc719b2902b7dea4",
+                        "utxo": "0x6f797dccdfbd57ef10c9671ba2a695171d4234b4960c7efe4798e295b23c8ed7f9c0eb79c20008784ae742a6db01f320dc49db76c54a31dae411a56b11eb44f6",
                         "unlock": {
-                            "bytes": "eNVs+lpcntzT6uAKWcSAzUQi0AX+H/65r4dDpV+wWQw5LqvYQq7slpvDXLHjoa2ovGm5HuUhnM8FaCPOkk946w=="
+                            "bytes": "NGoTlLFMIEzOosY2JCjE43C8E0Y5bcYRtYPODi9T+gHmiY+3SPevKJkDb2Q+k3mdIFErgq0XRc7J9Ss7udopew=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -1373,18 +1385,18 @@
                 "lock_height": "0"
             },
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0x1066661f53b4f9a8ef121743b5e5390b3d92e3b771667b73544cb83ffaadffac11ca5863912e7a5ed65fe59ff880355d64bbadaebf6100f6aa80645162833549",
+                        "utxo": "0xc3ae6c0138c3ea7e713b0cd48306d89ded5c5af190750d5c713678b20bd12728b76aeef4fc19f6c90b52882d62f5f277f666e472e173f26fef2220346e3a9ee7",
                         "unlock": {
-                            "bytes": "iClv7wOjZ29FrlcxtP717PAX39r5edy6xV+4HVihBALH0OIQO7hehiiGbFfpTrMraqbssxl344r4JmUXwOGu7A=="
+                            "bytes": "QucyF2OQA5FkWqxmsX9M1YY7M3eqzeTNHt/5iZcMwgRqEqza21z4rK2thKudteUEGYa0QbWMWaese8j8JLXXgg=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -1398,18 +1410,18 @@
                 "lock_height": "0"
             },
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0xf7c107492ce52114206b4c04dd5a11b1d268dff1779eb24114121149e5e199c5622a67cb3cbb788f2e75af5df15f3e6cc12bd2c0f2ad1522492dc5e634deadac",
+                        "utxo": "0xbf0bb6e8876e4c474a37bdb8ecae253db6cd1a2be94b4a97a587671b75d927bf9afdd5065f3203c0757377526db97b7beec351753d42f12d696509c2752c19c7",
                         "unlock": {
-                            "bytes": "C63WwR52FDbztFYIG6HvPSpfSkRffhB8bhhObUOIdQFKBWLRPZ0iy2rtqo8mHPn7Ib7Fw73HKgyN4ocwY65Bdg=="
+                            "bytes": "uE5uaYV38VlrTzi1GSmNszXZeAYKkKHAnQcVWl3zVAKwmI9dvVSg6lQxXUGQ9k6olX81mL2e9IiGtOtWxxzRBQ=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -1423,18 +1435,18 @@
                 "lock_height": "0"
             },
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0x9413cf381a0f8c8439a4b4df460e96689ef20eb336342fd622379cd85422e9a6582ba35e197b99c050f1f294486e3da5f30d6348bcb9238b35ca2e6dfab6ba34",
+                        "utxo": "0xa9fa9f5478b26adfd00d38a5274dca79178fabe70f0cb4fa8495a8793f1af26e6289c772b25df7a3e2ca76596c5e324dbe57a7f6ad1cb27c4c5aca5eca93607d",
                         "unlock": {
-                            "bytes": "mSXEy/jr8/A5xaE267Uwo4+wrNON2S6NLFnXB82/tgYqysSAHVIxVYu3XgX7ZSajFEOk8/0/zPLf78LbOZYFjA=="
+                            "bytes": "oIgL2/mwNpdpFPZwFU4KgAbDFtfWQfakYXlXHEQLfAu5Gg2mLx5jGPUOJKj0QzedVygfWgb0cM9QvB7hvf/xIQ=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -1448,18 +1460,18 @@
                 "lock_height": "0"
             },
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0x8180fcdf666d9ffe9308ac76aa58c9faf87e49726f154f8af82093e184af87f3a3042c0767f7dbb60485871eccea0eaef6637b9c43446352be1d08e6520d4143",
+                        "utxo": "0x60f9b578fec9652f9048e197c4021392bb800c01c9f5603b51b60bedb594a5bf708a38b2622f1d76c1666f420f1c7d50bbbde56d1eb0ecef5c57480f4731d10b",
                         "unlock": {
-                            "bytes": "iZoLbTChye4tPjkmESwg8F2HMlZp/rjIqxwhxhq4xgxA3+WBZCYzWgQC/6aIXncwSmEB30ne/OEP0s7awHzzgA=="
+                            "bytes": "mndFOflCx7Wul/ttyb93RQlk8LYp143z63BOGfR87QIfhBZk6J4SXf0hcDOm4f9Ax1EP0kLBlyCuaFMzaDLxLg=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -1473,18 +1485,18 @@
                 "lock_height": "0"
             },
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0x6b994570f2b02fff28e7a12f7ed606c19f5184754e06e63555bcf270acb085e3fa64e59d97c32966f274351d67916bff521cf2da4da1c4d1cb2c0c45bbd18198",
+                        "utxo": "0x9664919f5fcd5a101f0835cadaf7e6c68caa019ed8a28d4d8999090e83adc305385c2a2d26f63180d0b951a7c98e043d937accf9dd4248a23cf3832dd5e9034e",
                         "unlock": {
-                            "bytes": "N8dDiRvlQr5UewdqDVtFs4sgibpMeYC0uVbAZZRjRQ3zo6lTGZK8OGMQX4iNesX/TOG4qkk8EOZjVdPu624FmQ=="
+                            "bytes": "vK9TWaUT369y+LB6jUPb0xWe91It0ybl/WdaSQweOgRHmJPC9qqwUrq2eto74gaQYw3qVl2nOS+beclNpI64/A=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -1498,18 +1510,18 @@
                 "lock_height": "0"
             },
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0x133c515130e7ab7286455c2a488aba374cab1a118d25b39761d1893f0d4b5171d23a07e3940ba6e3a1605fecb6acabcb879d83369b3f8366ef918767e5a3d18d",
+                        "utxo": "0x8721d7c51641ac8ddf070d3756eaf9f1f2025abef2614349988eedc90cf54cb86527505428f683adbfa47f66f6b826772a05ab55b475d38b8e3a5b516a68006c",
                         "unlock": {
-                            "bytes": "SvMYi1qAPX5tVdv/vY38kuqzhbHFmgYmJUYdC50hQQZMETL/UgFt3vSyP6SUV+Br5FYDB8QrGJt3nCucN/Dx1Q=="
+                            "bytes": "YppXsEJSdQO/wzSrId37APqqNAAe5ujCuXRR1ZO+3gYH+9L2Hl0loY0OTR8K1k7C8J8DyJJrpD/7YbcMZQj10w=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -1523,18 +1535,18 @@
                 "lock_height": "0"
             },
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0x7f128711f90dd8456703911e056f6f59e48c863ce6ea1645430f4e624298372f9d88d3ed467444c53ca090a5d2729bac84548ca0544ccb4491b4bab11f8079f3",
+                        "utxo": "0xe8e85385a8f64bf49fa749aa92d4371a2961b49c14cc4e889ec7fb6834f99375f2b899abd6aef3a7420002f3fdcdc08da6d3949ba97270406ba0d4a3ff5ee0b8",
                         "unlock": {
-                            "bytes": "6dA3krJOq8xCk02l+KxeVB15rKuexV4k1Q+sZ6Dzoga+NVturYP/vbMNqOgjhkR4YRR4aKAzgXgAy9I1x4b/bA=="
+                            "bytes": "3LZQlWAP4YjpvBR3uT6hqvke1Ygnl7Gnlk/XRnJckglNrSDCaG02JX7M4ZZ74y5c3t8OpTYVd8Ft8VqGcP3pQA=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -1549,28 +1561,28 @@
             }
         ],
         "merkle_tree": [
-            "0xf8df7a46bc1a303face3a68f9cc1cf53edad23674f9da88c8b90a4167d5fe070354489769f35b3d7fca53d155937f78d67f9229f6483d9828c37f7c678df2eae",
-            "0xe3b09daa3779cd95a54e49e1be344b611f93c1cd936d0f7bc4c793bf7d524f8eb5184b94dbc1652395d33739a7222016b68f23452ce63838b83eae02c8ffb6cb",
-            "0x882b7bb58629c37e423c46dcce9fcc70e714ef79741766f161ece5bd189a031329b9d41905cb7bcfcd828bb4a492cd5d292d1c26df55ec19c84ac094a460d440",
-            "0x3f6a5cc159e0d255d16ba04c36da3730c0a938a59fada4ef783b19d7d9f30181de7a8755346cddec73351b7707dbd6a2f6641b6f9ff079dd4e7d026faac623d7",
-            "0xacc84b9448cc41543c118d8702cda2422fb5fc530c25260dc2090cec4ca7d2063f9c9d146e5597a36ebb819ff3aa7ea98ef5cdf614e7339ec0f0a127c9c271f1",
-            "0x53aef1158a6beb944497e902952f4d091a40dc178f00cdd35df425f2a24ab3dc687df41487a5f11694d1ef27d0be73209fa32a72a8938ef2e54a20fdaceade20",
-            "0x881621ced2978b9747ea6c69b6c0f92236f8fe831ca9ed0c353ee10b45d3c8e66bb72a46387a9c0c5ba674d7fe003e06a1c6ef270f80b893fed7076188151725",
-            "0x7d181c174201eb27bd593501353e2bec4efa7e35c75f67837a6711360a42aefa43a7a800ac954f13f39d2f5bd1eb3db2eda7734906355be2ec58b24f78d9edad",
-            "0xb20b0327d4cd2bd8546b8c92307b82e016d7361935490db06fefe8c101addc92abab17dd483f7b3a18059bcb4da416f0db06c784131dec37212a34a466e43444",
-            "0x90abd453b61a5d23c78548262362ba5027c27c638cfff5eb845490fcbf6e1058877c5d31262925e5c2d6f93381b03e06e73db21e49f2a83ea23f9dfa1b32bcff",
-            "0x89334f6136f83425b74dc147a4a989c82ab300c9ed0555ea817acc40f598c6f651f9d5b200f46cb4126abb6c7e1ee70f78df6762cb3d81ab2dc5b3fabb5dc67f",
-            "0x70f07902b58c5691a177e71ac4c85cd20602ee576c0c5c71de91d83ba796849ec999996ca1d0cfef9c14e0086aa8dae22e99c07497eff0e324b65a86b34ec4f5",
-            "0x524ca9b1c068b5413b575f7fe57686717bc729c9dcd6b4298403c6a061aef0844a539de13ce10c11f33bdca35560c6f5a2a1e46f43e97a5f3373dc94c7a5dde3",
-            "0x96356e7d00074517c40636de83faeeda4ffd863dfc7f4211f165370f4abfb2aae8ebf67763d0b9899a225a15e6501fb6a52eed5b9365cf1ecd6280e0b5752796",
-            "0xbccb4b24d481a24a7bde53e70a61e2701388e4b017cae33f83a650b52329b1c278305447b7bc81f025329ca33da414b3e3b5f115ec99ee4263c419e6ad4cffdf"
+            "0xf9ea89b0095ce271ecff665f516625527aae209caaeb3db9219baf989e3252abe9712dff8266a021c2694e6c1e15a07ce4daff42a73ffb8909ded5ca95f79c60",
+            "0xaa2b4ede829150bc4014b0c26ebe368a220bef48461c74ef77c16e6b729e1b61e814436753f03435a6d78638407d5c2128bfe64be9878527d8d4a2dbb65613ac",
+            "0x71cd6fe11ee186a5bd162421570472af61a64cf103ced227950324ab31ba91d53ca6881dda85e6e3579f3ba1396e8f1ee115f240cad1f2ae9d9822db9ab5c3a3",
+            "0x76864ff17d3502ffa5348ecaf830d5d6cda18d7f83f0b656a5d03bc7c096245f7805f56740c09c88c6178a57aada9802dc240ab31b7a3eb5fbdd9420e8d72ff6",
+            "0xfa9dfc24bdeb573d387a785e7f60f15bc4c7af1bba2f7a201af2972008544e3a73e80eee5901a58d623d6d3e8454fecca12cb299e4a0dca4ec527583b6886308",
+            "0x72451022d69d100632494aad91179b81c37a57b93b6a5416e825c409070a36d9d7af0dabaeadfbe00dfd280c1cad388bcf463e0209e1d4edc334b10c3ec868a1",
+            "0xca0344dc5dae1c16a6ea60a2dd117a17711a8fbc994608138c04a838e80d333f1ec3c09cd3d70c6d4a8f3670e828b5a5581c04bfff5c9b9ce7da18cecdd28a0d",
+            "0x79a0f8c096253422886265d2597b0490926f6cdb902e3c8fc5015502a2688e61261255cea3b811db2d105c7b9a5cb49f87b2944d3fb64953e7dc134dbd74f058",
+            "0x65eff74028f272094abb5a2b0ff5b6a459c34d46904f8b2649822ae4fba1145e33c28850202a5bc52184965e42fd8106e2f6f583a9b45bef4ef1704c0eada2b1",
+            "0xd79f06878e84e60cdcac692677139dd7dc14f78de914ab42e7b24faae5935fef37daaa58b2a3794152df634548b9c1a0b80fb4aaca2defb70918890fada1e92e",
+            "0x5371d109c0f150255e41b6d4ea905b95a93891e99b6bda25e2a1e3a01582e5df8d71da138c952b825363300f0487312759f6bfcfd2db0b2a37bdba45be7f53a9",
+            "0x83b97ea1ca13e77724106bbe1147da8208f1bea8a6a8db6f7bd8493e25d556187273803ee3a4f392b4d60dd18df57fc6cb59012229467eb89b92666a632ef438",
+            "0xec4f99cb074ecf98ccac3a7fe5910e8425364b93809acdc405887e1ae0222b9d57fc150b6a6bfd62ff005271e4625b9f8dba8cdfa9e748a20bfe297a5980d295",
+            "0x3f1c699dc5809b95106511df84eea39e53bc2eac8c62581b157fc6ab498fc22d93becf9726a50c227544a8c3547c265dc1a866f19e78f1bf4cb7402c8b023260",
+            "0x5f2742233d188b0eff3a945c196525a0693cf961d462f74edda46b5391375f5b9300133e127671e898ac570aeae543a5b8a0a124d0a132e7fe6675b42c3d737c"
         ]
     },
     {
         "header": {
-            "prev_block": "0x148a7d63c3a2b35ae1917c546d8df721c2480f12bde58c665328ea515b2cc3c2fac1de66256192b843b60eaf3c74f93351180d151f586ae5c60a8c75e8cca574",
+            "prev_block": "0x9eb947227389499e07ac0376dc5fb4862b76e598d192e3189734eb8d16d86b09a1bbb24ce77c6483957c3dc95756bd7e1a06b381d64ab425f656a27e00df0bef",
             "height": "7",
-            "merkle_root": "0x27cbaeddb7da199352befd945dfd9ee60d300dcfa50896ff257ce1fe0f3b4047989f9c583c50f5dc09825b5591b16b6fadb09b1283465324af6c3858bf0735fc",
+            "merkle_root": "0xfb8bd2808477511a42c62ca5134e91e0600aadc940036a396edb638531458978ff29254b99ecf82f0f34ad11499d22c3199196a97050fcf40e4b80a59cb07c86",
             "validators": "[252]",
             "signature": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
             "enrollments": [],
@@ -1580,18 +1592,18 @@
         },
         "txs": [
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0x0ec0e9d4f10a2bb38fcf1fc866b18e1f8930452d1f1e0e8bee380bbe36c6f983fca8d293aac3f5aeb9892ee2826fd6e509c2f4d780560dcff52a8662f9836307",
+                        "utxo": "0xd638d9c993109383a2adf4227d936b2905a84f32341341ef9efa67a0a68bfbeda86455a536835e8ba39036d8c7e0ac176a262197f0d5498700a8bac5843c00f5",
                         "unlock": {
-                            "bytes": "Fr5/EqSOIuI2vyv1CqxZTPegl/8xWHMRR2+TAnzvOA3UmUH4WyGk/JjCVLrL1B9tv5igNPsXyal5/UQz1UcM5Q=="
+                            "bytes": "7TA0be05K3eXmGv73VqxbArpXHFp6wvq44HwGP3uXgfnRS7jAOPOvC9JsreWkfdXSplOawJYLmYhHahvTkDHQA=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -1605,18 +1617,18 @@
                 "lock_height": "0"
             },
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0xfbeb4f48857497f8d0635cdf2c6a89fc045d1b4833a0574ca08dd8ead97277a29aa83946a6ce3d7678c78e37e88d27977d2e4357f5f8ae02fa71358a8f0a1f44",
+                        "utxo": "0x6454cab6ae4071e6bd3e72b13cae252ab98012744d7b11dc94edbeb9d62aaa217224c142415ffa8de18343957b3718a1fa9d9a6ce488d36b61a375faaca13b62",
                         "unlock": {
-                            "bytes": "wzaQ+S47O4a69k0PwIQh9xqqox5/QEGxHOn50VYWBQEG+J2huKvDI7c0XkdSQweMILXizVfXWJ85rXiUBlkLRg=="
+                            "bytes": "FbtKieoZ9PjzA8TiXF8AP9Usrydq/t7VYhUPIz9xQwT7i5yNjCHsqjfrOoU5d3G7qLt+Bo+bYXrGOc7LVanx/Q=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -1630,18 +1642,18 @@
                 "lock_height": "0"
             },
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0xc7611262ab3cfffb5c168b80af1ecce3f014c7eaf9f21a97dc65ac6af7df7d7b446474d9f248184e6159e7815c61f09b003f6ab28c62e43d43e444cd37ea1f96",
+                        "utxo": "0x61865aa045abb39562e22dd9a2de01616022747bd250d4307f57d9db8833ea38861cee47fc01c7cc6405697319da277b318a8d64eaa391afb250a6898dbcca15",
                         "unlock": {
-                            "bytes": "XK6IOeRiWgMJjB/mH7JCFfvvfHfqCrerGTrj28FTWwye7l+R1gdsILpO8vAco8Q+FOsuiGfp1ewc4MfMwu/EqA=="
+                            "bytes": "b9wrE5RUtgQYFCLawPMlBDCS/8ZttoOCl3TDfVlmnglwNTPNSN1FIy5HHqjobN4UXNolYwxcsf+zTV7R1cmsLg=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -1655,18 +1667,18 @@
                 "lock_height": "0"
             },
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0x1b187a53ed2caf6b15346ece557614f8b6ba75e33251026813088c479a0ab45de0be13443e421715a50b16487435109698772cae4e6961fd2f0007dfdab1085e",
+                        "utxo": "0x907ce71758df117b9b2bdb1a3dcf8d6d6bdbc5c74408ffb18ecd92e702e591f7da3848388dba8bf563eb058dbe43699aa32d296e5f1ea395051d8a1450c4bc66",
                         "unlock": {
-                            "bytes": "Wf7IxwMspAtoYt8FLXjt7VEGOxqN6xO6ktX++p31PgTM61D2YvLamyMr6w0MlbM2vvjBgKYoLyZCJAMMRsmy9Q=="
+                            "bytes": "NBEl3antjxfPNe5kfKo5r1uUKlbfyH9gSI6ufmHzJACXR4ZmgaUZMS640oEQUCf5zhy/FC0EX9NyklTZbrKnLg=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -1680,18 +1692,18 @@
                 "lock_height": "0"
             },
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0xc6aba9953021a19601910786bfd37af2bf113398cde831d2724ef0e4c2584943b6a9e97b934e4c11254b32c41b0b56c6b1b1ce87825b335a1ac911cc28bf672c",
+                        "utxo": "0x6ec52911444a41ac891b7752e4bbae5bc47fde7f19c3c0c1b473da5856b782ed74d893e7a875ca0c23e5a7f70550a83766c01384292d2eb9943d02e386956785",
                         "unlock": {
-                            "bytes": "ykOOXhVHNm1IV8RuL3ZebAc3sFMCAeeHvEMCLcoyBQ9u9NgGcC2iaZDI4vvc1l0VZ6ER7yX2LY9LfD0pCzVeMQ=="
+                            "bytes": "P1Qs6MgsPFvw8O0kvatIW7L3XimyEy4qhERVbEr1lwNd3pLJKd9IM2C0Yx/X1XIFGqea3jAL8HpiRKNb7Wi2Ig=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -1705,18 +1717,18 @@
                 "lock_height": "0"
             },
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0x4b76f366befbc2168b723ac7d91c19185c9b117247ee51e99734cf47c0aea22c655cd9f53547b05d8d90456faffb105ac04906e51f9e32930dc07bd75765dfc4",
+                        "utxo": "0x04312cf5bafae55a11b2867105ad6cdbb3df2910946a792a037a487397dd101b90293915cce8a1ab50bc537333fbbb73b79b4e22c56f6490694b5d47b269073b",
                         "unlock": {
-                            "bytes": "OJXAZiNbTXnP96zmb5l/loXDUK/A8ZH6Z0R3eYhGIgIjZ2IF1ZE8Wsi8lNtdcueHY2n30A+2yT1ViBw+M7rcqQ=="
+                            "bytes": "CehmM08tf0oywhRLy85ImR0oHStaEL7VSU+OrIxoTwE71P9ix1J3MGsmWR/WC4MJLiFOjiEX7NX4rkrFMeX4Xg=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -1730,18 +1742,18 @@
                 "lock_height": "0"
             },
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0x2411352026c90b7249683b4a2eb7650b5bf2596fa4ce86ece20ca5c8d3a7904a760633a66fca942a53de112dffc7c748af2ae4211630db2ab8c5452ffe76651b",
+                        "utxo": "0x8f31aa70682601c9fe391af1392ce3c229d9b3bb29a9c921b77d8c3323753138f2067b15c1dfb6c01ed40ec355376926b4ee0e0ceb5735678e644ffb5865269c",
                         "unlock": {
-                            "bytes": "pK8N91dHfYgZ4PUkoaZ9C/ze4tMl3744PY2DbxJyWAn/Aq94OfdVL1BnML+ahFrW8z6w+5GgxMZlK5sMS+BqAA=="
+                            "bytes": "7/uEKiUAiajiwYPFLxD5uzBoPA2Tr6aBBMaamtwSDQgEt0pAx42sz9TwvW5nvPLpVz3fhkYUdALM9adtM40ZDg=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -1755,18 +1767,18 @@
                 "lock_height": "0"
             },
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0xf33ec4f19dfbf629bb70dac504d8a8f86467fe0413ef185bb988f28b56e3924dabf92633bc232219d23c7d8c043fd846decd11ea884f1efae1ab753a48eec024",
+                        "utxo": "0x5fd0b5e93a3fcd0a12a24589e35d9c308cda7c2ad418399501acc8baab89cf7d03b767a1ef82b54ed7b27170a71bfd17cd0d4c31cfba2011dc2f1fa44c3e0180",
                         "unlock": {
-                            "bytes": "vT8zfrt0VwZJGfmic8RvmMaHAWkqttKmPqxe7t8DCA9EOnC1sQQJOaI2OFnT3EYtVLE2lsqQOlhfcwoIUjL2lQ=="
+                            "bytes": "TbmxCFlOsGJnVURSLLKd2YvUs+PiEcKyK/lyWJ7PLgLBopLkhvvrlVjC/empeqEerl0v6bsRfdUwc6Q21NnqvA=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -1781,28 +1793,28 @@
             }
         ],
         "merkle_tree": [
-            "0x796ca9a06b21b03884f95221f8e8a78925f0e898ddba108bf7bb61cb368e4e873be3c61dfdd5d487574d89112d0640791850b24c7d2e5e7ef11692fc567f82fc",
-            "0x7da8ad6b445894d78a5809745fc543d0acc646ae35df22cf946253e212cf3b1f0c22990e9d2bf5e4e58790050ebb4c4ea141cf81e61e647551c9ee3141e5edad",
-            "0x3b0f0cd895a70ba4c9ec6b8eed24347f529999874f54d34bea46abeb3e4857845eba3ce2e69bc9025b1ae1059af2a1c7401451e48f2dd99711c69a73b4de5897",
-            "0x04d9a80975f0d603f70f22d9dd48ccedb92c1886ec7d9b2ba080b0fa39713a00291beed17315c63e7b17dbd5269007e78cda274bb312381344a3a1405dc5ea7a",
-            "0x7fe15c67dee0cb8adf1481f46cbb6f8586f41f6da2b12a83624112a91db855068b6401355d412e0c88e53755bf08e62d46bce6f6fc118b031bbfdc2182780735",
-            "0x8d2d3f287a5589330fec632ef1f525698023859b69333358cc19404c0b1a8eda42d620287d70f17e8c7a5ef2f843d87267fb81bb15e1f2c1b4ee2655759bd3ec",
-            "0x13955e694933997de1f7fbed0aec1d9510170db1ab095796b700c2ebff91336d30d11ec129fb09c738ded36c4b2d0a0b4c1b5a11d7bbc6f528168775b420438a",
-            "0x33e85f5ec1dca67b876e0b4f67794e5456951eb0e10f094455eddf80c4787ba5b4b20a547368cdf18585ff23347e44a007e3219865a6025b1d884c5151a8d69b",
-            "0x9110c3890de99a0601b6d17113b1317cd9eb825cb56d85007989b1661128a7a7eb752558388d6fa5b1c5254c471150a17895bdcdae3a3562238452b850a8ff05",
-            "0x2472efda4894d3449c4c04b5bc34aad531dfad2807d2ba98b2b53346948bbe5bb581f96c34e9bf879206e647fb0e32639b43db13af49740388a1bc20b7d9c5f1",
-            "0x4b91f0f05f9565db30823b7817471a3fe34493a1bbd3a356dde0e08a8149d463adab909182d79612c3634f855db06efecd27d9737a554f1e14fcb87824821c95",
-            "0xae9beea51cc642e67edb4ee503a181a7809f06bc7cf069b8a57b06659f4822149847e60348e92077d3090e1b998f258df3babd86a1459158bd4269ba4c282f88",
-            "0x518d2ee634b4858cd79679e1c991adb3d58b0d8d1925cf1d30bc4dc78229b4a898c5d2e258527e4eb81f4c0c51a3b8734527c08200adba811b977a10354ca82d",
-            "0xd93d5f709ae0a7fab0afb318ca92079bbc298fb7d8f855bf11aa3ef612de34bcbe97fed7c5dcd1f9a2987a02ddb7a602b1b052c7ec9e62ff569195157172e64e",
-            "0x27cbaeddb7da199352befd945dfd9ee60d300dcfa50896ff257ce1fe0f3b4047989f9c583c50f5dc09825b5591b16b6fadb09b1283465324af6c3858bf0735fc"
+            "0x7f7d4faf934c836169ebbde5a0ecab6a3690b19909266fd02a6529f7af923d24c52aab14293f96a9392785dc5af75f0018b662c7fbf01ca197a5424e220dbc72",
+            "0x9f019402c052dbf2c71e1481c08de0db8b78033fd24aaf69814ca150bd7143e1c9027176e7ebc36575dc89975fcd8a330f8738830a7f242fa4d1e8f187511599",
+            "0x52faef16540bc6b9b0b7900681abc934af6ef5a74945765df31526250af48f971a536383fc6d0cafc7bf32a80965e0d1516028f0e43edc7348b38a8886ee6595",
+            "0x839d9a3c50690c0f1ebf979b099aefdb8d6bcf7341205f12d9ebb34132b034a9c3d026856c070a5b636a07f9c18e26137ee85b4da46aad62a531a79aba2e39b5",
+            "0xbe8b38a8fdd120e5f89ee03ef7edd6a89959b79ff2177e8a925fe65e251c9a5ac94f075de59324523dcab80d233c288c8db1a65ab4606ace16c6968868a2e474",
+            "0x98a6742943b70f55449e826cbf1a94919e8b5c6111e6de3a288b29f0441928434170519253b10bcaa03a1b9343851c0f6ea2c76ad04d51e9713d36bb08e9341f",
+            "0x5329198fffd32e83f25e51150b9ddea76db2d5bed0daf3f0c068425d7c0690bdf762a5ffceaa9163649316afcb2ec9c6dbdaa2d97cbce486a101829545328bcc",
+            "0x47287f108e2e2c5607ae790a793838b585ab70a65f1f1387e589a78147772d43ba1de77edef997787b775b74cd2b9f39c1335b90538b4028fd008ae5a1b11535",
+            "0xc28fc8eea3666427b2786f1da59b8f4a6ebcf7c4beba8f3ba9b4320c0aa32d8222292c00e442b5a8968266360f4f65cb6c92fa767578b3f823f16cf19cdd3aec",
+            "0xd1e407fcf930d16846d2a46593fec94e7781bf548fc934d614aa4afc7a9297b481698189679a68b9e672b0b71a100597238f0482557aa7e495dcea8afbd4b719",
+            "0x5548056881becc4a13054405dc447bbfbbcf7d3481c6e3487ec7ea4110d2f1dec1290c32e013f2252bc2d65e5ee82ecacd094b84f8c92bb276a13df640a3104d",
+            "0x3c80ec209257baa0c01d714f1d785bc1c766c5e73cb0e74a7aacb641014e7fde2e6ef658211d41c24bb645afee5dc1cfc00bf5000dbc27a57d4ebdf5bbc00a7c",
+            "0xde2e47d35345235cb31cf5380c95a4a692d719aad5e62efdd41587aaf956cbec3d74ece92f464f1541337754f398266afd23609202d7e24d5cd3f8adec189ff3",
+            "0x021141ae21c003bb1757a922f792c63a12391638d106077420929906a4d160fca243e1144efa90e35d9ef9edab4ad6df27671b0aeb1ab4f494a8adeaa8155c2b",
+            "0xfb8bd2808477511a42c62ca5134e91e0600aadc940036a396edb638531458978ff29254b99ecf82f0f34ad11499d22c3199196a97050fcf40e4b80a59cb07c86"
         ]
     },
     {
         "header": {
-            "prev_block": "0x13c64a3da83504583fa9a43267a307b548d8500d522e7d1bac31dbe7661e5217fbdb54efa43e593e388978f3a3f32f495301c73411a3ea05ec17214c21b36a86",
+            "prev_block": "0xad993558b4264d2b9c7f2e0b80e040a1c51b9d14b116d10600a391c83cf6d4f4a208afcd7f0f12506f6a66245a91dcd936672b2d2647ae485be47ed0197f50c0",
             "height": "8",
-            "merkle_root": "0xcbbd2703ea0835d861a87fe1b33aa40f9c6339ad00a66cb71821dbd03989fb28f97f33b16831790740196f6d81543b947b23b0c95a79f8f31eec3a68d496aca9",
+            "merkle_root": "0x58a0ab5b7829f496d90490036681afa8cab4584484e79489096d846113d41f91476c754054b96b5b1e94d956347757216c6462b6ae3d401e9f19b3fb78e894f2",
             "validators": "[252]",
             "signature": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
             "enrollments": [],
@@ -1812,18 +1824,18 @@
         },
         "txs": [
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0x882e205efe026b376326f278c5d5037f710b8dc08a8f3c05a56f542120dc2fd8b17a67556f0559fdb4e4b447d88641a8cf3921eb3e7a9504f41e25846015bb51",
+                        "utxo": "0x41651fcc9ec8be1682c85ca2dfa4e5c78b847bf5b11780e9e9730a3e03b3db293e8381e74ed021399b272644acbcfb0ffbe9d6d2f188a66314dce331d1081ecb",
                         "unlock": {
-                            "bytes": "foXv7C2/u8VD+32HgykWpV5ODdWzo8IdwEPvesYbnAOcQfJxDpi18KAFo+oKBr0doSM3+t3qYJKYmI+qJk4cOw=="
+                            "bytes": "JYwdC+JmVOGCTi2MBQwFu7yBSUJJyXtGBxUcgRxoTAsGlwWGMHEYXQ1lT/WZ7OfCb8QCIVDrHrIn6k7KP+ujeg=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -1837,18 +1849,18 @@
                 "lock_height": "0"
             },
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0x586e4862577562284bbe927ba54a04812ee582c40fef6d02a94ef6279dc6afb7dd29f38f142316eb97e0cd90c4a06972012b9e398ab62494073f8e7a06d3d325",
+                        "utxo": "0x30a340032a5f928c7b780d775faba1c04b3b5f57fa85f85bd56a1b6d527cab2a7044a7487ef908a6e04d5818fa01f59e9a306f3c96189e5653c48f0a5242faad",
                         "unlock": {
-                            "bytes": "Fy9Jn0odyA3cSnOsJQZTm5UrG8OZ4SVKyu6QThClnwlM8Fuj8sVd+nQoMAq3iZZvkLYxS9SxvVHKSQq6QPG5Hg=="
+                            "bytes": "ClPXj9bA+L3yFn+N3lJR5eepH0QHnQcz5I0sm9NxQQPu0OyLU4cmJQ/u07MnFCCpXh8Y6KKsYc5kMne9lxizZw=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -1862,18 +1874,18 @@
                 "lock_height": "0"
             },
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0x1a1263fb97c990724b75ca0ea69da29f76d9b2e51cb27c3cc83471d0291156bf216d947492aa719a6fa87565abba683a02cc1736bc6a946f8328631e15c752b4",
+                        "utxo": "0x5fb505f4b5fcb807944fcda42a2ea7b751ddedafe699632ae64e686f6ec223e6ac20abe65ff06ce862dfb1114c3352167b11003e0b9dfca4644b52dbcdef6445",
                         "unlock": {
-                            "bytes": "1nYj7s4iKx0Fj7zvrF3Pqi/opBw9g4hq0bZl9NkL5gxhK+f/Xe+Ets19aZHyl1/nWwFD6f085BJxpI5NIQSLgQ=="
+                            "bytes": "6XYAu4vAALXovhZyfa1cADHKumK/4fD8Su62yDByYQ+2sDPDTqyRwFmOP6Oo8gd+O4THsituMBIzOFVUuMqs2Q=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -1887,18 +1899,18 @@
                 "lock_height": "0"
             },
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0x69067f7ffcc24866b23369bee83e46174d4fdbe7bbbe41cef279766e127f222c50a5d07bce3c453c8dd7ad80bf8fa6c7e4efbc47d4149f2a255eda648059ef9a",
+                        "utxo": "0xaeaf862546bce69f9c0f11e70a78be661ad8f35683f3e36128851f40637d09eb28f3678c59ce4d2773816be7f850458983a3bcd8098f289683da95ca4096dbd5",
                         "unlock": {
-                            "bytes": "w2vpZ28Qpi0XJluHeHJby5UmcTwn16IFDRO0Z6S13QOZKgaWsZQKIrLupsVJEMVcIFZFrxEnmdJXoQqnLZGW2A=="
+                            "bytes": "FDw023rA6SNwe5/GPgLhrKbPHd8FtgMbCERKrK8sGQXftsWz9wyyfs6yABXck+qFu6zoiyxVcci/fGSiB8UghA=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -1912,18 +1924,18 @@
                 "lock_height": "0"
             },
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0x114575fc0859f513153534e1c259e7447b765209140dc44825f92afbd9c7b34a5c63c838948125a84fe9785be8b76fdeb1e9edbf602187bfe7ac8522b56b630f",
+                        "utxo": "0x6daef51a3fa11ce8c1504f1957e1d17673d1e6cc78d45b63d122148a42b2dd060bdae5ee3b07d8b430f678716f20333e016b68b323920444781cb3d236c0b0cf",
                         "unlock": {
-                            "bytes": "j+4xxz6isAzOdB1BSVo9bMMWOULxxX6vD8viU4E/yALu0BiVTjomn00hNb6nhbk8zVT+n88ADK1WOe+dg8dASQ=="
+                            "bytes": "7FJLjQeuHNvSZH4z05I3wu1GYdewTlZwqVBO/ce2DwRp2mI8L8br9XJ18y3/WBrQh/xqsoeZey7ir4nVZY4tsw=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -1937,18 +1949,18 @@
                 "lock_height": "0"
             },
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0x1c36a2f9c62d1237e4320844de773c8ae57207fe5c7d0783e3d61d7aa3b7405986bd3ade0c74d5dfaff449b1ff38a12368ebfce8d83248aafa5e6fca7c8c5d98",
+                        "utxo": "0x17d8a1914f78121a5ba71bd5a99b05a562fd7e784de4585ba781f64d681ec58a74da131114e9dfc0d95589f8e62537b18aa7492051009097c1607f92fade8b10",
                         "unlock": {
-                            "bytes": "pYnqg0DHB8XDse5GyYaikc842TRn4kN5g2mKr4UudgD3pkqA9e6hb7ZPUKFTQbIHzfDVyrFSDdSLhGk3Q5XHwg=="
+                            "bytes": "vxW6zmLtqErLnJBjXF6QjN4yAw4UmKjzgLf+KXRAZQcpEEI0Xbh6FJmH+UUsaUzEtnDdxbPmGG2eHzHk8igpYA=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -1962,18 +1974,18 @@
                 "lock_height": "0"
             },
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0xa2ff3b4e208a1824b262c06de1be74d93bcdb871c9a1648d0be908fc0aaf13db89ac8ebfc314b629dafcb2a4e58cd7baa6e2d7aefbaac11936b1d3929f9e339b",
+                        "utxo": "0xde63ea83324a0688cb8141e831437e9646c36a46bd601abd6b66cd7d3f30430a2ddbdadcf19c77da6831f605d869593db6a1778dd790f03872c7caf11812ca36",
                         "unlock": {
-                            "bytes": "yypiPnckaI+5eSPRCqlk+CwCoKGRfSRD5uJac61zEwBLwxp3tWHBtKPLtVV+A7v8ZHeoZYoEaQHWsg/eRtyJXA=="
+                            "bytes": "dU1DT8ZNz/S23UthGFL2YZS6ehApV87pinz2pHu7vgEgPHo1djDBQJwgqESN+TlZwrVKkkjckuSPVVKrNEASYg=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -1987,18 +1999,18 @@
                 "lock_height": "0"
             },
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0xe0441f59c65b928b4bf6b353994008cfad257f5452643ed0385c8cc41d93e2bf50e4f4520a90d11e79ddb303cc6c39cf71d30029c5d28be58a3a25f59be62652",
+                        "utxo": "0xe8ab74a913f5c9577755bb5c4a3e413c8fbe8c15adece3eb90b60030340cce21f2c6a32672631cbdb1be5ef00b1402aef0c8ff65a6955be20bb8822bf60c11d0",
                         "unlock": {
-                            "bytes": "K8tHYGrlLhknsFwU1sTTxjs4F4Pl2X3ubufPEWfHkQSc2mPhR1w3m24zV/qPLLZWIuypFI5J6iVltmpSysmrqg=="
+                            "bytes": "I3QBbnkjvy+rAL2B6YBj5W3YplTgIOiweZiaLWLoDQ2SwlUwlknFQuad+u10umGFrZs3Hl8WMceB0F7vET461g=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -2013,28 +2025,28 @@
             }
         ],
         "merkle_tree": [
-            "0xf2a6f938f59a1acfc70d17c1328aeeeac4e697876c2833fb1538aec192aba5d0d2a1e6fd991b90a7b874f43ea51a1864a1d84c1052d6927b255df3c27ec50d20",
-            "0xac8f136d1a5f85027bcfe066e0f3e498bcb3465fd6456cefb1d6d582bbaed12382a7c5d6c16e16ef33d247b11b51cbad39482176b2e1047a534fd1d72eb32936",
-            "0xe27d4ae7480c8bf32c3df230be00c662d6b04032aa9a53dc8df870cb5774f4be6c1f583ba1d3a02ac55b59e200161e30dd140089b0136c90f44371cb9190b28f",
-            "0xbe9180b428d71bb5a85d56ef2ff7e9925f994c35f639bbaf493851e2851c979443b83211dd9353cd52da143b2b5fb28b516302bf3670e618ec59fd428a0537a1",
-            "0x3244dc7f98f1c4e124e93de73eaa94766e3f172bff84a441db5a0d43e3f061ad032aaea3adcf0f93caf2858e51fb9f27c3484b31860062268394c0a91f7eb585",
-            "0x2fe85d1dba1382e0568e3860dd42e586598ad6c3b0908739596d1a68ee24b89cad81e59153762daf27ebb1942ca4c05af7187e6b22c23a47412bc57904dbedf5",
-            "0x4ce545a5829c5a83696f7ec90a0dbcd2e8e5065198a337c6f548b39dbac29d51b9cbc65fb57eecf954166bff8f3bc12c99e33357a97b99bd4b0c49f5def30a24",
-            "0x8b448357e5a17cc2082430ece040c7878ef2a91507588ab6a0f172d43fe2a859c3701bcd49dbb435b9cb2d2058c365d6b6ed480bf411ba435567ba3eb87988f4",
-            "0xe3ff2057fd3703d560112f040915f91cbf9556c519eea7960e2ca3b1916581da2226688435c328710d4741e35c43eaba787c649e21014740166f7cadf63c6d99",
-            "0x2c9aee41372bdf890624e01b4accc23d80f6c647357e06e3d1d9dc8058d0d33131ca1e2cba4ec95c521ffcc466a6ba6f8ac086ca8028d5eda03e4acd8ab37fe2",
-            "0xd9c2d16753d512816b0bfc85765d42135e86d696e9126658e98079915ac44bff1f81e705be032b95e80b73cfa5b770dd4e65cd0945791eef4b2b145c9454cfe0",
-            "0xc8fc74aa9c7cc737f775f31d69240888ad001f2e7d98b2437c727daa2cb8701c4f15d440c9b254d2089845a3f93fbfac2efd4e70be7f0ce34e70609a6633d9d7",
-            "0x46d6b9ec912ede94376aaf3f22b03b4ad9d68cc7950f933b2a693825ee675640310dd205827551dcadc3cc9f06de802c2c01ede8a18df3b823f7487d41bc0920",
-            "0xbb2c09fa95635cffd0756a175246a70e72f38650be70857f63330db9d95b9ebaafa40aa6a75d3c68343e8c91aa19856b02e1368987cc2836c1ce8f758f16f1d2",
-            "0xcbbd2703ea0835d861a87fe1b33aa40f9c6339ad00a66cb71821dbd03989fb28f97f33b16831790740196f6d81543b947b23b0c95a79f8f31eec3a68d496aca9"
+            "0x29b4d3cfa80abc3c60c2055da6c1726b82b9464cb43c00c705e5e16adda4107da3f6ff3fb59df50ce569f2355fa787bef3209db11973f41f89b9769622db1de6",
+            "0x85db399d821f15e4b00b8d7301c06e9eede643930d00174bd6dd8370a0b7b3fa881e425dde87131a581ef70dc7faa581795836e1b44aee9935acfab1898ec464",
+            "0xc9e537de55f0f353baf53d09f1524bf43778911c7aa0a4adc51ef263c4e7ea42eaca79f518a32f0669a4898edb5a43dcd7cb89882b6c1bb1ef074810a357ef61",
+            "0x4bef4da5a04f089d78a61447e2be984392dc0b1dd4dbc8c31678a9c0ca068c93e2e76d88d5e71b1d84b4236f84c96ae77390c163a997b6f283018c0c8a0426b1",
+            "0x5c5a609b668d2a0cba315b14a0d4212d771c8836baee746fc74f3f056ae30769f82afb4ffc84093c7dabcaa4cf12b4c4aded996a63a1e000efe91fa9062b53bb",
+            "0xef9682bcf592bde8a92fbf2a432e6af8f29125125a0a4a63d09fd7ef6bccb3df536a880216af07327efb285b4eb4ac4976f8b2fb8b78a479b4c8b6c59c16a7d8",
+            "0x807b55b3d238b6e9ccd07179b23b9200dbe5bd952ca66e8f96258ede27a5643a3ee799b1942b3498fa514773daf45e6dba2ad6dcce69cd6e2dc33f18de2f8c17",
+            "0x94519cef1c9393798bccbfd1a93cfdf29e7a0e810ceca5e3f0d4449bab4eec4bef1eaadb2c25c0103c43bf01d6b8b46c3f55c8f750649a2038ca0efa88417235",
+            "0xe8848536e49fd6009c0eab1b55658ea1f68cc1152f7ab8295eeb1d36f86d1e199832923d0d73b87e8c85c1f7bb56ca654dd89f92310c2679d73a21d00980f2bc",
+            "0x7511c04023a1cd63c7ba7d485b7ae9c21d80cfc38b9ded18b65325c500c85edc09cfdc3ba50f0ca684e0e0f4423f1aa4e99151fa4022d83ca95e89bd1ae1cfd3",
+            "0x0612c457d032c5a4099a58f47ea90bfcd7e389a67edee5ac640ba2b67988a218d8a84f66e9f4747ae335655e371905b5f549b39937b0174628f421e21934aa98",
+            "0x4d6a404a296e287992cb6b8408d76cac97493cb45a2b143d7eeeaaf52d24fa4ac11e2323a06961daab35030c569f7247dbc478cab5480957138d2deeaab9ad4c",
+            "0x806519761428e4ee28d1472201a8ffaf3bde4d00130b809016793c8f860f8ce9bdd217e32c2b7f61f5cb8565de6cb18f164698ac9c925483f84600a9af1f7a9d",
+            "0x044e12a47069cbf8d8f3839a25c7797fd376b1ca64282e41972ae722110238b81e78507c25a9b7f352835c5f264c818905403ab13afe7fb5510d5203edcd6b1b",
+            "0x58a0ab5b7829f496d90490036681afa8cab4584484e79489096d846113d41f91476c754054b96b5b1e94d956347757216c6462b6ae3d401e9f19b3fb78e894f2"
         ]
     },
     {
         "header": {
-            "prev_block": "0xb6775e1234eef57db8fa87a089e65fe003ee49a0fffa48346da71f30ef410d89df3cc6c46f346e8e7bfd193f21e1b36d1bacee3ac4511d83a6b93b8ab284d445",
+            "prev_block": "0x9b05fab31dc1e63edb7a3fed7ab157b37d577150b81273185cc0c688000cb44af28cb8f9843f6ff71564c380e7878cf1f4ba0ed80f0d79dc84c6925c0050207d",
             "height": "9",
-            "merkle_root": "0xbeb839470097e0719b90b3cfb530e33603c76a2a92d577c1d593b0b3335eecc7239655db932336ce9ded3abc439fd38b73744028d45ed27823e2eadb752dadb8",
+            "merkle_root": "0x4d9dacc87f623f49a1f96f42ff2d8f28432b65e8fd3c29954dbd2681f5c1c8bae8c879634c5e0fd185633bd7aa7a4e6f1f2b302c8e0dbb3fad07840ca704474d",
             "validators": "[252]",
             "signature": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
             "enrollments": [],
@@ -2044,18 +2056,18 @@
         },
         "txs": [
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0xedf8367000a0d457589b1ec9a312ec3d85eb7edeb9915d4f89676c3f54a18c6ede40841a4054141c656218ecfc938ba606af339d4a6a49be43275d8d7930aedf",
+                        "utxo": "0xc9dfc14696ab15d8dda539b4e8a25da5146848828481e83cddb6eaee56051d7975ebe51736e4c1cca26fd7187afd7e39e60f7890b647e8813da6c35449ba84a9",
                         "unlock": {
-                            "bytes": "aq14Pobxk5V6kFuv46DCi492awn+IGGpw7kMhQH97Azvh0VgFEEOB/HhWy7pzO8+0FWSTqIbvPcvfz81y1K+sA=="
+                            "bytes": "Y+lJvLaz//+Ma5HyoRYiIckPR2WVPbzGjKnyB5bW4gByw7zczV/CHC/yymZAgazQZBJv4DNQQhxnd3jQyKBI7w=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -2069,18 +2081,18 @@
                 "lock_height": "0"
             },
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0xfd753b8da1eba6f2878a020a5719748a16901083c53f96e6d770e0e58583ee1f87fd85ab16313b1cce0ab94fb020c841eae21fc339d5ecc7f6c0ab1ee1a9fb9c",
+                        "utxo": "0x6d7b0f6df19adc9faad3b98552cb2a846153464c4d43b12406376994405c5f999b67ba4dea8597a6b1828bba2b624cfa8af365518711436c1c769be42dca7a8b",
                         "unlock": {
-                            "bytes": "kgwimFUXKK7YL5AGKeOu5hjsYFQ7JzHb64RUNygbFAX65KIjHtADS58j/cN3OWwEHnIYXqXZUGhGe/4bvDa/Sw=="
+                            "bytes": "qqEoA0Guu13nhEIHP3t3/nDtjAkCrhXQL3w0iOKdTghdJa0AQNIG4kRv3sx4E02QT/8Z4B80MfMw7u1kHnyxiQ=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -2094,18 +2106,18 @@
                 "lock_height": "0"
             },
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0xba026fa11bea421ce73fbdf947c429d7719fdffb4d14a58301b30716bf8c8ff349e655133d50f9850b24baa8e9bdd7a1c2eca115c52acf21abf52531b821aedd",
+                        "utxo": "0x6e6e2f9682df7782483af8d0ea79f1e4d5d2c309a1fd79d071677cfb95aa837f81b73d08aae94f79d2f35b86358fc718b60d18187c50c324ac5ebd9a2adf57c2",
                         "unlock": {
-                            "bytes": "9dcfQHt8XOiCwuFvYEN+R9ZNWKSC+zYgqDHYr5trqQ/iy/+twukQwXY0UzXq91VW3QaFQAKca3W6lG3lMNwPiA=="
+                            "bytes": "9Ra710o0+p5nFucKRC6mIGVzLGwyVG2mFmsQKZJvSAWucrMTvDP9W+2lI4XC2Ft6Lo71ZVapUtbC8WYxHm3mAQ=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -2119,18 +2131,18 @@
                 "lock_height": "0"
             },
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0xea43753b07c3d6793ee688c53888bdd300211745640b4e434416514c10d4afa281bbb2179b72bf35201763a41e1a6eafc72155965afa6bbfdc138f55a394cef5",
+                        "utxo": "0xdcf5000b530682cc6d1337d0f7dce33bcc2041e49370d27dd212b47dd060901f44f8ce06ca27b8502feee81ad9bf174e2d781d2f1835fb2d6b7c073523245693",
                         "unlock": {
-                            "bytes": "qoVQrY3ciSLP++9hkcy8TYn/a1r4cgOhIo4WOPc3Dg/OaNoX8iXPF9U5djJYs1D9YqV5BLO8xUqcdoIA8OwKHg=="
+                            "bytes": "GwyFYl/uD8elkYstZsosJYopeDO4KEiF1qWYDOGb+Af9F/mqFb6tkjH1o1ahjxkLlf6rlvOLkCkNYWSGWwy7vQ=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -2144,18 +2156,18 @@
                 "lock_height": "0"
             },
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0xf524c2acd5c95eebc1578dedd3f35e32cfeb6fd7181ceee4839b70745fd8eaa12442762c5d688bb9e15a2c666bccf6bc7ec8456a62daff1ebf4945a76402b6cb",
+                        "utxo": "0x9fd93f7b6acf3a277569084fabc3b6a8e983087c03e75aed7327c45d0a853a18b142daf607990882fc6388856557219c2bce42fb208f9f7e2cbeb845b482dc50",
                         "unlock": {
-                            "bytes": "LNCuhDlPfjj5Qxf3X2HYKDC9ceeFcz2fuhE7gzJ40A/TlSDQzA823yQs7Ggr8LL+fZsnTbFg662Lx+bx/e7O5w=="
+                            "bytes": "1d7OALUBhUqLrjUJ5eMUVpV2xaCCroxRTba8ltV4jwlRzs4M7wqwXVP7wkfUcycH2PXQ4+ymXZLl2OhuNrH44A=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -2169,18 +2181,18 @@
                 "lock_height": "0"
             },
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0x0de692e5a5a3de45d7f56f2dcb81ea168f26229941468a1b94bc9098c3b2d526ea1a0a45ea20d82428a8219d6591cb97fb0f409fb2b6e1f8e4394c383470f1fa",
+                        "utxo": "0xf264a96711a24f1e46d8883d45beec2526377c5903282b2cd5707b42a34698c8e2689b3a5500dab101bf519e7f82a07069a73c95d9bb6d1724306218686baa6c",
                         "unlock": {
-                            "bytes": "Atu5t5jf/Uhh/32Sa7V5yLn+mXUdGeJeirFYTlFcTgX4u3qNt+xBUmNi4m5sz4XWtQfCPd0JEDpgJ/kKSHBp7w=="
+                            "bytes": "g1rXknVgY02grc9T0vtS6CckDRmG1thOuzB3WwvFBwwQJYBjP9KO/DmtfOEIc0CCQAWoOqvib1hQ8d+Tv4s3Qw=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -2194,18 +2206,18 @@
                 "lock_height": "0"
             },
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0xabcb55fbce9e48874c5b14522c28747ebb2aab500b27a14d3575a47464aa9540aa786b55257abf083459c2d3b55706aa0198c5ada31d328b6d5f0e3198f16640",
+                        "utxo": "0x129daa271359dfb9aa84f887b1d24000c118663e7ff47da18a4d311db357945d897452823a885a1a9575b77b7df0a306b5f621102da4a17672a6cdd8bc51789a",
                         "unlock": {
-                            "bytes": "sdsRYW8PitCvtinIog7GO+Oj9XVyj4GNLdQGjWzM7w7yWVJ2f/zagsrS1+/am4k81KKF64/ZXel0mBv7H17gLA=="
+                            "bytes": "BFO/bLj74kB6jFCI975MCDHeFgheYGSbDpfPnuGaSQpuJayyvLQaTFCsfB/KmhGBSMVJpJUiOKqjWzz8eOewXw=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -2219,18 +2231,18 @@
                 "lock_height": "0"
             },
             {
-                "type": 0,
                 "inputs": [
                     {
-                        "utxo": "0x4757f131da69f452002a9b6cf4f4a3d5c96a787d4ef629882c48610153e4d0cd7c074f43f53e125ef8adf65ea41ecb778e2de7b20f09c33156b43239676c2f73",
+                        "utxo": "0x551a6ba2f2789b93f9f2a7aa0f2761621456f59738950b4f9b1638585f2b45c02e23e2d05fb1eed2d55934257a155cbe688e7f087800c7b9b09d3f9c9ed68a8e",
                         "unlock": {
-                            "bytes": "rpu2AeidPahPPS+66fljTWa8SDQNIk46pFBljBY8TgVjpZvLp/qfhV4hG2KZLu6LFn1DFWwhuer7iUIYI1cknQ=="
+                            "bytes": "74oNdkLq1SY7bOaLwMUHuGGsjXQ/1Irw2Vz3JxVtcg5+Dx1NlVsnMl6bDyZY6dfRqOHitpNlJfn0GV6JA/1Vrg=="
                         },
                         "unlock_age": 0
                     }
                 ],
                 "outputs": [
                     {
+                        "type": 0,
                         "value": "610000000000000",
                         "lock": {
                             "type": 0,
@@ -2245,21 +2257,21 @@
             }
         ],
         "merkle_tree": [
-            "0x766c72563878430b68d5294e8bd339935f2ada03f03af3e08d854a4b2684094d4a157dd958963d22135c4221b4be29d013b645ac0eb53c8f19bf9efb82944363",
-            "0xa17a7009f5c9cf19df6e9a22a25c926a9659d413d4c1e4631e9d9610fb8f21953a49e99656d655fc2b636a9707b9bb66a399d41fae2af4300aff833279cf223a",
-            "0xbda1f70745ef97247cafdd569840014e3594286117921ba0e8d214fbfca6f15ec147d9ed99e37ac2f081eca9caf1d82db05a0e254476f85a71c406149e090c2e",
-            "0x200437af366382c74b1bd7cbd0d4ff79d48d3dc1e795cc6d2e678f8be9c9e0e520491deab1e706ee9f1ddcddbc119c2256f9e6121186069cf44735f1e973bdef",
-            "0xbd83d11bfbc2d77281d1435774990e587c871cc53564f527bb07865b31c3cb3cf5c3e235843ad7b967f7f17db5b691d3cc307983d470dd07d3347d3230cf7689",
-            "0xd3ff66bf482283f7dd64d6bb6bf99869f6111cc57aa2e7af279ac8146e60af99c8929a85785c28a81eee2eecb33b4ad28de2152365030f915810ef8cd4ea6305",
-            "0x4a451a69c30bcfa571d06071b817e4cd8290d973918bb32db8134deb10f54201aabbc2ed6228cf0762a2187325963ce3e2ed533f548d4cab06c233ca70b1f80a",
-            "0x8f445c1ad33af5be09ead25795e97d74a0b25d6da7b1f918bfe0b67edf351bc543804a68c34e89c84a451bf99e97ae5bf4c5b5c266bb1041f2be74415f2030a8",
-            "0xb12dacac28306e1a83aae9db1a3cbbf0c433762e80c97287612c62f0a74779d97a582fb53f953f8e37ba92b5abdd7ed6de30074d9c54b409548c53edf237855a",
-            "0x24ccf3455f670b8f7929a2e842d01aa9e2ed89a63c030ae89b9e74a9c39bdd211bf20ed9435761637551e744b5901959f6887be42bbf202eaead8b5b9fc9be51",
-            "0x51d87bd8369106ba14196cc462dc715a809df162943aa82c28db573b355c07baca63c847ba6da420cd33444580f0f380aa4242bfdb439731bfdbbe8871493e4e",
-            "0x07b9e644ca933cbc59ab11eb14801093d9155425006ee3da67f4d63a26984b2ee64515eff09d80155fbf5d563b600d9c1beb095cc8f9a226eae1264ea24581d0",
-            "0x8109020687a203a0d52a2b78070b5e39008cae4c9eaad18f841209a5c249966f940e2940b91e731925b45b3e464e15cb7fd7556a23fc6d26622f01d6b844c4ff",
-            "0x00124f5bd49829a6562ea9a17d10045447afebb6beee3b227ad65b5bf9e6e5fadca414fa7b700a4babbd0fce7e2af3ab6730d047fb9dfcb1d45a8ab00538e449",
-            "0xbeb839470097e0719b90b3cfb530e33603c76a2a92d577c1d593b0b3335eecc7239655db932336ce9ded3abc439fd38b73744028d45ed27823e2eadb752dadb8"
+            "0x0eed721accb0bf6fecb323388f18ed6b20216d19a0e6ac72c2a19294816f26036d8f4fa8964405cf7ec937d51d34fc0c2d1a8fdc26c4cc6a2ffda7cb59e33225",
+            "0x2ec898c428c993b170b99e300535118587aaca03b7d534035da72626a02ee5f6caba040fba4bf06fe56297f69d647b53536eb37d59a09d0ea7f3091092a162e3",
+            "0x8894ca7d78d78301cd93fcbb8b593cb64c872ea8eeffa2dad5a3439fd71549026091dff77bdc12ff688a0f4715cc646a6a82a6db53e5659bb7bd634c93f12eb3",
+            "0x932b87b133e3761140984bd5f5ad5c920d20f8fa903ed00482bcac8db53e12b0251be7c8baca0ef830dfb62bdadb645dbdc81ec68b3cb880007f70eaf4abe7ef",
+            "0x7a1f8c370a4e31f9f3cc1559c9f1c91cd1bf2efa39156bd88ee10848380f86b27a4ed029ce30550838a6e53eec156afb7b127a1ba872ecf6acea7ac1317f3386",
+            "0x8138dea4b2fffa2ff8add83046a262b600150935c906ad8b673460d75c6bc6132d3be14d5dcfab4482603622027abbb1933c9782e7c31e345f5b3b37404a8d55",
+            "0x716bdd1219e8e101ee604537eb231a458255e2af28c27914731b4869abe27cb3882650f17df326a084a7dc924a3534aa80978abc9fb71071ac5186df993c6e65",
+            "0x137dfda16ebdcc93de30a171bd3de2cc08f8e124dc55858507b4d4ed696952d711b09ed83b31e0583ebddd7a3a73cc30d09d1fb656e62245e2dd56c585d1f61b",
+            "0xf057b0f9078a03c9f486a7932a4408664b8994567c983867c0c1bcbeb2595d124704548c1e2c206695d378e1df1cb10d3190cf6b7d7a3e853a3bdbac35d0dc8f",
+            "0x3963f33dc1f2aa03f1d0597cefaa45423b4a6831c044dcb2a84e3fb7f257b07d98f0ae94b78939c3bdeaba13c1547ad10739371f70b51d24ed10aa471c2f81f8",
+            "0xc7c6761331e5405560ea249cf984c2aeb7f2ee706df913fd8c6abc3d240b19727d340b5f3e3e5ec65c5a2d639075961adaa43fc77ba4f67445ff9634c3f0acd1",
+            "0x1ae2715a03b3a3c091b3aadeb52896e7517bacf01d86e45e7f64345887a3111aab4a310dbdb0a1340374778629e12f7dfe6ac648f043086688608416fe85d9c3",
+            "0xf225e6b76f624aa5654715152bbfc8d85648582cd0e8ce117a2dc3bd5b94e8bff7966c78f6dc6e653f1247b03ad7222ad835b2e73f949df98e37b428f2bf8260",
+            "0x91a1947bd11a16c9fc61b7d13233932fdefadd99313dd273aaf18b70e2eeac847f9ec8ba657af64d1bc9c9d09392333a61d7bd9d090114e2fdde0793d95f2812",
+            "0x4d9dacc87f623f49a1f96f42ff2d8f28432b65e8fd3c29954dbd2681f5c1c8bae8c879634c5e0fd185633bd7aa7a4e6f1f2b302c8e0dbb3fad07840ca704474d"
         ]
     }
 ]


### PR DESCRIPTION
It was applied in accordance with the change in Agora.
The tx_type in Transaction was moved to each output.
This will ensure that refunding outputs are not frozen in freeze transactions.

https://github.com/bosagora/boa-sdk-ts/pull/178
Related to https://github.com/bosagora/agora/pull/2114