### PR TITLE
Add endpoint of wallet /wallet/transaction/detail/:hash

### DIFF
--- a/src/Types.ts
+++ b/src/Types.ts
@@ -514,6 +514,166 @@ export interface ITxOverviewInputElement {
 }
 
 /**
+ * The interface of the transaction detail
+ */
+export interface ITxDetail {
+    /**
+     * Transaction status
+     */
+    status: string;
+
+    /**
+     * Block height
+     */
+    height: string;
+
+    /**
+     * Transaction time
+     */
+    time: number;
+
+    /**
+     * Transaction hash
+     */
+    tx_hash: string;
+
+    /**
+     * Transaction type
+     */
+    tx_type: string;
+
+    /**
+     * Transaction type
+     */
+    tx_size: number;
+
+    /**
+     * Block height at which the output of the transaction becomes available
+     */
+    unlock_height: string;
+
+    /**
+     * Transaction lock height
+     */
+    lock_height: string;
+
+    /**
+     * Time at which the output of the transaction becomes available
+     */
+    unlock_time: number;
+
+    /**
+     * The transaction data payload
+     */
+    payload: string;
+
+    /**
+     * The address and amount of the output associated with the transaction input
+     */
+    senders: ITxDetailInputElement[];
+
+    /**
+     * The address and amount of transaction output
+     */
+    receivers: ITxDetailOutputElement[];
+
+    /**
+     * Total fee
+     */
+    fee: string;
+
+    /**
+     * Transaction fee
+     */
+    tx_fee: string;
+
+    /**
+     * Payload fee
+     */
+    payload_fee: string;
+}
+
+/**
+ * The interface of the transaction detail output element
+ */
+export interface ITxDetailOutputElement {
+    /**
+     * Output type
+     */
+    type: number;
+
+    /**
+     * Address, Public key
+     */
+    address: string;
+
+    /**
+     * Lock type
+     */
+    lock_type: number;
+
+    /**
+     * Lock type
+     */
+    index: number;
+
+    /**
+     * Lock bytes
+     */
+    bytes: string;
+
+    /**
+     * The hash of UTXO
+     */
+    utxo: string;
+
+    /**
+     * Amount
+     */
+    amount: string;
+}
+
+/**
+ * The interface of the transaction detail input element
+ */
+export interface ITxDetailInputElement {
+    /**
+     * Address, Public key
+     */
+    address: string;
+
+    /**
+     * Amount
+     */
+    amount: number;
+
+    /**
+     * The hash of UTXO
+     */
+    utxo: string;
+
+    /**
+     * Signature of block
+     */
+    signature: string;
+
+    /**
+     * Input index
+     */
+    index: number;
+
+    /**
+     * Unlock age
+     */
+    unlock_age: number;
+
+    /**
+     * Unlock bytes
+     */
+    bytes: string;
+}
+
+/**
  * The interface of the pending transactions
  */
 export interface IPendingTxs {

--- a/tests/WalletAPI.test.ts
+++ b/tests/WalletAPI.test.ts
@@ -119,9 +119,9 @@ describe("Test of Stoa API for the wallet", () => {
         assert.strictEqual(response.data[0].full_count, 9);
     });
 
-    it("Test of the path /wallet/transaction/overview", async () => {
+    it("Test of the path /wallet/transaction/detail", async () => {
         const uri = URI(stoa_addr)
-            .directory("/wallet/transaction/overview")
+            .directory("/wallet/transaction/detail")
             .filename(
                 "0x405ee9d66e83abd8c9a97c68db41de53c70c93c2f5bbe59eb134867ea1bf7f227ef06cc6babc34da81a43f1037e0f620eebe7f01368f9df498caaaef16fe9695"
             );
@@ -163,6 +163,8 @@ describe("Test of Stoa API for the wallet", () => {
                 },
             ],
             fee: "100000",
+            tx_fee: "100000",
+            payload_fee: "0",
         };
         assert.deepStrictEqual(response.data, expected);
     });
@@ -300,9 +302,9 @@ describe("Test of Stoa API for the wallet with `sample_data`", () => {
         await delay(2000);
     });
 
-    it("Test of the path /wallet/transaction/overview with payload", async () => {
+    it("Test of the path /wallet/transaction/detail with payload", async () => {
         const uri = URI(stoa_addr)
-            .directory("/wallet/transaction/overview")
+            .directory("/wallet/transaction/detail")
             .filename(
                 "0x35917fba7333947cfbc086164e81c1ad7b98dc6a4c61822a89f6eb061b29e956c5c964a2d4b9cce9a2119244e320091b20074351ab288e07f9946b9dcc4735a7"
             );
@@ -354,6 +356,8 @@ describe("Test of Stoa API for the wallet with `sample_data`", () => {
                 },
             ],
             fee: "1663649600",
+            tx_fee: "249600",
+            payload_fee: "1663400000",
         };
         assert.deepStrictEqual(response.data, expected);
     });


### PR DESCRIPTION
It is similar to /wallet/transaction/overview/:hash and was created to rename.
After this is completed, /wallet/transaction/overview/:hash will be removed.