### PR TITLE
When data does not exist, it delivers an empty array instead of an error code

### DIFF
--- a/src/Stoa.ts
+++ b/src/Stoa.ts
@@ -1704,11 +1704,6 @@ class Stoa extends WebService {
         this.ledger_storage
             .getWalletTransactionsPending(address)
             .then((rows: any[]) => {
-                if (!rows.length) {
-                    res.status(204).send(`No pending transactions. address': (${address})`);
-                    return;
-                }
-
                 const pending_array: IPendingTxs[] = [];
                 for (const row of rows) {
                     const tx = {


### PR DESCRIPTION
It delivers code 204 when data does not exist.
I modified this to transfer the arrangement.