### PR TITLE
Fix the endpoint wallet/balance/:address

### DIFF
--- a/tests/Stoa.test.ts
+++ b/tests/Stoa.test.ts
@@ -730,7 +730,7 @@ describe("Test of the path /utxo", () => {
         await client.post(url, { block: sample_data[0] });
         await client.post(url, { block: sample_data[1] });
         // Wait for the block to be stored in the database for the next test.
-        await delay(1500);
+        await delay(2000);
     });
 
     it("Test of the path /utxo no pending transaction ", async () => {
@@ -1192,7 +1192,7 @@ describe("Test of the path /wallet/balance:address", () => {
         await client.post(url, { block: blocks[0] });
         await client.post(url, { block: blocks[1] });
         // Wait for the block to be stored in the database for the next test.
-        await delay(1500);
+        await delay(2000);
     });
 
     it("Test of the path /wallet/balance no pending transaction", async () => {

--- a/tests/Stoa.test.ts
+++ b/tests/Stoa.test.ts
@@ -733,23 +733,6 @@ describe("Test of the path /utxo", () => {
         await delay(1500);
     });
 
-    it("Test of the path /wallet/balance no pending transaction ", async () => {
-        const uri = URI(host)
-            .port(port)
-            .directory("wallet/balance")
-            .filename("boa1xparc00qvv984ck00trwmfxuvqmmlwsxwzf3al0tsq5k2rw6aw427ct37mj");
-
-        const response = await client.get(uri.toString());
-        const expected = {
-            address: "boa1xparc00qvv984ck00trwmfxuvqmmlwsxwzf3al0tsq5k2rw6aw427ct37mj",
-            balance: "24399999990480",
-            spendable: "24399999990480",
-            frozen: "0",
-            locked: "0",
-        };
-        assert.deepStrictEqual(response.data, expected);
-    });
-
     it("Test of the path /utxo no pending transaction ", async () => {
         const uri = URI(host)
             .port(port)
@@ -778,23 +761,6 @@ describe("Test of the path /utxo", () => {
         const url = uri.toString();
         await client.post(url, { tx: Block.reviver("", sample_data2).txs[0] });
         await delay(500);
-    });
-
-    it("Test of the path /wallet/balance with pending transaction ", async () => {
-        const uri = URI(host)
-            .port(port)
-            .directory("wallet/balance")
-            .filename("boa1xparc00qvv984ck00trwmfxuvqmmlwsxwzf3al0tsq5k2rw6aw427ct37mj");
-
-        const response = await client.get(uri.toString());
-        const expected = {
-            address: "boa1xparc00qvv984ck00trwmfxuvqmmlwsxwzf3al0tsq5k2rw6aw427ct37mj",
-            balance: "0",
-            spendable: "0",
-            frozen: "0",
-            locked: "0",
-        };
-        assert.deepStrictEqual(response.data, expected);
     });
 
     it("Test of the path /utxo with pending transaction ", async () => {

--- a/tests/TransactionPool.test.ts
+++ b/tests/TransactionPool.test.ts
@@ -251,7 +251,7 @@ describe("Test of double spending transaction", () => {
         await client.post(url, { block: sample_data[0] });
         await client.post(url, { block: sample_data[1] });
         // Wait for the block to be stored in the database for the next test.
-        await delay(100);
+        await delay(2000);
     });
 
     it("Send the first transaction", async () => {
@@ -276,7 +276,7 @@ describe("Test of double spending transaction", () => {
 
         const url = uri.toString();
         await client.post(url, { tx });
-        await delay(100);
+        await delay(500);
     });
 
     it("Check if the pending transaction is the first transaction", async () => {
@@ -303,7 +303,7 @@ describe("Test of double spending transaction", () => {
 
         const url = uri.toString();
         await client.post(url, { tx });
-        await delay(100);
+        await delay(500);
     });
 
     it("Check if there is only a second transaction.", async () => {


### PR DESCRIPTION
Code is modified so that the refund amount remains in the balance during a pending transaction.

I created a transaction with re-funded output.
I saved this as a pending transaction.
Since then, I have saved blocks with this pending transaction. At this point, the pending transaction is deleted and the re-funded output is available.
I confirm that the balance before and after each condition is the same as the expected result.