### PR TITLE
Change class FeeManager for using fee rate

### DIFF
--- a/src/modules/common/FeeManager.ts
+++ b/src/modules/common/FeeManager.ts
@@ -26,12 +26,9 @@ export class FeeManager {
      */
     public static getTxFee(tx_size: number, disparity: number): [JSBI, JSBI, JSBI] {
         const size = JSBI.BigInt(tx_size);
-        const factor = JSBI.BigInt(200);
-        const minimum = JSBI.BigInt(100_000); // 0.01BOA
-        let medium = JSBI.multiply(size, factor);
-        if (JSBI.lessThan(medium, minimum)) medium = JSBI.BigInt(minimum);
-
-        medium = JSBI.add(medium, JSBI.BigInt(disparity));
+        const rate = JSBI.BigInt(700);
+        const minimum = JSBI.multiply(size, rate);
+        let medium = JSBI.multiply(size, rate);
         if (JSBI.lessThan(medium, minimum)) medium = JSBI.BigInt(minimum);
 
         const width = JSBI.divide(medium, JSBI.BigInt(10));

--- a/tests/FeeManager.test.ts
+++ b/tests/FeeManager.test.ts
@@ -19,14 +19,14 @@ import * as assert from "assert";
 describe("Test of FeeManager", () => {
     it("Test of FeeManager.getTxFee()", async () => {
         assert.deepStrictEqual(FeeManager.getTxFee(500, 0), [
-            JSBI.BigInt(110_000),
-            JSBI.BigInt(100_000),
-            JSBI.BigInt(100_000),
+            JSBI.BigInt(385_000),
+            JSBI.BigInt(350_000),
+            JSBI.BigInt(350_000),
         ]);
         assert.deepStrictEqual(FeeManager.getTxFee(500, 100_000), [
-            JSBI.BigInt(220_000),
-            JSBI.BigInt(200_000),
-            JSBI.BigInt(180_000),
+            JSBI.BigInt(385_000),
+            JSBI.BigInt(350_000),
+            JSBI.BigInt(350_000),
         ]);
     });
 

--- a/tests/Stoa.test.ts
+++ b/tests/Stoa.test.ts
@@ -763,9 +763,9 @@ describe("Test of the path /utxo", () => {
         const uri = URI(stoa_addr).directory("transaction/fees").filename("1000");
 
         const response = await client.get(uri.toString());
-        assert.strictEqual(response.data.medium, "185000");
-        assert.strictEqual(response.data.low, "166500");
-        assert.strictEqual(response.data.high, "203500");
+        assert.strictEqual(response.data.medium, "700000");
+        assert.strictEqual(response.data.low, "700000");
+        assert.strictEqual(response.data.high, "770000");
     });
 
     it("Test getting height at", async () => {


### PR DESCRIPTION
In Agora, the value of the fee for the transaction size, that is, the minimum value of the fee rate is set to 700. I apply this to STOA.