### PR TITLE
Apply mysql connection pool

### DIFF
--- a/docs/config.example.yaml
+++ b/docs/config.example.yaml
@@ -19,6 +19,9 @@ database:
    database : stoa
    password : "12345678"
    port : 3306
+   waitForConnections : true
+   connectionLimit : 30
+   queueLimit : 0
 
 ################################################################################
 ##                               Logging options                              ##

--- a/docs/config.test.yaml
+++ b/docs/config.test.yaml
@@ -19,6 +19,9 @@ database:
    database : devstoa
    password : "12345678"
    port : 3306
+   waitForConnections : true
+   connectionLimit : 10
+   queueLimit : 0
 
 ################################################################################
 ##                               Logging options                              ##

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -916,7 +916,7 @@ export interface IAvgFee {
     /**
      * Granularity of Record
      */
-    granularity: string
+    granularity: string;
 
     /**
      * Block unix timestamp

--- a/src/modules/common/Config.ts
+++ b/src/modules/common/Config.ts
@@ -211,6 +211,23 @@ export class DatabaseConfig implements IDatabaseConfig {
     multipleStatements: boolean;
 
     /**
+     * The maximum number of connections to create at once.
+     */
+    waitForConnections: boolean;
+
+    /**
+     * The maximum number of connections
+     */
+    connectionLimit: number;
+
+    /**
+     * The maximum number of connection requests the pool
+     * will queue before returning an error from getConnection.
+     * If set to 0, there is no limit to the number of queued connection requests.
+     */
+    queueLimit: number;
+
+    /**
      * Constructor
      * @param host Mysql database host
      * @param user Mysql database user
@@ -224,7 +241,10 @@ export class DatabaseConfig implements IDatabaseConfig {
         password?: string,
         database?: string,
         port?: number,
-        multipleStatements?: boolean
+        multipleStatements?: boolean,
+        waitForConnections?: boolean,
+        connectionLimit?: number,
+        queueLimit?: number
     ) {
         const conf = extend(true, {}, DatabaseConfig.defaultValue());
         extend(true, conf, {
@@ -234,6 +254,9 @@ export class DatabaseConfig implements IDatabaseConfig {
             database,
             port,
             multipleStatements,
+            waitForConnections,
+            connectionLimit,
+            queueLimit,
         });
         this.host = conf.host;
         this.user = conf.user;
@@ -241,6 +264,9 @@ export class DatabaseConfig implements IDatabaseConfig {
         this.database = conf.database;
         this.port = conf.port;
         this.multipleStatements = conf.multipleStatements;
+        this.waitForConnections = conf.waitForConnections;
+        this.connectionLimit = conf.connectionLimit;
+        this.queueLimit = conf.queueLimit;
     }
 
     /**
@@ -256,6 +282,9 @@ export class DatabaseConfig implements IDatabaseConfig {
         this.database = conf.database;
         this.port = conf.port;
         this.multipleStatements = conf.multipleStatements;
+        this.waitForConnections = conf.waitForConnections;
+        this.connectionLimit = conf.connectionLimit;
+        this.queueLimit = conf.queueLimit;
     }
 
     /**
@@ -269,6 +298,9 @@ export class DatabaseConfig implements IDatabaseConfig {
             database: "stoa",
             port: 3306,
             multipleStatements: true,
+            waitForConnections: true,
+            connectionLimit: 10,
+            queueLimit: 0,
         };
     }
 }
@@ -431,6 +463,23 @@ export interface IDatabaseConfig {
      * Multiple Statements execution statement Option
      */
     multipleStatements: boolean;
+
+    /**
+     * The maximum number of connections to create at once.
+     */
+    waitForConnections: boolean;
+
+    /**
+     * The maximum number of connections
+     */
+    connectionLimit: number;
+
+    /**
+     * The maximum number of connection requests the pool
+     * will queue before returning an error from getConnection.
+     * If set to 0, there is no limit to the number of queued connection requests.
+     */
+    queueLimit: number;
 }
 
 /**

--- a/tests/Boascan.test.ts
+++ b/tests/Boascan.test.ts
@@ -69,14 +69,14 @@ describe("Test of Stoa API Server", () => {
         coinMarketService = new CoinMarketService(gecko_market);
     });
 
-    before("Create TestStoa", async () => {
-        testDBConfig = await MockDBConfig();
+    before("Create TestStoa", () => {
+        testDBConfig = MockDBConfig();
         stoa_server = new TestStoa(testDBConfig, new URL("http://127.0.0.1:2826"), port, coinMarketService);
-        await stoa_server.createStorage();
+        return stoa_server.createStorage();
     });
 
-    before("Start TestStoa", async () => {
-        await stoa_server.start();
+    before("Start TestStoa", () => {
+        return stoa_server.start();
     });
 
     after("Stop Stoa and Agora server instances", async () => {

--- a/tests/Storage.test.ts
+++ b/tests/Storage.test.ts
@@ -45,7 +45,7 @@ describe("Test ledger storage and inquiry function.", () => {
 
     after("Close Storage", async () => {
         await ledger_storage.dropTestDB(testDBConfig.database);
-        await ledger_storage.close();
+        ledger_storage.close();
     });
 
     it("Test for saving of all blocks", async () => {
@@ -267,8 +267,8 @@ describe("Test for storing block data in the database", () => {
         ledger_storage = await LedgerStorage.make(testDBConfig, 1609459200);
     });
 
-    afterEach("Close Storage", () => {
-        ledger_storage.dropTestDB(testDBConfig.database);
+    afterEach("Close Storage", async () => {
+        await ledger_storage.dropTestDB(testDBConfig.database);
         ledger_storage.close();
     });
 
@@ -347,8 +347,8 @@ describe("Tests that sending a pre-image", () => {
         await ledger_storage.getEnrollments(height);
     });
 
-    after("Close Storage", () => {
-        ledger_storage.dropTestDB(testDBConfig.database);
+    after("Close Storage", async () => {
+        await ledger_storage.dropTestDB(testDBConfig.database);
         ledger_storage.close();
     });
 
@@ -414,8 +414,8 @@ describe("Tests storing transaction pools of a transaction", () => {
         });
     });
 
-    after("Close Storage", () => {
-        ledger_storage.dropTestDB(testDBConfig.database);
+    after("Close Storage", async () => {
+        await ledger_storage.dropTestDB(testDBConfig.database);
         ledger_storage.close();
     });
 
@@ -464,8 +464,8 @@ describe("Tests update blockHeader", () => {
         });
     });
 
-    after("Close Storage", () => {
-        ledger_storage.dropTestDB(testDBConfig.database);
+    after("Close Storage", async () => {
+        await ledger_storage.dropTestDB(testDBConfig.database);
         ledger_storage.close();
     });
 

--- a/tests/TestConfig.ts
+++ b/tests/TestConfig.ts
@@ -10,6 +10,9 @@ export let MockDBConfig = () => {
         password: config.database.password,
         user: config.database.user,
         port: config.database.port,
-        multipleStatements: true,
+        multipleStatements: config.database.multipleStatements,
+        waitForConnections: config.database.waitForConnections,
+        connectionLimit: config.database.connectionLimit,
+        queueLimit: config.database.queueLimit,
     };
 };


### PR DESCRIPTION
Connection pools help reduce the time spent connecting to the MySQL server by reusing a previous connection,
leaving them open instead of closing when you are done with them.
This improves the latency of queries as you avoid all of the overhead
that comes with establishing a new connection.
The connection can now be pulled out of the pool and used to 
create a new connection or to use the created connection.