### PR TITLE
Fix Bug: Fix field name bug in the storage of the transaction pool

### DIFF
--- a/src/modules/storage/TransactionPool.ts
+++ b/src/modules/storage/TransactionPool.ts
@@ -105,7 +105,7 @@ export class TransactionPool {
         this.spenders.clear();
         const rows = await this.query(connection, "SELECT `key`, `val` FROM tx_pool;", []);
         for (const row of rows) {
-            const tx = Transaction.deserialize(SmartBuffer.fromBuffer(row.tx));
+            const tx = Transaction.deserialize(SmartBuffer.fromBuffer(row.val));
             await this.updateSpenderList(tx);
         }
     }

--- a/tests/TransactionPool.test.ts
+++ b/tests/TransactionPool.test.ts
@@ -176,6 +176,12 @@ describe("Test TransactionPool", () => {
         await transaction_pool.add(ledger_storage.connection, tx2);
         assert.strictEqual(await transaction_pool.getLength(ledger_storage.connection), 1);
     });
+
+    it("Test for TransactionPool.loadSpenderList()", async () => {
+        assert.strictEqual(await transaction_pool.getLength(ledger_storage.connection), 1);
+        const other_pool = new TransactionPool();
+        return other_pool.loadSpenderList(ledger_storage.connection);
+    });
 });
 
 describe("Test of double spending transaction", () => {


### PR DESCRIPTION
When Stoa is restarted, an exception occurs in the process of reading the previously recorded information.
Changing the field name from `tx` to `val` caused a bug in the code.
I received this from @TrustHenry. Create a correction PR for this.