### PR TITLE
Endpoint: Add an endpoint that provides the balance of the entered address

### DIFF
--- a/src/modules/storage/LedgerStorage.ts
+++ b/src/modules/storage/LedgerStorage.ts
@@ -2382,6 +2382,52 @@ export class LedgerStorage extends Storages {
     }
 
     /**
+     * Provides a balance of address
+     * @param address The address to check the balance
+     */
+    public getWalletBalance(address: string): Promise<any[]> {
+        let sql = `
+            SELECT
+                ? as address,
+                IFNULL(SUM(amount), 0) AS balance,
+                IFNULL(SUM(CASE WHEN ((unlock_height <= height + 1) AND ((type = 0) OR (type = 2))) THEN amount ELSE 0 END), 0) AS spendable,
+                IFNULL(SUM(CASE WHEN ((unlock_height <= height + 1) AND ((type = 1))) THEN amount ELSE 0 END), 0) AS frozen,
+                IFNULL(SUM(CASE WHEN ((unlock_height > height + 1) AND ((type = 0) OR (type = 2))) THEN amount ELSE 0 END), 0) AS locked
+            FROM
+            (
+                SELECT
+                    O.utxo_key as utxo,
+                    O.amount,
+                    O.lock_type,
+                    O.lock_bytes,
+                    T.block_height,
+                    B.time_stamp as block_time,
+                    O.type,
+                    O.unlock_height,
+                    (SELECT MAX(height) as height FROM blocks) as height
+                FROM
+                    utxos O
+                    INNER JOIN transactions T ON (T.tx_hash = O.tx_hash)
+                    INNER JOIN blocks B ON (B.height = T.block_height)
+                WHERE
+                    O.address = ?
+                    AND O.utxo_key NOT IN 
+                    (
+                        SELECT
+                            S.utxo_key
+                        FROM
+                            utxos S
+                            INNER JOIN tx_input_pool I ON (I.utxo = S.utxo_key)
+                            INNER JOIN transaction_pool T ON (T.tx_hash = I.tx_hash)
+                        WHERE
+                            S.address = ?
+                    )
+            ) AS T;`;
+
+        return this.query(sql, [address, address, address]);
+    }
+
+    /**
      * Provides a status of a transaction.
      * @param tx_hash The hash of the transaction
      */

--- a/tests/Stoa.test.ts
+++ b/tests/Stoa.test.ts
@@ -754,6 +754,23 @@ describe("Test of the path /utxo", () => {
         await delay(1500);
     });
 
+    it("Test of the path /wallet/balance no pending transaction ", async () => {
+        let uri = URI(host)
+            .port(port)
+            .directory("wallet/balance")
+            .filename("boa1xparc00qvv984ck00trwmfxuvqmmlwsxwzf3al0tsq5k2rw6aw427ct37mj");
+
+        let response = await client.get(uri.toString());
+        let expected = {
+            address: "boa1xparc00qvv984ck00trwmfxuvqmmlwsxwzf3al0tsq5k2rw6aw427ct37mj",
+            balance: "24399999990480",
+            spendable: "24399999990480",
+            frozen: "0",
+            locked: "0",
+        };
+        assert.deepStrictEqual(response.data, expected);
+    });
+
     it("Test of the path /utxo no pending transaction ", async () => {
         let uri = URI(host)
             .port(port)
@@ -782,6 +799,23 @@ describe("Test of the path /utxo", () => {
         let url = uri.toString();
         await client.post(url, { tx: Block.reviver("", sample_data2).txs[0] });
         await delay(500);
+    });
+
+    it("Test of the path /wallet/balance with pending transaction ", async () => {
+        let uri = URI(host)
+            .port(port)
+            .directory("wallet/balance")
+            .filename("boa1xparc00qvv984ck00trwmfxuvqmmlwsxwzf3al0tsq5k2rw6aw427ct37mj");
+
+        let response = await client.get(uri.toString());
+        let expected = {
+            address: "boa1xparc00qvv984ck00trwmfxuvqmmlwsxwzf3al0tsq5k2rw6aw427ct37mj",
+            balance: "0",
+            spendable: "0",
+            frozen: "0",
+            locked: "0",
+        };
+        assert.deepStrictEqual(response.data, expected);
     });
 
     it("Test of the path /utxo with pending transaction ", async () => {


### PR DESCRIPTION
I made a UTXO that only provides the balance without checking the entire UTXO.
Currently, all UTXO is required to check the balance of a specific address.
However, if this is added, the load on the balance calculation can be reduced.