### PR TITLE
Fix an error that occur when no transactions are in the block

### DIFF
--- a/src/modules/storage/LedgerStorage.ts
+++ b/src/modules/storage/LedgerStorage.ts
@@ -475,7 +475,8 @@ export class LedgerStorage extends Storages {
                     total_fee = JSBI.add(total_fee, fees[0]);
                 }
             }
-            const average_tx_fee = JSBI.divide(sum, JSBI.BigInt(block.txs.length));
+            const average_tx_fee =
+                block.txs.length !== 0 ? JSBI.divide(sum, JSBI.BigInt(block.txs.length)) : JSBI.BigInt(0);
             let newEntry = await this.applyGranularity(block.header.time_offset + this.genesis_timestamp);
             if (newEntry.length > 0) {
                 for (let index = 0; index < newEntry.length; index++) {


### PR DESCRIPTION
When there are no transactions inside the block, the number is zero, so it is treated to avoid being divided by zero.