### PR TITLE
Replace `DataPayload` with `Buffer` (BOA-SDK-TS Ver 0.0.48)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -336,9 +336,9 @@
       "dev": true
     },
     "boa-sdk-ts": {
-      "version": "0.0.47",
-      "resolved": "https://registry.npmjs.org/boa-sdk-ts/-/boa-sdk-ts-0.0.47.tgz",
-      "integrity": "sha512-Lv46sGywo4NHubZ1BDtzRqrc4DDvfiO5JaBv5xIn2kAJBcl04nK8boCPKkORwhRYEwhdo2ZllVLNp7tGDVVf6A==",
+      "version": "0.0.48",
+      "resolved": "https://registry.npmjs.org/boa-sdk-ts/-/boa-sdk-ts-0.0.48.tgz",
+      "integrity": "sha512-9hq07eoATS2TkR0DwQUcx3W8EYuwFvW7+Fu1iCMVLaI1SbbAP0Loi6/zBnFFZH8+7svuqzEJQ//YzPkSfAjuzw==",
       "requires": {
         "@ctrl/ts-base32": "^1.2.1",
         "ajv": "^6.12.6",
@@ -1000,9 +1000,9 @@
       }
     },
     "glob-parent": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
       "requires": {
         "is-glob": "^4.0.1"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "test": "NODE_ENV=test mocha --exit -r ts-node/register tests/**/*.test.ts --timeout 10000",
     "debug": "NODE_ENV=development mocha -r ts-node/register tests/**/*.test.ts",
     "start": "NODE_ENV=production ts-node src/main.ts",
-    "tsc": "tsc"
+    "convert": "ts-node .npm/convert-stoa-sample-data/convert-blocks.ts .npm/convert-stoa-sample-data/old/sample.json .npm/convert-stoa-sample-data/old/sample_utxo.json",
+      "tsc": "tsc"
   },
   "repository": {
     "type": "git",
@@ -27,7 +28,7 @@
     "argparse": "^2.0.1",
     "assert": "^2.0.0",
     "axios": "^0.21.1",
-    "boa-sdk-ts": "^0.0.47",
+    "boa-sdk-ts": "^0.0.48",
     "body-parser": "^1.19.0",
     "coingecko-api-v3": "0.0.11",
     "cors": "^2.8.5",

--- a/src/Stoa.ts
+++ b/src/Stoa.ts
@@ -5,14 +5,14 @@ import { LedgerStorage } from './modules/storage/LedgerStorage';
 import { CoinMarketService } from './modules/service/CoinMaketService';
 import { logger } from './modules/common/Logger';
 import { Height, PreImageInfo, Hash, hash, Block, Utils,
-    Endian, Transaction, hashFull, DataPayload } from 'boa-sdk-ts';
+    Endian, Transaction, hashFull } from 'boa-sdk-ts';
 import { WebService } from './modules/service/WebService';
 import { ValidatorData, IPreimage, IUnspentTxOutput, ITxStatus,
     ITxHistoryElement, ITxOverview, ConvertTypes, DisplayTxType,
     IPendingTxs, ISPVStatus, ITransactionFee, IBlock, ITransaction,
     IBlockOverview, IBlockEnrollmentElements, IBlockEnrollment, IBlockTransactions, IBlockTransactionElements,
     IBOAStats, IPagination, IMarketCap, IMarketChart} from './Types';
-import { Time } from './modules/common/Time';    
+import { Time } from './modules/common/Time';
 
 import bodyParser from 'body-parser';
 import cors from 'cors';
@@ -756,7 +756,7 @@ class Stoa extends WebService
                     unlock_height: JSBI.BigInt(data.tx[0].unlock_height).toString(),
                     lock_height: JSBI.BigInt(data.tx[0].lock_height).toString(),
                     unlock_time: data.tx[0].unlock_time,
-                    payload: (data.tx[0].payload !== null) ? new DataPayload(data.tx[0].payload, Endian.Little).toString() : "",
+                    payload: (data.tx[0].payload !== null) ? data.tx[0].payload.toString("base64") : "",
                     senders: [],
                     receivers: [],
                     fee: JSBI.add(JSBI.BigInt(data.tx[0].tx_fee), JSBI.BigInt(data.tx[0].payload_fee)).toString()
@@ -1697,7 +1697,7 @@ class Stoa extends WebService
                      });
                     res.status(200).send(marketCapChart);
                  }
-                
+
             })
             .catch((err)=>{
                 logger.error("Failed to data lookup to the DB: " + err);

--- a/src/modules/storage/LedgerStorage.ts
+++ b/src/modules/storage/LedgerStorage.ts
@@ -14,7 +14,7 @@
 import {
     Block, Enrollment, Hash, Height, PreImageInfo, Transaction,
     TxInput, TxOutput, makeUTXOKey, hashFull,
-    Utils, Endian, Lock, Unlock, PublicKey, DataPayload, TxPayloadFee, OutputType
+    Utils, Endian, Lock, Unlock, PublicKey, TxPayloadFee, OutputType
 } from 'boa-sdk-ts';
 import { Storages } from './Storages';
 import { IDatabaseConfig } from '../common/Config';
@@ -749,7 +749,7 @@ export class LedgerStorage extends Storages
                         else
                         {
                             total_fee = JSBI.subtract(SumOfInput, SumOfOutput);
-                            payload_fee = TxPayloadFee.getFee(tx.payload.data.length);
+                            payload_fee = TxPayloadFee.getFee(tx.payload.length);
                             tx_fee = JSBI.subtract(total_fee, payload_fee);
                         }
 
@@ -837,7 +837,7 @@ export class LedgerStorage extends Storages
                         tx_size,
                         tx.inputs.length,
                         tx.outputs.length,
-                        tx.payload.data.length
+                        tx.payload.length
                     ]
                 )
                     .then(() =>
@@ -1035,7 +1035,7 @@ export class LedgerStorage extends Storages
         {
             return new Promise<void>((resolve, reject) =>
             {
-                if (tx.payload.data.length == 0)
+                if (tx.payload.length == 0)
                     resolve();
 
                 storage.run(
@@ -1045,7 +1045,7 @@ export class LedgerStorage extends Storages
                         (?, ?)`,
                     [
                         tx_hash.toBinary(Endian.Little),
-                        tx.payload.toBinary(Endian.Little)
+                        tx.payload
                     ]
                 )
                     .then(() =>
@@ -1071,7 +1071,7 @@ export class LedgerStorage extends Storages
 
                         await save_transaction(this, block.header.height, tx_idx, block.merkle_tree[tx_idx], block.txs[tx_idx]);
 
-                        if (block.txs[tx_idx].payload.data.length > 0)
+                        if (block.txs[tx_idx].payload.length > 0)
                             await save_payload(this, block.merkle_tree[tx_idx], block.txs[tx_idx]);
 
                         for (let in_idx = 0; in_idx < block.txs[tx_idx].inputs.length; in_idx++)
@@ -1133,7 +1133,7 @@ export class LedgerStorage extends Storages
                     [
                         hash.toBinary(Endian.Little),
                         tx_type,
-                        tx.payload.toBinary(Endian.Little),
+                        tx.payload,
                         tx.lock_height.toString(),
                         fees[1].toString(),
                         fees[2].toString(),
@@ -1869,7 +1869,7 @@ export class LedgerStorage extends Storages
                     resolve(new Transaction(
                         inputs,
                         outputs,
-                        new DataPayload((rows[0].payload !== null) ? (rows[0].payload) : Buffer.alloc(0), Endian.Little),
+                        (rows[0].payload !== null) ? (rows[0].payload) : Buffer.alloc(0),
                         new Height(rows[0].lock_height)));
                 }
                 else
@@ -1918,7 +1918,7 @@ export class LedgerStorage extends Storages
                     resolve(new Transaction(
                         inputs,
                         outputs,
-                        new DataPayload((rows[0].payload !== null) ? (rows[0].payload) : Buffer.alloc(0), Endian.Little),
+                        (rows[0].payload !== null) ? (rows[0].payload) : Buffer.alloc(0),
                         new Height(rows[0].lock_height)));
                 }
                 else
@@ -2165,12 +2165,12 @@ export class LedgerStorage extends Storages
 
         return this.query(sql, []);
     }
-    
+
     /**
      * Get the latest Coin Market cap chart of BOA coin
      * @returns Returns the Promise. If it is finished successfully the `.then`
      * of the returned Promise is called with the records
-     * and if an error occurs the `.catch` is called with an error. 
+     * and if an error occurs the `.catch` is called with an error.
      */
     public getCoinMarketChart(from: number, to: number): Promise<any[]> {
         let sql =

--- a/tests/Boascan.test.ts
+++ b/tests/Boascan.test.ts
@@ -13,7 +13,7 @@
 
 import {
     BitField, Block, BlockHeader, Enrollment, Height, Hash, Signature, SodiumHelper,
-    Transaction, OutputType, TxInput, TxOutput, DataPayload, PublicKey, JSBI
+    Transaction, OutputType, TxInput, TxOutput, PublicKey, JSBI
 } from 'boa-sdk-ts';
 import {
     sample_data,

--- a/tests/Stoa.test.ts
+++ b/tests/Stoa.test.ts
@@ -13,7 +13,7 @@
 
 import {
     BitField, Block, BlockHeader, Enrollment, Height, Hash, Signature, SodiumHelper,
-    Transaction, OutputType, TxInput, TxOutput, DataPayload, PublicKey, JSBI, Sig
+    Transaction, OutputType, TxInput, TxOutput, PublicKey, JSBI, Sig
 } from 'boa-sdk-ts';
 import {
     sample_data,
@@ -453,9 +453,7 @@ describe ('Test of Stoa API Server', () =>
                     }
                 }
             ],
-            "payload": {
-                "bytes": "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0+P0BBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWltcXV5fYGFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6e3x9fn+AgYKDhIWGh4iJiouMjY6PkJGSk5SVlpeYmZqbnJ2en6ChoqOkpaanqKmqq6ytrq+wsbKztLW2t7i5uru8vb6/wMHCw8TFxsfIycrLzM3Oz9DR0tPU1dbX2Nna29zd3t/g4eLj5OXm5+jp6uvs7e7v8PHy8/T19vf4+fr7/P3+/wABAgMEBQYHCAkKCwwNDg8QERITFBUWFxgZGhscHR4fICEiIyQlJicoKSorLC0uLzAxMjM0NTY3ODk6Ozw9Pj9AQUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVpbXF1eX2BhYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5ent8fX5/gIGCg4SFhoeIiYqLjI2Oj5CRkpOUlZaXmJmam5ydnp+goaKjpKWmp6ipqqusra6vsLGys7S1tre4ubq7vL2+v8DBwsPExcbHyMnKy8zNzs/Q0dLT1NXW19jZ2tvc3d7f4OHi4+Tl5ufo6err7O3u7/Dx8vP09fb3+Pn6+/z9/v8AAQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyAhIiMkJSYnKCkqKywtLi8wMTIzNDU2Nzg5Ojs8PT4/QEFCQ0RFRkdISUpLTE1OT1BRUlNUVVZXWFlaW1xdXl9gYWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXp7fH1+f4CBgoOEhYaHiImKi4yNjo+QkZKTlJWWl5iZmpucnZ6foKGio6SlpqeoqaqrrK2ur7CxsrO0tba3uLm6u7y9vr/AwcLDxMXGx8jJysvMzc7P0NHS09TV1tfY2drb3N3e3+Dh4uPk5ebn6Onq6+zt7u/w8fLz9PX29/j5+vv8/f7/AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0+P0BBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWltcXV5fYGFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6e3x9fn+AgYKDhIWGh4iJiouMjY6PkJGSk5SVlpeYmZqbnJ2en6ChoqOkpaanqKmqq6ytrq+wsbKztLW2t7i5uru8vb6/wMHCw8TFxsfIycrLzM3Oz9DR0tPU1dbX2Nna29zd3t/g4eLj5OXm5+jp6uvs7e7v8PHy8/T19vf4+fr7/P3+/w=="
-            },
+            "payload": "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0+P0BBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWltcXV5fYGFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6e3x9fn+AgYKDhIWGh4iJiouMjY6PkJGSk5SVlpeYmZqbnJ2en6ChoqOkpaanqKmqq6ytrq+wsbKztLW2t7i5uru8vb6/wMHCw8TFxsfIycrLzM3Oz9DR0tPU1dbX2Nna29zd3t/g4eLj5OXm5+jp6uvs7e7v8PHy8/T19vf4+fr7/P3+/wABAgMEBQYHCAkKCwwNDg8QERITFBUWFxgZGhscHR4fICEiIyQlJicoKSorLC0uLzAxMjM0NTY3ODk6Ozw9Pj9AQUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVpbXF1eX2BhYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5ent8fX5/gIGCg4SFhoeIiYqLjI2Oj5CRkpOUlZaXmJmam5ydnp+goaKjpKWmp6ipqqusra6vsLGys7S1tre4ubq7vL2+v8DBwsPExcbHyMnKy8zNzs/Q0dLT1NXW19jZ2tvc3d7f4OHi4+Tl5ufo6err7O3u7/Dx8vP09fb3+Pn6+/z9/v8AAQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyAhIiMkJSYnKCkqKywtLi8wMTIzNDU2Nzg5Ojs8PT4/QEFCQ0RFRkdISUpLTE1OT1BRUlNUVVZXWFlaW1xdXl9gYWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXp7fH1+f4CBgoOEhYaHiImKi4yNjo+QkZKTlJWWl5iZmpucnZ6foKGio6SlpqeoqaqrrK2ur7CxsrO0tba3uLm6u7y9vr/AwcLDxMXGx8jJysvMzc7P0NHS09TV1tfY2drb3N3e3+Dh4uPk5ebn6Onq6+zt7u/w8fLz9PX29/j5+vv8/f7/AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0+P0BBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWltcXV5fYGFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6e3x9fn+AgYKDhIWGh4iJiouMjY6PkJGSk5SVlpeYmZqbnJ2en6ChoqOkpaanqKmqq6ytrq+wsbKztLW2t7i5uru8vb6/wMHCw8TFxsfIycrLzM3Oz9DR0tPU1dbX2Nna29zd3t/g4eLj5OXm5+jp6uvs7e7v8PHy8/T19vf4+fr7/P3+/w==",
             "lock_height": "0"
         };
         assert.deepStrictEqual(response.data, expected);
@@ -681,9 +679,7 @@ describe ('Test of Stoa API Server', () =>
                     }
                 }
             ],
-            "payload": {
-                "bytes": ""
-            },
+            "payload": "",
             "lock_height": "0"
         };
         assert.deepStrictEqual(response.data, expected);
@@ -893,7 +889,7 @@ describe ('Test of the path /utxo for freezing', () =>
                 new TxOutput(OutputType.Payment, JSBI.BigInt(  "100000000000"), new PublicKey("boa1xparc00qvv984ck00trwmfxuvqmmlwsxwzf3al0tsq5k2rw6aw427ct37mj")),
                 new TxOutput(OutputType.Freeze, JSBI.BigInt("24300000000000"), new PublicKey("boa1xparc00qvv984ck00trwmfxuvqmmlwsxwzf3al0tsq5k2rw6aw427ct37mj"))
             ],
-            DataPayload.init
+            Buffer.alloc(0)
         );
 
         uri = URI(host)
@@ -914,7 +910,7 @@ describe ('Test of the path /utxo for freezing', () =>
                 new TxOutput(OutputType.Payment, JSBI.BigInt(  "400000000000"), new PublicKey("boa1xrard006yhapr2dzttap6yg3l0rv5yf94hdnmmfj5zkwhhyw80sj785segs")),
                 new TxOutput(OutputType.Freeze, JSBI.BigInt("24000000000000"), new PublicKey("boa1xrard006yhapr2dzttap6yg3l0rv5yf94hdnmmfj5zkwhhyw80sj785segs"))
             ],
-            DataPayload.init
+            Buffer.alloc(0)
         );
 
         // Create block with two transactions
@@ -1113,3 +1109,4 @@ describe ('Test of the path /merkle_path', () =>
         assert.deepStrictEqual(response.data, expected);
     })
 });
+

--- a/tests/Storage.test.ts
+++ b/tests/Storage.test.ts
@@ -13,7 +13,7 @@
 
 import * as assert from 'assert';
 import { LedgerStorage } from '../src/modules/storage/LedgerStorage';
-import { Block, Hash, Height, DataPayload, PreImageInfo, SodiumHelper, Endian } from 'boa-sdk-ts';
+import { Block, Hash, Height, PreImageInfo, SodiumHelper, Endian } from 'boa-sdk-ts';
 import { sample_data, sample_data2, sample_preImageInfo } from "./Utils";
 
 import * as fs from 'fs';
@@ -183,7 +183,7 @@ describe ('Test ledger storage and inquiry function.', () =>
         await ledger_storage.putBlocks(block);
         let rows = await ledger_storage.getPayload(block.merkle_tree[0]);
         assert.strictEqual(rows.length, 1);
-        assert.deepStrictEqual(new DataPayload(rows[0].payload, Endian.Little), block.txs[0].payload);
+        assert.deepStrictEqual(rows[0].payload, block.txs[0].payload);
     });
 
     it ('Test for UTXO', async () => {

--- a/tests/WalletAPI.test.ts
+++ b/tests/WalletAPI.test.ts
@@ -136,7 +136,7 @@ describe ('Test of Stoa API for the wallet', () =>
                     "signature": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
                     "index": 0,
                     "unlock_age": 0,
-                    "bytes": "0xd5dece00b501854a8bae3509e5e314569576c5a082ae8c514db6bc96d5788f0951cece0cef0ab05d53fbc247d4732707d8f5d0e3eca65d92e5d8e86e36b1f8e0"
+                    "bytes": "0x92a70f8a1e99375e305c50269835545711daca7fbe3f97a1a2c94fcb75b67f004a1a9bd6f9d84f9b057b6901e0c93dbeac67a08f447021e31a604b65f1d0bda0"
                 }
             ],
             "receivers": [

--- a/tests/data/Block.0.sample1.json
+++ b/tests/data/Block.0.sample1.json
@@ -100,9 +100,7 @@
                     }
                 }
             ],
-            "payload": {
-                "bytes": ""
-            },
+            "payload": "",
             "lock_height": "0"
         },
         {
@@ -173,9 +171,7 @@
                     }
                 }
             ],
-            "payload": {
-                "bytes": ""
-            },
+            "payload": "",
             "lock_height": "0"
         }
     ],

--- a/tests/data/Block.1.sample1.json
+++ b/tests/data/Block.1.sample1.json
@@ -223,9 +223,7 @@
                     }
                 }
             ],
-            "payload": {
-                "bytes": ""
-            },
+            "payload": "",
             "lock_height": "0"
         },
         {
@@ -440,9 +438,7 @@
                     }
                 }
             ],
-            "payload": {
-                "bytes": ""
-            },
+            "payload": "",
             "lock_height": "0"
         },
         {
@@ -657,9 +653,7 @@
                     }
                 }
             ],
-            "payload": {
-                "bytes": ""
-            },
+            "payload": "",
             "lock_height": "0"
         },
         {
@@ -874,9 +868,7 @@
                     }
                 }
             ],
-            "payload": {
-                "bytes": ""
-            },
+            "payload": "",
             "lock_height": "0"
         },
         {
@@ -1091,9 +1083,7 @@
                     }
                 }
             ],
-            "payload": {
-                "bytes": ""
-            },
+            "payload": "",
             "lock_height": "0"
         },
         {
@@ -1308,9 +1298,7 @@
                     }
                 }
             ],
-            "payload": {
-                "bytes": ""
-            },
+            "payload": "",
             "lock_height": "0"
         },
         {
@@ -1525,9 +1513,7 @@
                     }
                 }
             ],
-            "payload": {
-                "bytes": ""
-            },
+            "payload": "",
             "lock_height": "0"
         },
         {
@@ -1742,9 +1728,7 @@
                     }
                 }
             ],
-            "payload": {
-                "bytes": ""
-            },
+            "payload": "",
             "lock_height": "0"
         }
     ],

--- a/tests/data/Block.2.sample1.json
+++ b/tests/data/Block.2.sample1.json
@@ -39,9 +39,7 @@
                     }
                 }
             ],
-            "payload": {
-                "bytes": "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0+P0BBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWltcXV5fYGFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6e3x9fn+AgYKDhIWGh4iJiouMjY6PkJGSk5SVlpeYmZqbnJ2en6ChoqOkpaanqKmqq6ytrq+wsbKztLW2t7i5uru8vb6/wMHCw8TFxsfIycrLzM3Oz9DR0tPU1dbX2Nna29zd3t/g4eLj5OXm5+jp6uvs7e7v8PHy8/T19vf4+fr7/P3+/wABAgMEBQYHCAkKCwwNDg8QERITFBUWFxgZGhscHR4fICEiIyQlJicoKSorLC0uLzAxMjM0NTY3ODk6Ozw9Pj9AQUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVpbXF1eX2BhYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5ent8fX5/gIGCg4SFhoeIiYqLjI2Oj5CRkpOUlZaXmJmam5ydnp+goaKjpKWmp6ipqqusra6vsLGys7S1tre4ubq7vL2+v8DBwsPExcbHyMnKy8zNzs/Q0dLT1NXW19jZ2tvc3d7f4OHi4+Tl5ufo6err7O3u7/Dx8vP09fb3+Pn6+/z9/v8AAQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyAhIiMkJSYnKCkqKywtLi8wMTIzNDU2Nzg5Ojs8PT4/QEFCQ0RFRkdISUpLTE1OT1BRUlNUVVZXWFlaW1xdXl9gYWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXp7fH1+f4CBgoOEhYaHiImKi4yNjo+QkZKTlJWWl5iZmpucnZ6foKGio6SlpqeoqaqrrK2ur7CxsrO0tba3uLm6u7y9vr/AwcLDxMXGx8jJysvMzc7P0NHS09TV1tfY2drb3N3e3+Dh4uPk5ebn6Onq6+zt7u/w8fLz9PX29/j5+vv8/f7/AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0+P0BBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWltcXV5fYGFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6e3x9fn+AgYKDhIWGh4iJiouMjY6PkJGSk5SVlpeYmZqbnJ2en6ChoqOkpaanqKmqq6ytrq+wsbKztLW2t7i5uru8vb6/wMHCw8TFxsfIycrLzM3Oz9DR0tPU1dbX2Nna29zd3t/g4eLj5OXm5+jp6uvs7e7v8PHy8/T19vf4+fr7/P3+/w=="
-            },
+            "payload": "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0+P0BBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWltcXV5fYGFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6e3x9fn+AgYKDhIWGh4iJiouMjY6PkJGSk5SVlpeYmZqbnJ2en6ChoqOkpaanqKmqq6ytrq+wsbKztLW2t7i5uru8vb6/wMHCw8TFxsfIycrLzM3Oz9DR0tPU1dbX2Nna29zd3t/g4eLj5OXm5+jp6uvs7e7v8PHy8/T19vf4+fr7/P3+/wABAgMEBQYHCAkKCwwNDg8QERITFBUWFxgZGhscHR4fICEiIyQlJicoKSorLC0uLzAxMjM0NTY3ODk6Ozw9Pj9AQUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVpbXF1eX2BhYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5ent8fX5/gIGCg4SFhoeIiYqLjI2Oj5CRkpOUlZaXmJmam5ydnp+goaKjpKWmp6ipqqusra6vsLGys7S1tre4ubq7vL2+v8DBwsPExcbHyMnKy8zNzs/Q0dLT1NXW19jZ2tvc3d7f4OHi4+Tl5ufo6err7O3u7/Dx8vP09fb3+Pn6+/z9/v8AAQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyAhIiMkJSYnKCkqKywtLi8wMTIzNDU2Nzg5Ojs8PT4/QEFCQ0RFRkdISUpLTE1OT1BRUlNUVVZXWFlaW1xdXl9gYWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXp7fH1+f4CBgoOEhYaHiImKi4yNjo+QkZKTlJWWl5iZmpucnZ6foKGio6SlpqeoqaqrrK2ur7CxsrO0tba3uLm6u7y9vr/AwcLDxMXGx8jJysvMzc7P0NHS09TV1tfY2drb3N3e3+Dh4uPk5ebn6Onq6+zt7u/w8fLz9PX29/j5+vv8/f7/AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0+P0BBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWltcXV5fYGFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6e3x9fn+AgYKDhIWGh4iJiouMjY6PkJGSk5SVlpeYmZqbnJ2en6ChoqOkpaanqKmqq6ytrq+wsbKztLW2t7i5uru8vb6/wMHCw8TFxsfIycrLzM3Oz9DR0tPU1dbX2Nna29zd3t/g4eLj5OXm5+jp6uvs7e7v8PHy8/T19vf4+fr7/P3+/w==",
             "lock_height": "0"
         },
         {
@@ -96,9 +94,7 @@
                     }
                 }
             ],
-            "payload": {
-                "bytes": ""
-            },
+            "payload": "",
             "lock_height": "0"
         }
     ],

--- a/tests/data/Recovery.blocks.sample10.json
+++ b/tests/data/Recovery.blocks.sample10.json
@@ -101,9 +101,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             },
             {
@@ -174,9 +172,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             }
         ],
@@ -219,9 +215,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             },
             {
@@ -244,9 +238,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             },
             {
@@ -269,9 +261,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             },
             {
@@ -294,9 +284,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             },
             {
@@ -319,9 +307,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             },
             {
@@ -344,9 +330,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             },
             {
@@ -369,9 +353,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             },
             {
@@ -394,9 +376,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             }
         ],
@@ -451,9 +431,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             },
             {
@@ -476,9 +454,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             },
             {
@@ -486,7 +462,7 @@
                     {
                         "utxo": "0x3c43dd733130dd3c3136a6691a14e5e30d0a93dc9ec0112bfbb84637fdb78713468b8cae99905993569080f90a5478312d6446e2f89e15f67b10936ee002f9be",
                         "unlock": {
-                            "bytes": "YYHcuRbOh492ldr1gzhJO40BtBy3aselK8rNBfNHYgRbkIv0GRczF3dwYMrvf1uoaxDK7TuE9JiIthW4V8ltoA=="
+                            "bytes": "tCDkfqYlkepIDxSAFbOnVLHNCh2zlrf0U6z3UE8GEAu4GwZqR+isoR9iQFB4Rae3J5qf30yqZLqDCFt3p9G6rA=="
                         },
                         "unlock_age": 0
                     }
@@ -501,9 +477,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             },
             {
@@ -511,7 +485,7 @@
                     {
                         "utxo": "0x2616febbea6e01019b104f566290e055d006d26876d271fb46fc35bfba350f844f17b0fd8509077240d64f3ad373b603299750bb71bb679f8326028056f341b9",
                         "unlock": {
-                            "bytes": "d0/gbUwyUv7DhOPkNc9IfoqhDpKAeZaVGZI9SPtJ2QNrUHLjTjb+ughUw8yLqZqFjwnTDL0AoeTHXgrM+zibcA=="
+                            "bytes": "MbNpyuEcN1G9Bxr/H3rOE0a2C0rtPPJq/3pk9WH2IwqEKfYYTAxViVo3GpinUwoS/VU1wGfDjMRLAI1/IWkB7w=="
                         },
                         "unlock_age": 0
                     }
@@ -526,9 +500,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             },
             {
@@ -536,7 +508,7 @@
                     {
                         "utxo": "0x544bf713d158c24df391ff91b1b452d79e70417adc706efd9b129ca3b181c2336eb0615733cdfeac014e6df022b7b57f48faa49fa66f8fd42fe9de0375fc2ba5",
                         "unlock": {
-                            "bytes": "xxZ6HFUfj6vB6Qx6v9ht2iTk/QdhakfR04Q4Un7ACwnct6omlmX3HWTiG1k+baU9JOgru7ixbSpNvpsz1iZ9Mg=="
+                            "bytes": "4OVzVF/0xuATHJL4qKkIR/62NOgerZBMbTDgG9WV/wt/3xcF3v2C6keoR+o2sUc1xTCI2H6VRAhgQBs4PbVVRQ=="
                         },
                         "unlock_age": 0
                     }
@@ -551,9 +523,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             },
             {
@@ -561,7 +531,7 @@
                     {
                         "utxo": "0xdaa32dbaffc6c2ad3b78605922580a80fcb20ea74b7d19168450ffe130c24f0f83ed141c9190868de4befde92fc151ae536de68d41b14295a97062416288f2da",
                         "unlock": {
-                            "bytes": "1FddW0dLAV3ZBqiZKywYo3yB3MHBL4HchXJI3MMNhArIVEnj04uXnIAEGYXHGUCEb4B0w0oEFjdkwGleejLDlQ=="
+                            "bytes": "nR8X+N/gV73Fgi7jSEcfpjaVSmDHgNLoMdx+ix6ojAuMOsL7sv8MCIdWd8Z0ncT7VJ64n43zF1OdelNIX0vSug=="
                         },
                         "unlock_age": 0
                     }
@@ -576,9 +546,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             },
             {
@@ -586,7 +554,7 @@
                     {
                         "utxo": "0x6520c9d8c04709d78ee3a0745a471997d141717a397f27570ad1de95f05efb9ec9fea75589bae674cf332be213113eab444f625d24b70e725475eb495a70059d",
                         "unlock": {
-                            "bytes": "J9XQnvEcXr1v4rXuh8y69gmBAZfDww6mvYpnSk+m/w8CS5BoHqpY0nnngmQi0nXl1UF0tJiSAOn4TOv7NiD1MQ=="
+                            "bytes": "jSD94rQ7OlX1woQJc/SgyXWKOE4XAc+cYtpf6/rf7wmSHU42PbuXWnAkgFTZC+vu3Vk4hKB+vfL1dmy7YjfEBw=="
                         },
                         "unlock_age": 0
                     }
@@ -601,9 +569,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             },
             {
@@ -611,7 +577,7 @@
                     {
                         "utxo": "0x9d82aebcfeae95f70d84e955b8484c2c58e3d58d5d3cb7ca749e4cff14de018987836316aa21bc2f2ffc7270b90ee2c7810687b6bd6e8bf8eb66212c13a69d9d",
                         "unlock": {
-                            "bytes": "TMimx70dhgIutHgUoEwubhhOOKwYRiUV3I4RmpIVSQI830ll6whUO79W8obtvj5SSP9VVKwI3ZmbzJJlhrXE2w=="
+                            "bytes": "D/tK6q1//jG4uIdox5VWNx4cM3ksfqs4FBZUdSt9GAZGSypg3gSb9BPTFl0Kl7Gvnarm6rvOq7WBQojVNT+6zA=="
                         },
                         "unlock_age": 0
                     }
@@ -626,9 +592,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             }
         ],
@@ -668,7 +632,7 @@
                     {
                         "utxo": "0xd08da4d80adcc83e487fe9bc46f34a666c1daab840723d43f88222aef7b61f624632cd0ed299c8172260992f5ec769669cc4a4bed973e2d7585eda1bea5ee474",
                         "unlock": {
-                            "bytes": "Z1iBWcRWyKvZgA+S8iJHBML9fEkF/VjNwIRRJz1y2ged10HYLpopulb26hoI2hiRhnf7MAq05fGXg+JnBIRVdQ=="
+                            "bytes": "JiKR53a1Fs54fDJqIjv/2wnXqltmaqpJNvMozJ0jiAntheGC+Q/Xf01CEYl8ziPUVbRn6gGX4rJCab/TbdzghQ=="
                         },
                         "unlock_age": 0
                     }
@@ -683,9 +647,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             },
             {
@@ -693,7 +655,7 @@
                     {
                         "utxo": "0xe72f4605a0acf6ea61c6c491e424e3bea45146ff8cdaccc5937ed7316886ce7bd723381cdab3826a7103ebfcc5f37a0092f0d2521a7ce5b95090e4a923cff143",
                         "unlock": {
-                            "bytes": "3hqv7hRSzb4NRchKQIBW0tdPmqUKQ8+JCYqHi78tcAekOGojVnmN+GXZVTScG70DmeOJx/xt9ncaTErO9DCSZw=="
+                            "bytes": "UdQkY3JjIzhhVvxf773nQ3r+I3oYwaBUSQGsKGahIAwoiHbX+7n9jH9OFaApu/IZwaHkZt3QkK8EU4nQquRYuw=="
                         },
                         "unlock_age": 0
                     }
@@ -708,9 +670,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             },
             {
@@ -718,7 +678,7 @@
                     {
                         "utxo": "0xa80e7a1f148008c0dfe5e25fb3401b7e957646f0ae86a6621d3194abba712a2def47d23cba5340c9ad0e84f00cc4785b915f3b2ce9c0704a670d6f02bd605303",
                         "unlock": {
-                            "bytes": "1wOaONTNAL3Ix8s9otCVm+mdCLDkCJpboIO9QFERhAORAZVrEHY1JQnuOpOB+gmFQdhGDdcEnhqJCskRNc2ikQ=="
+                            "bytes": "eU42SJhcMlED8wfxCW4dK27nrZonH38DN8u5YshWhQ0y/CdQaKJ7hZjS8InlNWBWg5eMRvCbbFRueJL5nPn2Qw=="
                         },
                         "unlock_age": 0
                     }
@@ -733,9 +693,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             },
             {
@@ -743,7 +701,7 @@
                     {
                         "utxo": "0x352bcc14b7811ec1e79730f920bd79c5d0c01d07bb00ff2c19ca1266f57fccb117f6fb9737c3d243b858fe6a528082de5cd7192486878449fe3a7fad0a7f4d3c",
                         "unlock": {
-                            "bytes": "mFPrbVzqSLE/eo/z+SGa0kzvJrEZyU+WXyBwRJXpEAxfWdt5Lru8yBw7BUTYPsPHUi5Qj5RBRXh9As4KsNjNog=="
+                            "bytes": "P8B7EhOsQyRfwxg2CDiFaYYlSst6ch4BUdkxcwIg4g0tiy9wKsS5oNIhTBhwwsjPTSIqLgYEM15ObrJ9vJjs9g=="
                         },
                         "unlock_age": 0
                     }
@@ -758,9 +716,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             },
             {
@@ -768,7 +724,7 @@
                     {
                         "utxo": "0x35066061001a9d2dae1c01f92df3fec9f774713ee31b0345febb30eaec4dd5353221061ba9e68ce98a2c4389567fc49296a0a9c97576799ffe228c7c1afc2e3e",
                         "unlock": {
-                            "bytes": "USxBvT57kCqGv7dYEmzhy64ulbj6b10O6u4KZZ4KcwHi/xG0pjv68MXp3RITnH/zCv5w/wRRHOEqweNSzOD5ug=="
+                            "bytes": "RLF4JmjD6sVpNGzXC4Ave+g8OvYcxNbcVCEPKfQohgO4XBL4Hkvb6uVWBefMwU2QZ6dgyH/Rs79Iq50Fpb7AJw=="
                         },
                         "unlock_age": 0
                     }
@@ -783,9 +739,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             },
             {
@@ -793,7 +747,7 @@
                     {
                         "utxo": "0x93e2fd3f24aa81f2beae4d3f9f2cfdb8bcba32d0c5694e9c5dc60fab0bad026ca335b918a794e5191c784e6eccebbd4c0ba4c6a4b34a0e2ac6bd8af48df29a06",
                         "unlock": {
-                            "bytes": "PLQ2Epiyf8swAx5oBq/eWUImY37OKBcg2OKMPLieBwX2iNWXiS9ZwOcULWS+iGuvA3rF7Su32hOhkCbAxSEb2w=="
+                            "bytes": "uXVcgWzq0Jz5MQKvv+X7wozLdDBQhcGjgcsy6AbKgwF+5YTr2M13EV96+fX3qcD79726RL13Vk2mLvuXHlu4Fw=="
                         },
                         "unlock_age": 0
                     }
@@ -808,9 +762,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             },
             {
@@ -818,7 +770,7 @@
                     {
                         "utxo": "0x12b8a2a28516e77a7e1e653120a3ba4747810de67e93a20ac16f8a1c23347a1b152423559f321f3944f3940781e5f7a2a121c629a25bf554a2e9d3f867ed24d7",
                         "unlock": {
-                            "bytes": "hHFaHJ48kpvOrfCZyO+QmXHLs1xeyq5PlUY4EPvECwnjG0dIKAJ9mwtpc4fZgautxKYaaYaFXd1It7QiGi6+Xg=="
+                            "bytes": "aGuxpG54bXvVptTFlskQGCuKMZ1Iz1wlMHX0xPupygHHmpmtuw9J7pLTA7h4cHizW37qPLFXYuKScUhXdGkT9g=="
                         },
                         "unlock_age": 0
                     }
@@ -833,9 +785,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             },
             {
@@ -843,7 +793,7 @@
                     {
                         "utxo": "0xc1b0be3cb1af257d0c7233f958223c0e9325532ac51cd9c1467ccb746b7e960b37bfaa4de94bf437341abfd025c0661cc61afff8baaf4285fe412c69ba2f6258",
                         "unlock": {
-                            "bytes": "mQr1yMzTbR+ULrl3az3QIdnrt/Sfluu1UwtM503oZgJZkWvMGdKiCSeHcxMlkRfKvPAuFA92VPNJ0IduxRqMmQ=="
+                            "bytes": "MirfpRVetNmflGJM53f5xDPyDvcSEYdfS7VSVh4khwbdnPD3kOf+Jd07IqLvShn75/sRKkzc2EStgL/fLNlSVA=="
                         },
                         "unlock_age": 0
                     }
@@ -858,9 +808,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             }
         ],
@@ -900,7 +848,7 @@
                     {
                         "utxo": "0x14a47a5bf3d4c4313b6d90af89cf73b6d2879f03345623c11fd709989e51731aa11197b5f92115194e7f1f79ecfae61ea83501d14bf3bf4f6d712dd32b6e95d0",
                         "unlock": {
-                            "bytes": "dBYQLTo6UVF3GiZGJfLXAyb+xHpA3wBH++qS1bzPIA4Bt8Hz/B3KfLmOG/ugsPpE65EZy1WLUKjSDZpzDC/RSQ=="
+                            "bytes": "mD3j9e5IhqhObA5l1OGYXoAVyCB0Pj6w9G26wBD3MASneBhvZmaZUBt5ER6aV0ensnzAKLzyvAAamZjIBS21cg=="
                         },
                         "unlock_age": 0
                     }
@@ -915,9 +863,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             },
             {
@@ -925,7 +871,7 @@
                     {
                         "utxo": "0xca53f4eccff25f4a6bf586b4e37085dbfbe6d02a05c17173588bae6a66cb3a10e2ebb9fb4223f37f1b65d478d1e597c560a532fb0effc9a488827f9e8e795831",
                         "unlock": {
-                            "bytes": "gu70t4chUNVfoV0IrpVngm07vhctGAotPE+uuf60aAoVhLJqgOE5HnNXLobUu7sPjARNyEflQJIdEJDtIYOsng=="
+                            "bytes": "oVdOFVZ3KHiQHpj5m0VLOeday5HxRRu8tx/rXzYcigWvS1LH5A5zbmSCPCVJhvx/mblpTzcTLXM27HbB6o8DYQ=="
                         },
                         "unlock_age": 0
                     }
@@ -940,9 +886,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             },
             {
@@ -950,7 +894,7 @@
                     {
                         "utxo": "0xc770684c17ed65877a942e60644dcd2bd4469f6898e0361184db5f05795313b41fe3b6ecb331336f715f328b604a824584210e95aa28f0cf4ecba1678fa8027e",
                         "unlock": {
-                            "bytes": "CLJCYbyqNW1tlmZRd9UxgysYdyhuWeNrZTyfuLaG7g/l2tsP/avgWRQye2hBh1LewUKdfGXZDtZTTkHSZxeMcg=="
+                            "bytes": "vmd+1CrtmSBBHBU/5qeIQpFSSe5HIHZJM5J+BiEkIAVvkOvGj5jml78VcdOXrYRt0xr6aixs90iLzQPUWT51AA=="
                         },
                         "unlock_age": 0
                     }
@@ -965,9 +909,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             },
             {
@@ -975,7 +917,7 @@
                     {
                         "utxo": "0x26745786615f86065a3327ead851821d43da9a1ebe33a75ab583fbce66e1beb417c2f922e6013f86f5de6fbe0285d2b9920be8d4f1402c28332de2e72e1d8e5a",
                         "unlock": {
-                            "bytes": "7HS0d98i2WPlkUwh0lRwSoQYSVae1MTzymSe0frauAoZ0KxzyQMDvk5EDG9COzKYFB26bcGB4iz/bNGHIzGd7A=="
+                            "bytes": "iN4xyPN74XUM3ue0oVQFs3Im9XfdoWZq8DQZvsNcAwIB9+a4ON84ho1ceOPEVS4T/3cvvhz0RcqiVocbPbKxgw=="
                         },
                         "unlock_age": 0
                     }
@@ -990,9 +932,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             },
             {
@@ -1000,7 +940,7 @@
                     {
                         "utxo": "0xf55a3d8c3a3709c51a243854b2e1b4d95d0ecf0d3037cc81d98c9931926cce87535b590b1d309e7ee39ebee90e66eeeca7d213c7882ff8756478f4d5f7adcfa1",
                         "unlock": {
-                            "bytes": "W7QKJc7Y2L3SGZPyN80H8lFATH/UcEm1yi5TvpGFzwak2wVDkKf0yYZx9qruHkdaRzQ8gIiCxjNyJx0Q4qv5GQ=="
+                            "bytes": "rFjNx0kZ1hgzmzhWypltToy126Ji4MV8Y+RJ6ExQ9ArLBX8NzmxFtvCEGImpEgm34RTnmTqPUIMYAoVuQuDPZQ=="
                         },
                         "unlock_age": 0
                     }
@@ -1015,9 +955,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             },
             {
@@ -1025,7 +963,7 @@
                     {
                         "utxo": "0x614cf2ea0874889e4cdcc304f7ad9674fe49cd0f21a8040d623f9dca9fbd3375d64192621fcb49be757401efa84f9d1c6beb7ebe7944c55097e1865a5ca2cc9b",
                         "unlock": {
-                            "bytes": "muJEZaWseo2F3eezO/WM0ezCF7ywpL/xD+Mo65YGLQaHR5NtUYt7IsYM52gPKZ3dCK9xpvTsByIUv8syMncaig=="
+                            "bytes": "UQ26NJgmRekQgKSJ6eziwqE39lY4+RLFecJqKjanigBHr3Ax4P0e6wZ42fNi+v9GlcABK4OaecnObF2VdUsEPA=="
                         },
                         "unlock_age": 0
                     }
@@ -1040,9 +978,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             },
             {
@@ -1050,7 +986,7 @@
                     {
                         "utxo": "0x047f99e01a21bf561a1883ee47d107b2ea4c4f710f07b3fe4bb82ef6633a796fe2f141ce96beae4159efdbc4d20f0c194d54b1e5d93fa6438bc218c4747badc8",
                         "unlock": {
-                            "bytes": "D+IVBZgvYKdXpWQtMU2xAxy20J2WYHcTUJybvZDSSwREfontk1gc53dmbdr3NW/WeAlSM9lX4IU5hGbaHVIWBQ=="
+                            "bytes": "mTTHZS3RQ1riZhjjfcAK2N/rd6Vryg7auhiZmMl3yAZXfWPazapLyyoSs0hzMv+4OSC6qqJjhn22ABC2z0QqeQ=="
                         },
                         "unlock_age": 0
                     }
@@ -1065,9 +1001,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             },
             {
@@ -1075,7 +1009,7 @@
                     {
                         "utxo": "0x50be030556c60ccf48c8a215757d726ed956487bf898de36cbe57c483394814b874f3714f5235afd58c4f9f3db99cc110ebe6a8bb8a28c7d00380445ceadb07f",
                         "unlock": {
-                            "bytes": "RWQ7Q6+IFFGhzAwoIZTCqZqMvwbHkUuu+HPl2fKaSgYNHSVihDtTIs3F/v+4apqJlC6zsjn1IdVO9UgzWgT/Kw=="
+                            "bytes": "mQqzNNSRka6vIxT5wKoZ1fPxW/nkMIyWLC2uDWknLQwQ+NukgbVO66LvKC2ek8/4WnQum+KhBb2EDHNqL30HQQ=="
                         },
                         "unlock_age": 0
                     }
@@ -1090,9 +1024,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             }
         ],
@@ -1132,7 +1064,7 @@
                     {
                         "utxo": "0xe13244dcb3239e5269d8bbf14dad1fcc342d94137b916c8943d549353fe30548cb821f264fa5f5d231cd94615a140e1b719d21e9a7b5ae85a5dda371f70b47a5",
                         "unlock": {
-                            "bytes": "zRe85rbZ/Zc3VdgRVpb0vRC35U6u2QuIHY1jmBI4ego0h6rexWUl3BzMVjMFvr7otyL0UkmST7acVlNUoD4zmQ=="
+                            "bytes": "MRfE0++8H02+bfCvdf17gNQDIQ32bK2s43BQlAhLcw2mRk1FxDpNQlDIQJshCKkKpfLp2Pw79BzLE1KygVA5RA=="
                         },
                         "unlock_age": 0
                     }
@@ -1147,9 +1079,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             },
             {
@@ -1157,7 +1087,7 @@
                     {
                         "utxo": "0x842c057798b2a10486b3f9a9ff8749b73ce45573b6329ef870040660380ba783df33d0bbc39cec2312596145fd9174d53602f2854e4da68147a05685f849325b",
                         "unlock": {
-                            "bytes": "1fklVN2nQRFiPlG5FIESj9/cYdTVJ5QXyFmPVCLgeQtqcHemwu0Jg/5hPkoRuOb427yv6EpsNbuRVV6roNH4LA=="
+                            "bytes": "GFkORdbMkpPpOrOxQHCW/pBitxjnUgSSRF8+wq9yjw+GdkzWZ2QYVxBHmjUJxr77tCdT+doyppJL1jux5yWv1A=="
                         },
                         "unlock_age": 0
                     }
@@ -1172,9 +1102,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             },
             {
@@ -1182,7 +1110,7 @@
                     {
                         "utxo": "0x928bd75263d6215f0b27a51d193afc8876a1a271cffd15191b60228ec3e66599f070cc122f3685d8bf70aebc333e6f29cdb313ff055853d582f21294d1a7b063",
                         "unlock": {
-                            "bytes": "agj8QTnwl3t3RXzLtzNVaKnKAj2N5Crj9CKC5yYm/Q5SoltQ7IensuKC1rTK/Ss0CO9ILRuHpp7vyQZ6g35P5g=="
+                            "bytes": "PRWNSBIh7C2rsLVNcOCYjHAhf8suD+J/UirjydCFYAuRc4ETMplfWfOngPgOjFbbNq0Jrp0YCk1oh7RcGLF/JQ=="
                         },
                         "unlock_age": 0
                     }
@@ -1197,9 +1125,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             },
             {
@@ -1207,7 +1133,7 @@
                     {
                         "utxo": "0x21c536105163bb44d37aebff429337a3b73465dfa8646db8cd38f13e48caadd9e209ef1eda9266c68678c417940f3267014ca0d1cc05cb3b4bd33fb54851b851",
                         "unlock": {
-                            "bytes": "+Cp7diDTSh3G3pXbC35Y2MUeD0mrBEQc0EyAi93NIw/7wbY+LIJjcFVnc5Jy3oXV8Jmkv+Jk/jpSLK0WUo4j6w=="
+                            "bytes": "LYGtd1dGYdBjYbtgoMRlM8wtOvuDLzaEfLjYwEpOqgBL7ftaST9DJa83N4NfN014E5YMRt/gpvHHlJxx6wboAw=="
                         },
                         "unlock_age": 0
                     }
@@ -1222,9 +1148,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             },
             {
@@ -1232,7 +1156,7 @@
                     {
                         "utxo": "0x77c3c6273d50de8408f75671350aaf51050bcf9022288c38812330221271727a89f6044ef8b24af4f2eff4faf20c177a032e6f67f680f227f6d014c9cec16ff6",
                         "unlock": {
-                            "bytes": "mHv+b951YphYx1crn04rRgd89SykBzvYfC1V6+1ScwFW9aOr6wRx1SiRqdrR09SFDstEhVFR9Xy0YCOePTJ0vg=="
+                            "bytes": "nOYrbze7s6XrWFpP/n9EowJk4ilaX8jrcDA4l7pQ7ArmdvJT2RRkWpiF87Zkz86C2GZteSgrZ3TcvUae5eDqnQ=="
                         },
                         "unlock_age": 0
                     }
@@ -1247,9 +1171,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             },
             {
@@ -1257,7 +1179,7 @@
                     {
                         "utxo": "0xdfd3b01a7cf2c7928fe2f23bbe99cfaa6f54f4d03e6d20280421e0fb277f0033995307af3fa25de9c39b9b35bb981417fa0662de061bf55efca1bc16a0b834e0",
                         "unlock": {
-                            "bytes": "F60/cyzFrwt0mw4FN5Bxu1+3iCP27UBrpRyXnyKdUgHyKss3nUs87zZcde02c6j1kLVV2kX5d8sfvkUjIbMUBA=="
+                            "bytes": "WfB+/6yf7zFqItvmNABE5QKqEqfGMM0PhzFFaEvINwuCYrjmxJEtNGcmSKX2xJrF3wFcX7Y2xmzoj7A5/WmF4w=="
                         },
                         "unlock_age": 0
                     }
@@ -1272,9 +1194,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             },
             {
@@ -1282,7 +1202,7 @@
                     {
                         "utxo": "0x2fdc90428217487c412fb27841bd60f6cba82afeaf654b5b0a64a364ea649f373d719b30e8932edb822e06b4151834b68a363f94b7914b1e750a9cb305ddafcf",
                         "unlock": {
-                            "bytes": "5nQxHsd2neATzNGMJbFdaTI5/ClQFE2KbRe8v68YjgQ5VVkSnhTFjXJERN0ruyByDM8YgnsgIN2IDfYPwYCRgg=="
+                            "bytes": "UfjpIK2GjqGj4xKSDQz9INGwc7x072UsRUdrquhSsg+14NDZW6hGQnVrjB8Rr6I9lfp0iDcdPGVQFUDHDFC91g=="
                         },
                         "unlock_age": 0
                     }
@@ -1297,9 +1217,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             },
             {
@@ -1307,7 +1225,7 @@
                     {
                         "utxo": "0xfa0bc972ede527b33b869e7fe1693a104dc4d0027ac646a6f923f37a2a8ee13c31ef8e5a0431dfa8ba12f4e98d851bd7460ee666bf76ba14591299cc4325a0f1",
                         "unlock": {
-                            "bytes": "J+DKMC991WVI1+ESGwtVIIYhId0hu++twoHZHjRv/As/1sFp9c/XQ8ibhSPzwqngIf28e9fS6mpQKR1dAj7zUw=="
+                            "bytes": "Z+9sJr3ynHdtRDrpjqnPP7dQfdwGdSURPjPLF2tKJAZz1mMGsKPDXbLMfo0bqx8HDezCyhHbFwVUQzEbmXeKGQ=="
                         },
                         "unlock_age": 0
                     }
@@ -1322,9 +1240,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             }
         ],
@@ -1364,7 +1280,7 @@
                     {
                         "utxo": "0x6f797dccdfbd57ef10c9671ba2a695171d4234b4960c7efe4798e295b23c8ed7f9c0eb79c20008784ae742a6db01f320dc49db76c54a31dae411a56b11eb44f6",
                         "unlock": {
-                            "bytes": "NGoTlLFMIEzOosY2JCjE43C8E0Y5bcYRtYPODi9T+gHmiY+3SPevKJkDb2Q+k3mdIFErgq0XRc7J9Ss7udopew=="
+                            "bytes": "hswQRyOyy9e/joqqjpuVCbvI2JNvnC2YHBpoEJHIUAFl6hSVtwh+yoy+Fops9cGqn5elymIaq2NEYOHX9VhudQ=="
                         },
                         "unlock_age": 0
                     }
@@ -1379,9 +1295,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             },
             {
@@ -1389,7 +1303,7 @@
                     {
                         "utxo": "0xc3ae6c0138c3ea7e713b0cd48306d89ded5c5af190750d5c713678b20bd12728b76aeef4fc19f6c90b52882d62f5f277f666e472e173f26fef2220346e3a9ee7",
                         "unlock": {
-                            "bytes": "QucyF2OQA5FkWqxmsX9M1YY7M3eqzeTNHt/5iZcMwgRqEqza21z4rK2thKudteUEGYa0QbWMWaese8j8JLXXgg=="
+                            "bytes": "K1Qv+5jtPZfHWUma3qmqYQPCQ25+GnQ7HgN83/DlmAf2+Z+zMNl4yKsjBMpOkrjN+vyUOE3zbvr+1MtVckXhzA=="
                         },
                         "unlock_age": 0
                     }
@@ -1404,9 +1318,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             },
             {
@@ -1414,7 +1326,7 @@
                     {
                         "utxo": "0xbf0bb6e8876e4c474a37bdb8ecae253db6cd1a2be94b4a97a587671b75d927bf9afdd5065f3203c0757377526db97b7beec351753d42f12d696509c2752c19c7",
                         "unlock": {
-                            "bytes": "uE5uaYV38VlrTzi1GSmNszXZeAYKkKHAnQcVWl3zVAKwmI9dvVSg6lQxXUGQ9k6olX81mL2e9IiGtOtWxxzRBQ=="
+                            "bytes": "TN0CEJn5AwlAI4N5qXagQkEPhL7qZVzQj4cQB0NcXgvFRrL37A+l/g83aBqEYyat6StDqeEl2ctC7mSUuZ7Deg=="
                         },
                         "unlock_age": 0
                     }
@@ -1429,9 +1341,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             },
             {
@@ -1439,7 +1349,7 @@
                     {
                         "utxo": "0xa9fa9f5478b26adfd00d38a5274dca79178fabe70f0cb4fa8495a8793f1af26e6289c772b25df7a3e2ca76596c5e324dbe57a7f6ad1cb27c4c5aca5eca93607d",
                         "unlock": {
-                            "bytes": "oIgL2/mwNpdpFPZwFU4KgAbDFtfWQfakYXlXHEQLfAu5Gg2mLx5jGPUOJKj0QzedVygfWgb0cM9QvB7hvf/xIQ=="
+                            "bytes": "Vsl/bWohQWrcJqKNd5PPdhXD0b5vWJj+bIN65c4QkgThiLL3MAN3XUI4LzzePPYT0R1cJxNGeU6W2gXqmjuA8w=="
                         },
                         "unlock_age": 0
                     }
@@ -1454,9 +1364,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             },
             {
@@ -1464,7 +1372,7 @@
                     {
                         "utxo": "0x60f9b578fec9652f9048e197c4021392bb800c01c9f5603b51b60bedb594a5bf708a38b2622f1d76c1666f420f1c7d50bbbde56d1eb0ecef5c57480f4731d10b",
                         "unlock": {
-                            "bytes": "mndFOflCx7Wul/ttyb93RQlk8LYp143z63BOGfR87QIfhBZk6J4SXf0hcDOm4f9Ax1EP0kLBlyCuaFMzaDLxLg=="
+                            "bytes": "o1qfNr+rv7ce9qY8vk4CZ/0dyrf1xLouDKua3dEA2Q3U5+tBAr5jQKWL0oLyRi0KpvackK6TM7sHOb8WjhS4Ow=="
                         },
                         "unlock_age": 0
                     }
@@ -1479,9 +1387,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             },
             {
@@ -1489,7 +1395,7 @@
                     {
                         "utxo": "0x9664919f5fcd5a101f0835cadaf7e6c68caa019ed8a28d4d8999090e83adc305385c2a2d26f63180d0b951a7c98e043d937accf9dd4248a23cf3832dd5e9034e",
                         "unlock": {
-                            "bytes": "vK9TWaUT369y+LB6jUPb0xWe91It0ybl/WdaSQweOgRHmJPC9qqwUrq2eto74gaQYw3qVl2nOS+beclNpI64/A=="
+                            "bytes": "nTauGPl/O5a0cIWtYD/dbE/bJr/RzLSUERPNCUY1YgzYhXB8GBMpxZU9Iyoskb92BC7CaSLBSTGAhHzCYI/aEg=="
                         },
                         "unlock_age": 0
                     }
@@ -1504,9 +1410,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             },
             {
@@ -1514,7 +1418,7 @@
                     {
                         "utxo": "0x8721d7c51641ac8ddf070d3756eaf9f1f2025abef2614349988eedc90cf54cb86527505428f683adbfa47f66f6b826772a05ab55b475d38b8e3a5b516a68006c",
                         "unlock": {
-                            "bytes": "YppXsEJSdQO/wzSrId37APqqNAAe5ujCuXRR1ZO+3gYH+9L2Hl0loY0OTR8K1k7C8J8DyJJrpD/7YbcMZQj10w=="
+                            "bytes": "f/CHakopuPDx4lP2drScCBsgx0FKPEuXNolBaD6xGAivHcnx26U0ZF2v1f0kLGxt8yYd9VK0Ufs9kKWKMOjbIA=="
                         },
                         "unlock_age": 0
                     }
@@ -1529,9 +1433,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             },
             {
@@ -1539,7 +1441,7 @@
                     {
                         "utxo": "0xe8e85385a8f64bf49fa749aa92d4371a2961b49c14cc4e889ec7fb6834f99375f2b899abd6aef3a7420002f3fdcdc08da6d3949ba97270406ba0d4a3ff5ee0b8",
                         "unlock": {
-                            "bytes": "3LZQlWAP4YjpvBR3uT6hqvke1Ygnl7Gnlk/XRnJckglNrSDCaG02JX7M4ZZ74y5c3t8OpTYVd8Ft8VqGcP3pQA=="
+                            "bytes": "xdYU0gbvJ7W0Yu77OyXf80xdhXiEGMOu9IqAvzYAGAGzsl5+IjDk4GzdW+jMetI+Io2VYWGGjaFJUNgRtqZfrg=="
                         },
                         "unlock_age": 0
                     }
@@ -1554,9 +1456,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             }
         ],
@@ -1596,7 +1496,7 @@
                     {
                         "utxo": "0xd638d9c993109383a2adf4227d936b2905a84f32341341ef9efa67a0a68bfbeda86455a536835e8ba39036d8c7e0ac176a262197f0d5498700a8bac5843c00f5",
                         "unlock": {
-                            "bytes": "7TA0be05K3eXmGv73VqxbArpXHFp6wvq44HwGP3uXgfnRS7jAOPOvC9JsreWkfdXSplOawJYLmYhHahvTkDHQA=="
+                            "bytes": "r/I5VzgsL7pVeZKJOcoecncVr7+x/yh/uPehWydv6AaG7Vjt+pvTWxqqOLObZUCENIyhlpCu+2BMGj6OKFs2wA=="
                         },
                         "unlock_age": 0
                     }
@@ -1611,9 +1511,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             },
             {
@@ -1621,7 +1519,7 @@
                     {
                         "utxo": "0x6454cab6ae4071e6bd3e72b13cae252ab98012744d7b11dc94edbeb9d62aaa217224c142415ffa8de18343957b3718a1fa9d9a6ce488d36b61a375faaca13b62",
                         "unlock": {
-                            "bytes": "FbtKieoZ9PjzA8TiXF8AP9Usrydq/t7VYhUPIz9xQwT7i5yNjCHsqjfrOoU5d3G7qLt+Bo+bYXrGOc7LVanx/Q=="
+                            "bytes": "A92JIEVV+Wxm7oAfDBkeFKkaBDi9o+8HyU0MtQqmDAiiPVDyGIsQkQf4OBJS+UL4gbcrxxTf3eZmvXAEWytNkQ=="
                         },
                         "unlock_age": 0
                     }
@@ -1636,9 +1534,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             },
             {
@@ -1646,7 +1542,7 @@
                     {
                         "utxo": "0x61865aa045abb39562e22dd9a2de01616022747bd250d4307f57d9db8833ea38861cee47fc01c7cc6405697319da277b318a8d64eaa391afb250a6898dbcca15",
                         "unlock": {
-                            "bytes": "b9wrE5RUtgQYFCLawPMlBDCS/8ZttoOCl3TDfVlmnglwNTPNSN1FIy5HHqjobN4UXNolYwxcsf+zTV7R1cmsLg=="
+                            "bytes": "ynhLWe55oOumNCwe2uyA9VAopcr5Os8N9BrR+66vGQTu6VgFLpWzgXEaJiB+At5IRFu+wgZaGwNDkoxXny308w=="
                         },
                         "unlock_age": 0
                     }
@@ -1661,9 +1557,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             },
             {
@@ -1671,7 +1565,7 @@
                     {
                         "utxo": "0x907ce71758df117b9b2bdb1a3dcf8d6d6bdbc5c74408ffb18ecd92e702e591f7da3848388dba8bf563eb058dbe43699aa32d296e5f1ea395051d8a1450c4bc66",
                         "unlock": {
-                            "bytes": "NBEl3antjxfPNe5kfKo5r1uUKlbfyH9gSI6ufmHzJACXR4ZmgaUZMS640oEQUCf5zhy/FC0EX9NyklTZbrKnLg=="
+                            "bytes": "xAAj5xFbOI+OlUrs2QGF+z2dTbbvgOA/hJtq2unTqAGlGXT9SJFLOLypg70i72cXzvNHVNW3wgkYrhE/O8vqtw=="
                         },
                         "unlock_age": 0
                     }
@@ -1686,9 +1580,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             },
             {
@@ -1696,7 +1588,7 @@
                     {
                         "utxo": "0x6ec52911444a41ac891b7752e4bbae5bc47fde7f19c3c0c1b473da5856b782ed74d893e7a875ca0c23e5a7f70550a83766c01384292d2eb9943d02e386956785",
                         "unlock": {
-                            "bytes": "P1Qs6MgsPFvw8O0kvatIW7L3XimyEy4qhERVbEr1lwNd3pLJKd9IM2C0Yx/X1XIFGqea3jAL8HpiRKNb7Wi2Ig=="
+                            "bytes": "J4X4hBY5h66OuDk1w7B4JizQlAVA6xV0MlAW12V7rgeW9AewUHMdhfOzc7liXRrcMT2FcUjaysMaVJY8+MUPww=="
                         },
                         "unlock_age": 0
                     }
@@ -1711,9 +1603,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             },
             {
@@ -1721,7 +1611,7 @@
                     {
                         "utxo": "0x04312cf5bafae55a11b2867105ad6cdbb3df2910946a792a037a487397dd101b90293915cce8a1ab50bc537333fbbb73b79b4e22c56f6490694b5d47b269073b",
                         "unlock": {
-                            "bytes": "CehmM08tf0oywhRLy85ImR0oHStaEL7VSU+OrIxoTwE71P9ix1J3MGsmWR/WC4MJLiFOjiEX7NX4rkrFMeX4Xg=="
+                            "bytes": "H9xFUIDSIrEi7tY+/ZGuOplvF1p4+dauKxw70Ke1YQoUje60z4ycwyIlXlu6Xfd17yHVbTTmJCQ4tU7szRXbXA=="
                         },
                         "unlock_age": 0
                     }
@@ -1736,9 +1626,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             },
             {
@@ -1746,7 +1634,7 @@
                     {
                         "utxo": "0x8f31aa70682601c9fe391af1392ce3c229d9b3bb29a9c921b77d8c3323753138f2067b15c1dfb6c01ed40ec355376926b4ee0e0ceb5735678e644ffb5865269c",
                         "unlock": {
-                            "bytes": "7/uEKiUAiajiwYPFLxD5uzBoPA2Tr6aBBMaamtwSDQgEt0pAx42sz9TwvW5nvPLpVz3fhkYUdALM9adtM40ZDg=="
+                            "bytes": "H/VYqCMpqR4n6HZNqwwNiOSBqQ7Ue4JBz/Xtrx6wwQ3ZG9Dtqrjlx90weLR1bSOnFRe0aIeR0YpFvnIcFKMq9g=="
                         },
                         "unlock_age": 0
                     }
@@ -1761,9 +1649,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             },
             {
@@ -1771,7 +1657,7 @@
                     {
                         "utxo": "0x5fd0b5e93a3fcd0a12a24589e35d9c308cda7c2ad418399501acc8baab89cf7d03b767a1ef82b54ed7b27170a71bfd17cd0d4c31cfba2011dc2f1fa44c3e0180",
                         "unlock": {
-                            "bytes": "TbmxCFlOsGJnVURSLLKd2YvUs+PiEcKyK/lyWJ7PLgLBopLkhvvrlVjC/empeqEerl0v6bsRfdUwc6Q21NnqvA=="
+                            "bytes": "4LvgllQ5CG2wti+wNmCUtHzMzcu6J61D1UY8LVFRuAQH+uMmgPxMMAaEJSQlQ9qwDPP4ZfVsEpuuvss3HvzR7A=="
                         },
                         "unlock_age": 0
                     }
@@ -1786,9 +1672,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             }
         ],
@@ -1828,7 +1712,7 @@
                     {
                         "utxo": "0x41651fcc9ec8be1682c85ca2dfa4e5c78b847bf5b11780e9e9730a3e03b3db293e8381e74ed021399b272644acbcfb0ffbe9d6d2f188a66314dce331d1081ecb",
                         "unlock": {
-                            "bytes": "JYwdC+JmVOGCTi2MBQwFu7yBSUJJyXtGBxUcgRxoTAsGlwWGMHEYXQ1lT/WZ7OfCb8QCIVDrHrIn6k7KP+ujeg=="
+                            "bytes": "fiT9Du+9oPwCk8NitiJiq7WcNpa7ZI+3ZdsCsDfQ7AXz2hfVsN1WUe3+Q4+2YdhndL3akIaYMU5f3TEan6JCmA=="
                         },
                         "unlock_age": 0
                     }
@@ -1843,9 +1727,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             },
             {
@@ -1853,7 +1735,7 @@
                     {
                         "utxo": "0x30a340032a5f928c7b780d775faba1c04b3b5f57fa85f85bd56a1b6d527cab2a7044a7487ef908a6e04d5818fa01f59e9a306f3c96189e5653c48f0a5242faad",
                         "unlock": {
-                            "bytes": "ClPXj9bA+L3yFn+N3lJR5eepH0QHnQcz5I0sm9NxQQPu0OyLU4cmJQ/u07MnFCCpXh8Y6KKsYc5kMne9lxizZw=="
+                            "bytes": "2MY3PlsfKc9+57IlcPKizhDSsK8wU18aFeEgc3lKYAhiDZgsqILoEbSuBuM3BLdTUP0lb8gVkx4Gfwr2wMITgg=="
                         },
                         "unlock_age": 0
                     }
@@ -1868,9 +1750,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             },
             {
@@ -1878,7 +1758,7 @@
                     {
                         "utxo": "0x5fb505f4b5fcb807944fcda42a2ea7b751ddedafe699632ae64e686f6ec223e6ac20abe65ff06ce862dfb1114c3352167b11003e0b9dfca4644b52dbcdef6445",
                         "unlock": {
-                            "bytes": "6XYAu4vAALXovhZyfa1cADHKumK/4fD8Su62yDByYQ+2sDPDTqyRwFmOP6Oo8gd+O4THsituMBIzOFVUuMqs2Q=="
+                            "bytes": "FtRsyJILo5s/2QnRxxoeOYeSvnGiaAcFXf9oqPiK7QYvO9BZidSWslkgQRAWlei1porov07L7miP8nv0dY0mHw=="
                         },
                         "unlock_age": 0
                     }
@@ -1893,9 +1773,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             },
             {
@@ -1903,7 +1781,7 @@
                     {
                         "utxo": "0xaeaf862546bce69f9c0f11e70a78be661ad8f35683f3e36128851f40637d09eb28f3678c59ce4d2773816be7f850458983a3bcd8098f289683da95ca4096dbd5",
                         "unlock": {
-                            "bytes": "FDw023rA6SNwe5/GPgLhrKbPHd8FtgMbCERKrK8sGQXftsWz9wyyfs6yABXck+qFu6zoiyxVcci/fGSiB8UghA=="
+                            "bytes": "UjcihYBQGp08GHqAysV0XUj6emMAdk6dh6GtCfx2TAWHy+78cwGr/l/WB6QQgEbuKUN4ykRnzAPVcYzNDgQ2ww=="
                         },
                         "unlock_age": 0
                     }
@@ -1918,9 +1796,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             },
             {
@@ -1928,7 +1804,7 @@
                     {
                         "utxo": "0x6daef51a3fa11ce8c1504f1957e1d17673d1e6cc78d45b63d122148a42b2dd060bdae5ee3b07d8b430f678716f20333e016b68b323920444781cb3d236c0b0cf",
                         "unlock": {
-                            "bytes": "7FJLjQeuHNvSZH4z05I3wu1GYdewTlZwqVBO/ce2DwRp2mI8L8br9XJ18y3/WBrQh/xqsoeZey7ir4nVZY4tsw=="
+                            "bytes": "MD0/6g//N013LED3YXjfBNtlYV4OUGR6oRkTlKmkWAhfVMVz8OldR/px0VUCMNuwEGAkNDnqRKeiTWVwscTN9w=="
                         },
                         "unlock_age": 0
                     }
@@ -1943,9 +1819,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             },
             {
@@ -1953,7 +1827,7 @@
                     {
                         "utxo": "0x17d8a1914f78121a5ba71bd5a99b05a562fd7e784de4585ba781f64d681ec58a74da131114e9dfc0d95589f8e62537b18aa7492051009097c1607f92fade8b10",
                         "unlock": {
-                            "bytes": "vxW6zmLtqErLnJBjXF6QjN4yAw4UmKjzgLf+KXRAZQcpEEI0Xbh6FJmH+UUsaUzEtnDdxbPmGG2eHzHk8igpYA=="
+                            "bytes": "+Yv7VauiAhkH4ej8UNPUmLbNHbP5rfG7NwyVIP5B0wZ3SjxxwSBPjsMTLkZKHlOM5Y76ahPDBdRIXGRmVYCU9Q=="
                         },
                         "unlock_age": 0
                     }
@@ -1968,9 +1842,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             },
             {
@@ -1978,7 +1850,7 @@
                     {
                         "utxo": "0xde63ea83324a0688cb8141e831437e9646c36a46bd601abd6b66cd7d3f30430a2ddbdadcf19c77da6831f605d869593db6a1778dd790f03872c7caf11812ca36",
                         "unlock": {
-                            "bytes": "dU1DT8ZNz/S23UthGFL2YZS6ehApV87pinz2pHu7vgEgPHo1djDBQJwgqESN+TlZwrVKkkjckuSPVVKrNEASYg=="
+                            "bytes": "y0GtK3pQ6lTZpDoQ9KVLFxNB1SYK9SJFthRBHe+hpwcEk4+Fo+vVvUVRm6WTnuOCZnfyx0VZZfgCm4z/Pldb0g=="
                         },
                         "unlock_age": 0
                     }
@@ -1993,9 +1865,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             },
             {
@@ -2003,7 +1873,7 @@
                     {
                         "utxo": "0xe8ab74a913f5c9577755bb5c4a3e413c8fbe8c15adece3eb90b60030340cce21f2c6a32672631cbdb1be5ef00b1402aef0c8ff65a6955be20bb8822bf60c11d0",
                         "unlock": {
-                            "bytes": "I3QBbnkjvy+rAL2B6YBj5W3YplTgIOiweZiaLWLoDQ2SwlUwlknFQuad+u10umGFrZs3Hl8WMceB0F7vET461g=="
+                            "bytes": "ECTvKUx7SbtJxdHje+0HvD/v/iX+vgTwuefE+oFjtwCPCpP1c/bzyIZ4c/TL01OjI8HmSmCk7WElHzTDxosJ1A=="
                         },
                         "unlock_age": 0
                     }
@@ -2018,9 +1888,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             }
         ],
@@ -2060,7 +1928,7 @@
                     {
                         "utxo": "0xc9dfc14696ab15d8dda539b4e8a25da5146848828481e83cddb6eaee56051d7975ebe51736e4c1cca26fd7187afd7e39e60f7890b647e8813da6c35449ba84a9",
                         "unlock": {
-                            "bytes": "Y+lJvLaz//+Ma5HyoRYiIckPR2WVPbzGjKnyB5bW4gByw7zczV/CHC/yymZAgazQZBJv4DNQQhxnd3jQyKBI7w=="
+                            "bytes": "LB0S5Jp55/XOMtjrEs09e3kv5iO2f7XJ/ku/c9ov9wsY68XjTW+vO4N4TzWWHXgHDl6eQVRqQg+PdLEYqV1T3g=="
                         },
                         "unlock_age": 0
                     }
@@ -2075,9 +1943,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             },
             {
@@ -2085,7 +1951,7 @@
                     {
                         "utxo": "0x6d7b0f6df19adc9faad3b98552cb2a846153464c4d43b12406376994405c5f999b67ba4dea8597a6b1828bba2b624cfa8af365518711436c1c769be42dca7a8b",
                         "unlock": {
-                            "bytes": "qqEoA0Guu13nhEIHP3t3/nDtjAkCrhXQL3w0iOKdTghdJa0AQNIG4kRv3sx4E02QT/8Z4B80MfMw7u1kHnyxiQ=="
+                            "bytes": "0CeRHHercTwzXjoKYtypbvdUYEw8XsL7qv8D6RFN1AgwrityBy8OlEFYsu9pnwwYqerjsgX/0pNS87mNpUk2NA=="
                         },
                         "unlock_age": 0
                     }
@@ -2100,9 +1966,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             },
             {
@@ -2110,7 +1974,7 @@
                     {
                         "utxo": "0x6e6e2f9682df7782483af8d0ea79f1e4d5d2c309a1fd79d071677cfb95aa837f81b73d08aae94f79d2f35b86358fc718b60d18187c50c324ac5ebd9a2adf57c2",
                         "unlock": {
-                            "bytes": "9Ra710o0+p5nFucKRC6mIGVzLGwyVG2mFmsQKZJvSAWucrMTvDP9W+2lI4XC2Ft6Lo71ZVapUtbC8WYxHm3mAQ=="
+                            "bytes": "gDlkcyra85GYbvBcD8o6bwe+6BIfpqm+hKdFr+9w0QpihGItr8PglH5aQcya+hG6WC+VbK6cfW5XVpl+4qCFiQ=="
                         },
                         "unlock_age": 0
                     }
@@ -2125,9 +1989,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             },
             {
@@ -2135,7 +1997,7 @@
                     {
                         "utxo": "0xdcf5000b530682cc6d1337d0f7dce33bcc2041e49370d27dd212b47dd060901f44f8ce06ca27b8502feee81ad9bf174e2d781d2f1835fb2d6b7c073523245693",
                         "unlock": {
-                            "bytes": "GwyFYl/uD8elkYstZsosJYopeDO4KEiF1qWYDOGb+Af9F/mqFb6tkjH1o1ahjxkLlf6rlvOLkCkNYWSGWwy7vQ=="
+                            "bytes": "wp26zLpPAsRJHpMo9WjCGXkisycJb0Aw8EvDb/lvlg0eXgAlUsSkCfvmIZPJBJAL/04XxIL094itE2xnagEing=="
                         },
                         "unlock_age": 0
                     }
@@ -2150,9 +2012,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             },
             {
@@ -2160,7 +2020,7 @@
                     {
                         "utxo": "0x9fd93f7b6acf3a277569084fabc3b6a8e983087c03e75aed7327c45d0a853a18b142daf607990882fc6388856557219c2bce42fb208f9f7e2cbeb845b482dc50",
                         "unlock": {
-                            "bytes": "1d7OALUBhUqLrjUJ5eMUVpV2xaCCroxRTba8ltV4jwlRzs4M7wqwXVP7wkfUcycH2PXQ4+ymXZLl2OhuNrH44A=="
+                            "bytes": "kqcPih6ZN14wXFAmmDVUVxHayn++P5ehoslPy3W2fwBKGpvW+dhPmwV7aQHgyT2+rGegj0RwIeMaYEtl8dC9oA=="
                         },
                         "unlock_age": 0
                     }
@@ -2175,9 +2035,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             },
             {
@@ -2185,7 +2043,7 @@
                     {
                         "utxo": "0xf264a96711a24f1e46d8883d45beec2526377c5903282b2cd5707b42a34698c8e2689b3a5500dab101bf519e7f82a07069a73c95d9bb6d1724306218686baa6c",
                         "unlock": {
-                            "bytes": "g1rXknVgY02grc9T0vtS6CckDRmG1thOuzB3WwvFBwwQJYBjP9KO/DmtfOEIc0CCQAWoOqvib1hQ8d+Tv4s3Qw=="
+                            "bytes": "9i8bxxTqNW0JpZ7i967ZUUwbF3xgEQsTJLSlIm8yUw8FW2HYqOcAICxi3DTwYA7zP1HouzL9EqYxI0NA0Rx58A=="
                         },
                         "unlock_age": 0
                     }
@@ -2200,9 +2058,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             },
             {
@@ -2210,7 +2066,7 @@
                     {
                         "utxo": "0x129daa271359dfb9aa84f887b1d24000c118663e7ff47da18a4d311db357945d897452823a885a1a9575b77b7df0a306b5f621102da4a17672a6cdd8bc51789a",
                         "unlock": {
-                            "bytes": "BFO/bLj74kB6jFCI975MCDHeFgheYGSbDpfPnuGaSQpuJayyvLQaTFCsfB/KmhGBSMVJpJUiOKqjWzz8eOewXw=="
+                            "bytes": "ol0Kx2azzIk1XSINqCB+14UpHclhYtogKyeg7ZNVCAtYPUFqa4ry6qJyoGoNQfEZTHUxeQHNLy6km9E3kiZ+fg=="
                         },
                         "unlock_age": 0
                     }
@@ -2225,9 +2081,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             },
             {
@@ -2250,9 +2104,7 @@
                         }
                     }
                 ],
-                "payload": {
-                    "bytes": ""
-                },
+                "payload": "",
                 "lock_height": "0"
             }
         ],


### PR DESCRIPTION
It was applied in accordance with the change in Agora. https://github.com/bosagora/agora/pull/2138
It changed the transaction member, payload, to an instance of Buffer.