### PR TITLE
Wallet: Returns only the same information as the sent address on pending transactions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -526,9 +526,9 @@
             "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
         },
         "boa-sdk-ts": {
-            "version": "0.0.55",
-            "resolved": "https://registry.npmjs.org/boa-sdk-ts/-/boa-sdk-ts-0.0.55.tgz",
-            "integrity": "sha512-YWotodrLGP0n8JwMrrfXRPmRKSWcu5D93YPZ8JR764If0N/3+qIJHlAfHHoFTCpNXQeChLy3jwuMNb7ZWDpdfg==",
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/boa-sdk-ts/-/boa-sdk-ts-0.1.3.tgz",
+            "integrity": "sha512-vBVJDcpjpj9A7qiHGM0WI1KiNTdj9GdjqQ0vVhz5WsilWxjkgGS1EzkyhMQ723vyWfrYh3u8Vja4xifd050/wQ==",
             "requires": {
                 "@ctrl/ts-base32": "^1.2.1",
                 "ajv": "^6.12.6",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "argparse": "^2.0.1",
         "assert": "^2.0.0",
         "axios": "^0.21.1",
-        "boa-sdk-ts": "^0.0.55",
+        "boa-sdk-ts": "^0.1.3",
         "body-parser": "^1.19.0",
         "coingecko-api-v3": "0.0.11",
         "cors": "^2.8.5",

--- a/src/modules/storage/LedgerStorage.ts
+++ b/src/modules/storage/LedgerStorage.ts
@@ -2370,25 +2370,6 @@ export class LedgerStorage extends Storages {
             WHERE
                 S.address = ?
             GROUP BY T.tx_hash
-
-            UNION ALL
-
-            SELECT
-                T.tx_hash,
-                T.time,
-                T.type,
-                O.address,
-                T.tx_fee,
-                T.payload_fee,
-                T.received_height,
-                IFNULL(SUM(O.amount), 0) AS income,
-                0 as spend
-            FROM
-                tx_output_pool O
-                INNER JOIN transaction_pool T ON (T.tx_hash = O.tx_hash)
-            WHERE
-                O.address = ?
-            GROUP BY T.tx_hash
         ) AS TX
         GROUP BY TX.tx_hash
         ORDER BY TX.time DESC`;

--- a/tests/TransactionPool.test.ts
+++ b/tests/TransactionPool.test.ts
@@ -279,7 +279,7 @@ describe("Test of double spending transaction", () => {
                 "25e470aeb36bea739c9c0f094b56fc1f8097bbbbc7721bf99208154ec74801950"
         );
         assert.strictEqual(response.data[0].address, "boa1xparc00qvv984ck00trwmfxuvqmmlwsxwzf3al0tsq5k2rw6aw427ct37mj");
-        assert.strictEqual(response.data[0].amount, "9520");
+        assert.strictEqual(response.data[0].amount, "24399999990480");
     });
 
     it("Send a second transaction with the same input as the first transaction", async () => {


### PR DESCRIPTION
/wallet/transactions/pending/:address could you please check this API. the pending transaction has also appeared on the receiver address. while the transaction is in a pending state it should only be listed on the sender address, not on the receiver address.