### PR TITLE
Add `TransactionPool` for double-spend transaction processing

### DIFF
--- a/docs/Database_Schema.md
+++ b/docs/Database_Schema.md
@@ -448,3 +448,22 @@ Create TABLE IF NOT EXISTS "marketcap" (
     PRIMARY KEY ("last_updated_at")
 );
 ```
+
+## 16. Table **tx_pool**
+
+### _Schema_
+
+| Column            | Data Type | PK | Not NULL | Default  |Description|
+|:----------------- |:--------- |:--:|:--------:| -------- | --------- |
+| key               | TINYBLOB  | Y  | Y        |          | The hash of transaction |
+| val               | BLOB      |    | Y        |          | The transaction serialized to binary |
+
+### _Create Script_
+
+```sql
+CREATE TABLE IF NOT EXISTS tx_pool (
+    `key`   TINYBLOB    NOT NULL,
+    `val`   BLOB        NOT NULL,
+    PRIMARY KEY (`key`(64))
+)
+```

--- a/src/modules/storage/LedgerStorage.ts
+++ b/src/modules/storage/LedgerStorage.ts
@@ -234,7 +234,14 @@ export class LedgerStorage extends Storages
             change_24h      BIGINT(20),
             PRIMARY KEY (last_updated_at)
         );
-
+        
+        CREATE TABLE IF NOT EXISTS tx_pool
+        (
+            \`key\`     TINYBLOB    NOT NULL,
+            \`val\`     BLOB        NOT NULL,
+            PRIMARY KEY(\`key\`(64))
+        );
+        
        DROP TRIGGER IF EXISTS tx_trigger;
        CREATE TRIGGER tx_trigger AFTER INSERT
        ON transactions

--- a/src/modules/storage/Storages.ts
+++ b/src/modules/storage/Storages.ts
@@ -263,4 +263,9 @@ export class Storages
             });
         });
     }
+
+    public get connection (): mysql.Connection
+    {
+        return this.db;
+    }
 }

--- a/src/modules/storage/TransactionPool.ts
+++ b/src/modules/storage/TransactionPool.ts
@@ -1,0 +1,224 @@
+/*******************************************************************************
+
+    Contains a transaction pool that is serializable to disk,
+    using MySQL as a store.
+    It was added to remove double-spending transactions that use the same input.
+
+    Copyright:
+        Copyright (c) 2021 BOSAGORA Foundation
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+import { Endian, Hash, hashFull, Transaction } from "boa-sdk-ts";
+import { SmartBuffer } from "smart-buffer";
+
+import * as mysql from "mysql2";
+
+/**
+ * It was added to remove double-spending transactions that use the same input.
+ */
+export class TransactionPool
+{
+    /**
+     * Keeps track of which TXs spend which inputs
+     */
+    private spenders: Map<string, Set<string>>
+
+    /**
+     * Constructor
+     */
+    constructor ()
+    {
+        this.spenders = new Map<string, Set<string>>();
+    }
+
+    /**
+     * Add a transaction to the pool
+     * @param connection MySQL connection
+     * @param tx the transaction to add
+     */
+    public async add (connection: mysql.Connection, tx: Transaction)
+    {
+        this.updateSpenderList(tx);
+
+        let buffer = new SmartBuffer();
+        tx.serialize(buffer);
+
+        let tx_hash = hashFull(tx);
+        await this.query(connection, "INSERT INTO tx_pool (`key`, `val`) VALUES (?, ?);",
+            [tx_hash.toBinary(Endian.Little), buffer.toBuffer()]);
+    }
+
+    /**
+     * Remove the transaction with the given key from the pool
+     * @param connection MySQL connection
+     * @param key the transaction to remove
+     * @param rm_double_spent  remove the TXs that use the same inputs
+     */
+    public async remove (connection: mysql.Connection, key: Transaction | Hash,
+                         rm_double_spent: boolean = true)
+    {
+        if (key instanceof Transaction)
+        {
+            let tx_hash = hashFull(key);
+            let tx_hash_data = tx_hash.toBinary(Endian.Little);
+            await this.query(connection, `
+                DELETE FROM tx_pool WHERE \`key\` = ?;
+                DELETE FROM transaction_pool WHERE tx_hash = ?;
+                DELETE FROM tx_input_pool WHERE tx_hash = ?;
+                DELETE FROM tx_output_pool WHERE tx_hash = ?;`
+            , [tx_hash_data, tx_hash_data, tx_hash_data, tx_hash_data]);
+
+            if (rm_double_spent)
+            {
+                let inv_txs = new Set<string>();
+                this.gatherDoubleSpentTXs(key, inv_txs);
+                for (const input of key.inputs)
+                    this.spenders.delete(hashFull(input).toString());
+                for (const inv_tx_hash_string of inv_txs)
+                    await this.remove(connection, new Hash(inv_tx_hash_string), false);
+            }
+            else
+            {
+                let tx_hash_string = tx_hash.toString();
+                for (const input of key.inputs)
+                {
+                    let in_hash_string = hashFull(input).toString();
+                    let set = this.spenders.get(in_hash_string);
+                    if ((set !== undefined) && (set.has(tx_hash_string)))
+                        set.delete(tx_hash_string)
+                }
+            }
+        }
+        else
+        {
+            let rows = await this.query(connection, `SELECT \`val\` FROM tx_pool WHERE \`key\` = ?;`,
+                [key.toBinary(Endian.Little)]);
+            if (rows.length !== 0)
+            {
+                let tx = Transaction.deserialize(SmartBuffer.fromBuffer(rows[0].val));
+                await this.remove(connection, tx, rm_double_spent);
+            }
+        }
+    }
+
+    /**
+     * Load transactions and make the spender list
+     * @param connection MySQL connection
+     */
+    public async loadSpenderList (connection: mysql.Connection)
+    {
+        this.spenders.clear();
+        let rows = await this.query(connection, "SELECT `key`, `val` FROM tx_pool;", []);
+        for (let row of rows)
+        {
+            let tx = Transaction.deserialize(SmartBuffer.fromBuffer(row.tx));
+            await this.updateSpenderList(tx);
+        }
+    }
+
+    /**
+     * Add the given TX to `spenders` list
+     * @param tx the transaction to add
+     */
+    public updateSpenderList (tx: Transaction)
+    {
+        let tx_hash_string = hashFull(tx).toString();
+
+        // insert each input information of the transaction
+        for (const input of tx.inputs)
+        {
+            const in_hash_string = hashFull(input).toString();
+
+            // Update the spenders list
+            let set = this.spenders.get(in_hash_string);
+            if (set === undefined)
+            {
+                set = new Set<string>();
+                this.spenders.set(in_hash_string, set);
+            }
+            set.add(tx_hash_string);
+        }
+    }
+
+    /**
+     * Gather TXs that share inputs with the given TX
+     * @param tx a transaction
+     * @param double_spent_txs container to write the double-spend TXs
+     * @return true if double-spend TXs where found, false otherwise
+     */
+    public gatherDoubleSpentTXs (tx: Transaction, double_spent_txs: Set<string>): boolean
+    {
+        double_spent_txs.clear();
+
+        const tx_hash_string = hashFull(tx).toString();
+        for (const input of tx.inputs)
+        {
+            const in_hash_string = hashFull(input).toString();
+            let set = this.spenders.get(in_hash_string);
+            if (set !== undefined)
+            {
+                for (let spender of set)
+                    if (spender != tx_hash_string)
+                        double_spent_txs.add(spender);
+            }
+        }
+
+        return double_spent_txs.size > 0;
+    }
+
+    /**
+     * Return the number of transactions in the pool
+     * @param connection MySQL connection
+     */
+    public getLength (connection: mysql.Connection): Promise<number>
+    {
+        return new Promise<number>((resolve, reject) =>
+        {
+            this.query(connection, `SELECT count(*) as value FROM tx_pool;`, [])
+                .then((rows: any[]) =>
+                {
+                    if ((rows.length > 0) && (rows[0].value !== undefined))
+                    {
+                        resolve(rows[0].value);
+                    }
+                    else
+                    {
+                        resolve(0);
+                    }
+                })
+                .catch((err) =>
+                {
+                    reject(err);
+                });
+        });
+    }
+
+    /**
+     * Execute SQL to query the database for data.
+     * @param connection MySQL connection
+     * @param sql The SQL query to run.
+     * @param params When the SQL statement contains placeholders,
+     * you can pass them in here.
+     * @returns Returns the Promise. If it is finished successfully the `.then`
+     * of the returned Promise is called with the records
+     * and if an error occurs the `.catch` is called with an error.
+     */
+    protected query (connection: mysql.Connection, sql: string, params: any): Promise<any>
+    {
+        return new Promise<any>((resolve, reject) =>
+        {
+            connection.query(sql, params, (err: Error | null, rows: any) =>
+            {
+                if (!err)
+                    resolve(rows);
+                else
+                    reject(err);
+            });
+        });
+    }
+}

--- a/tests/TransactionPool.test.ts
+++ b/tests/TransactionPool.test.ts
@@ -1,0 +1,157 @@
+/*******************************************************************************
+
+    Test of transaction pool
+
+    Copyright:
+        Copyright (c) 2021 BOSAGORA Foundation
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+import {
+    SodiumHelper, Hash, Transaction, TxInput, TxOutput, OutputType,
+    PublicKey, JSBI, Signature, Unlock
+} from 'boa-sdk-ts';
+import { BOASodium } from 'boa-sodium-ts';
+import { LedgerStorage } from "../src/modules/storage/LedgerStorage";
+import { TransactionPool } from "../src/modules/storage/TransactionPool";
+import { IDatabaseConfig } from "../src/modules/common/Config";
+import { MockDBConfig } from "./TestConfig";
+
+import * as assert from 'assert';
+
+describe ('Test TransactionPool', () =>
+{
+    let ledger_storage: LedgerStorage;
+    let transaction_pool: TransactionPool;
+    let testDBConfig: IDatabaseConfig;
+
+    before ('Wait for the package libsodium to finish loading', async () =>
+    {
+        SodiumHelper.assign(new BOASodium());
+        await SodiumHelper.init();
+    });
+
+    before ('Prepare Storage', async() =>
+    {
+        testDBConfig = await MockDBConfig();
+        return LedgerStorage.make(testDBConfig, 1609459200)
+            .then((result) =>
+            {
+                ledger_storage = result;
+                transaction_pool = new TransactionPool();
+                return transaction_pool.loadSpenderList(ledger_storage.connection);
+            });
+    });
+
+    after ('Close Storage', async () =>
+    {
+        await ledger_storage.dropTestDB(testDBConfig.database);
+        await ledger_storage.close();
+    });
+
+    it ('Test for deletion of a pending transaction that all use the same input', async () =>
+    {
+        let tx1 = new Transaction(
+            [
+                new TxInput(
+                    new Hash(
+                        "0x75283072696d82d8bca2fe45471906a26df1dbe0736e41a9f78e02a14e2bfce" +
+                        "d6e0cb671f023626f890f28204556aca217f3023c891fe64b9f4b3450cb3e80ad"),
+                    Unlock.fromSignature(new Signature(Buffer.alloc(Signature.Width)))
+                )
+            ],
+            [
+                new TxOutput(
+                    OutputType.Payment,
+                    JSBI.BigInt(10_000_000),
+                    new PublicKey("boa1xza007gllhzdawnr727hds36guc0frnjsqscgf4k08zqesapcg3uujh9g93")
+                )
+            ],
+            Buffer.alloc(0)
+        );
+        await transaction_pool.add(ledger_storage.connection, tx1);
+        assert.strictEqual(await transaction_pool.getLength(ledger_storage.connection), 1);
+
+        let tx2 = new Transaction(
+            [
+                new TxInput(
+                    new Hash(
+                        "0x75283072696d82d8bca2fe45471906a26df1dbe0736e41a9f78e02a14e2bfce" +
+                        "d6e0cb671f023626f890f28204556aca217f3023c891fe64b9f4b3450cb3e80ad"),
+                    Unlock.fromSignature(new Signature(Buffer.alloc(Signature.Width)))
+                )
+            ],
+            [
+                new TxOutput(
+                    OutputType.Payment,
+                    JSBI.BigInt(10_000_000),
+                    new PublicKey("boa1xrc00kar2yqa3jzve9cm4cvuaa8duazkuwrygmqgpcuf0gqww8ye7ua9lkl")
+                )
+            ],
+            Buffer.alloc(0)
+        );
+        await transaction_pool.remove(ledger_storage.connection, tx2, true);
+        assert.strictEqual(await transaction_pool.getLength(ledger_storage.connection), 0);
+
+        await transaction_pool.add(ledger_storage.connection, tx2);
+        assert.strictEqual(await transaction_pool.getLength(ledger_storage.connection), 1);
+    });
+
+    it ('Test for deletion of a pending transaction that use some of the same inputs', async () =>
+    {
+        let tx1 = new Transaction(
+            [
+                new TxInput(
+                    new Hash(
+                        "0x75283072696d82d8bca2fe45471906a26df1dbe0736e41a9f78e02a14e2bfce" +
+                        "d6e0cb671f023626f890f28204556aca217f3023c891fe64b9f4b3450cb3e80ad"),
+                    Unlock.fromSignature(new Signature(Buffer.alloc(Signature.Width)))
+                ),
+                new TxInput(
+                    new Hash(
+                        "0x6fbcdb2573e0f5120f21f1875b6dc281c2eca3646ec2c39d703623d89b0eb83" +
+                        "cd4b12b73f18db6bc6e8cbcaeb100741f6384c498ff4e61dd189e728d80fb9673"),
+                    Unlock.fromSignature(new Signature(Buffer.alloc(Signature.Width)))
+                )
+            ],
+            [
+                new TxOutput(
+                    OutputType.Payment,
+                    JSBI.BigInt(10_000_000),
+                    new PublicKey("boa1xza007gllhzdawnr727hds36guc0frnjsqscgf4k08zqesapcg3uujh9g93")
+                )
+            ],
+            Buffer.alloc(0)
+        );
+        await transaction_pool.add(ledger_storage.connection, tx1);
+        assert.strictEqual(await transaction_pool.getLength(ledger_storage.connection), 2);
+
+        let tx2 = new Transaction(
+            [
+                new TxInput(
+                    new Hash(
+                        "0x75283072696d82d8bca2fe45471906a26df1dbe0736e41a9f78e02a14e2bfce" +
+                        "d6e0cb671f023626f890f28204556aca217f3023c891fe64b9f4b3450cb3e80ad"),
+                    Unlock.fromSignature(new Signature(Buffer.alloc(Signature.Width)))
+                )
+            ],
+            [
+                new TxOutput(
+                    OutputType.Payment,
+                    JSBI.BigInt(10_000_000),
+                    new PublicKey("boa1xrc00kar2yqa3jzve9cm4cvuaa8duazkuwrygmqgpcuf0gqww8ye7ua9lkl")
+                )
+            ],
+            Buffer.alloc(0)
+        );
+        await transaction_pool.remove(ledger_storage.connection, tx2, true);
+        assert.strictEqual(await transaction_pool.getLength(ledger_storage.connection), 0);
+
+        await transaction_pool.add(ledger_storage.connection, tx2);
+        assert.strictEqual(await transaction_pool.getLength(ledger_storage.connection), 1);
+    });
+});


### PR DESCRIPTION
This is necessary when a transaction is canceled, to reflect it in a pending transaction.