### PR TITLE
Add endpoint /wallet/utxo:address to provide UTXO for the required amount

### DIFF
--- a/tests/WalletAPI.test.ts
+++ b/tests/WalletAPI.test.ts
@@ -11,7 +11,7 @@
 
 *******************************************************************************/
 
-import { SodiumHelper } from "boa-sdk-ts";
+import { SodiumHelper, JSBI } from "boa-sdk-ts";
 import {
     delay,
     recovery_sample_data,
@@ -366,5 +366,159 @@ describe("Test of Stoa API for the wallet with `sample_data`", () => {
 
         response = await client.get(uri.toString());
         assert.strictEqual(response.data.length, 0);
+    });
+
+    it("Test of the path /wallet/utxo - Two UTXO", async () => {
+        let amount = JSBI.BigInt("24399999990481");
+        let uri = URI(host)
+            .port(port)
+            .directory("/wallet/utxo")
+            .filename("boa1xzfv00s88ky9mf50nqngvztmnmtjzv4yr0w555aet366ssrv5zqaj6zsga3")
+            .setSearch("amount", amount.toString());
+
+        let response = await client.get(uri.toString());
+        let expected = [
+            {
+                utxo: "0xa8d769089ccd2c8dd1bde0fd94fabe3e7ae414f7ce6143a9d65b32dc8ec998e34e9bbddb253fdb46058582f0f69de959d2b5af9edea4e8e5f951b1228aa7fe5a",
+                type: 0,
+                unlock_height: "2",
+                amount: "24399999990480",
+                height: "1",
+                time: 1609459800,
+                lock_type: 0,
+                lock_bytes: "kse+Bz2IXaaPmCaGCXue1yEypBvdSlO5XHWoQGyggdk=",
+            },
+            {
+                utxo: "0xe681a6b99e8f4ee51a54d4c3d0876566e08571b794f8446c3916457739bb7872fa3040845400d9b8ee3ca310f6e4e852c1dbc25bbb8cc255bbaa6b32196264c6",
+                type: 0,
+                unlock_height: "2",
+                amount: "24399999990480",
+                height: "1",
+                time: 1609459800,
+                lock_type: 0,
+                lock_bytes: "kse+Bz2IXaaPmCaGCXue1yEypBvdSlO5XHWoQGyggdk=",
+            },
+        ];
+        assert.deepStrictEqual(response.data, expected);
+        assert.ok(
+            JSBI.greaterThanOrEqual(
+                response.data.reduce((sum, m) => JSBI.add(sum, JSBI.BigInt(m.amount)), JSBI.BigInt(0)),
+                amount
+            )
+        );
+    });
+
+    it("Test of the path /wallet/utxo - One UTXO", async () => {
+        let amount = JSBI.BigInt("24399999990480");
+        let uri = URI(host)
+            .port(port)
+            .directory("/wallet/utxo")
+            .filename("boa1xzfv00s88ky9mf50nqngvztmnmtjzv4yr0w555aet366ssrv5zqaj6zsga3")
+            .setSearch("amount", amount.toString());
+
+        let response = await client.get(uri.toString());
+        let expected = [
+            {
+                utxo: "0xa8d769089ccd2c8dd1bde0fd94fabe3e7ae414f7ce6143a9d65b32dc8ec998e34e9bbddb253fdb46058582f0f69de959d2b5af9edea4e8e5f951b1228aa7fe5a",
+                type: 0,
+                unlock_height: "2",
+                amount: "24399999990480",
+                height: "1",
+                time: 1609459800,
+                lock_type: 0,
+                lock_bytes: "kse+Bz2IXaaPmCaGCXue1yEypBvdSlO5XHWoQGyggdk=",
+            },
+        ];
+        assert.deepStrictEqual(response.data, expected);
+        assert.ok(
+            JSBI.greaterThanOrEqual(
+                response.data.reduce((sum, m) => JSBI.add(sum, JSBI.BigInt(m.amount)), JSBI.BigInt(0)),
+                amount
+            )
+        );
+    });
+
+    it("Test of the path /wallet/utxo - Use filter last", async () => {
+        let amount = JSBI.BigInt("24399999990480");
+        let uri = URI(host)
+            .port(port)
+            .directory("/wallet/utxo")
+            .filename("boa1xzfv00s88ky9mf50nqngvztmnmtjzv4yr0w555aet366ssrv5zqaj6zsga3")
+            .setSearch("amount", amount.toString())
+            .setSearch(
+                "last",
+                "0xa8d769089ccd2c8dd1bde0fd94fabe3e7ae414f7ce6143a9d65b32dc8ec998e34e9bbddb253fdb46058582f0f69de959d2b5af9edea4e8e5f951b1228aa7fe5a"
+            );
+
+        let response = await client.get(uri.toString());
+        let expected = [
+            {
+                utxo: "0xe681a6b99e8f4ee51a54d4c3d0876566e08571b794f8446c3916457739bb7872fa3040845400d9b8ee3ca310f6e4e852c1dbc25bbb8cc255bbaa6b32196264c6",
+                type: 0,
+                unlock_height: "2",
+                amount: "24399999990480",
+                height: "1",
+                time: 1609459800,
+                lock_type: 0,
+                lock_bytes: "kse+Bz2IXaaPmCaGCXue1yEypBvdSlO5XHWoQGyggdk=",
+            },
+        ];
+        assert.deepStrictEqual(response.data, expected);
+        assert.ok(
+            JSBI.greaterThanOrEqual(
+                response.data.reduce((sum, m) => JSBI.add(sum, JSBI.BigInt(m.amount)), JSBI.BigInt(0)),
+                amount
+            )
+        );
+    });
+
+    it("Test of the path /wallet/utxo - Get frozen UTXO", async () => {
+        let amount = JSBI.BigInt("10000");
+        let uri = URI(host)
+            .port(port)
+            .directory("/wallet/utxo")
+            .filename("boa1xrvald6jsqfuctlr4nr4h9c224vuah8vgv7f9rzjauwev7j8tj04qee8f0t")
+            .setSearch("amount", amount.toString())
+            .setSearch("type", "1");
+
+        let response = await client.get(uri.toString());
+        let expected = [
+            {
+                utxo: "0x00bac393977fbd1e0edc70a34c7ca802dafe57f2b4a2aabf1adaac54892cb1cbae72cdeeb212904101382690d18d2d2c6ac99b83227ca73b307fde0807c4af03",
+                type: 1,
+                unlock_height: "1",
+                amount: "20000000000000",
+                height: "0",
+                time: 1609459200,
+                lock_type: 0,
+                lock_bytes: "2d+3UoATzC/jrMdblwpVWc7c7EM8koxS7x2Wekdcn1A=",
+            },
+        ];
+        assert.deepStrictEqual(response.data, expected);
+    });
+
+    it("Test of the path /wallet/utxo - Get locked UTXO", async () => {
+        let amount = JSBI.BigInt("10000");
+        let uri = URI(host)
+            .port(port)
+            .directory("/wallet/utxo")
+            .filename("boa1xzvald7hxvgnzk50sy04ha7ezgyytxt5sgw323zy8dlj3ya2q40e6elltwq")
+            .setSearch("amount", amount.toString())
+            .setSearch("type", "2");
+
+        let response = await client.get(uri.toString());
+        let expected = [
+            {
+                utxo: "0x009b3800b3f1f3b4eaf6f449244902b5e9a632fac59c3366d06cf31b9d683d7205cb86e4bf424a9d04aec8ff91e896705780f8ac9b55199decf2c1fef21a0a40",
+                type: 0,
+                unlock_height: "2018",
+                amount: "3999999980000",
+                height: "2",
+                time: 1609460400,
+                lock_type: 0,
+                lock_bytes: "md+31zMRMVqPgR9b99kSCEWZdIIdFUREO38ok6oFX50=",
+            },
+        ];
+        assert.deepStrictEqual(response.data, expected);
     });
 });


### PR DESCRIPTION
Currently, SDK requests all UTXO and then extracts the UTXO required.
I changed it like this.
SDK requests Stoa for UTXO with the required amount for a specific address.
Stoa extracts UTXO that meets the conditions and provides it to SDK.

Relates to https://github.com/bosagora/boa-sdk-ts/issues/198